### PR TITLE
Added the TSLint rules for .js files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/react-router": "^4.4.1",
     "@types/webpack-env": "^1.13.6",
     "convert-tsconfig-paths-to-webpack-aliases": "^0.9.2",
+    "extract-text-webpack-plugin": "^3.0.2",
     "rimraf": "^2.6.2",
     "serve": "^10.1.1",
     "ts-loader": "^5.3.1",

--- a/static.config.js
+++ b/static.config.js
@@ -1,11 +1,8 @@
+import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import fetch from 'node-fetch';
 import path from 'path';
 
-// Paths Aliases defined through tsconfig.json
-const typescriptWebpackPaths = require('./webpack.config.js');
-
-/** Load extract-text-webpack-plugin for proper implement as the example shows: {@link https://github.com/webpack-contrib/extract-text-webpack-plugin#usage} */
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
+import TypescriptWebpackPaths from './webpack.config.js';
 
 export default {
   entry: path.join(__dirname, 'src', 'index.tsx'),
@@ -36,7 +33,7 @@ export default {
 
     // Add TypeScript Path Mappings (from tsconfig via webpack.config.js)
     // To react-statics alias resolution
-    config.resolve.alias = typescriptWebpackPaths.resolve.alias;
+    config.resolve.alias = TypescriptWebpackPaths.resolve.alias;
 
     // We replace the existing JS rule with one, that allows us to use
     // Both TypeScript and JavaScript interchangeably
@@ -53,7 +50,7 @@ export default {
           },
           {
             test: /\.css$/,
-            use: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' })
+            use: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }),
           },
           defaultLoaders.fileLoader,
         ],
@@ -61,6 +58,7 @@ export default {
     ];
     // FIXME: You might need to make the file name universal
     config.plugins.push(new ExtractTextPlugin('app.css'));
+
     return config;
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "allowJs": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "noEmit": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,21 @@
     "tslint-config-airbnb",
     "tslint-react"
   ],
+  "jsRules": {
+    "no-default-export": false,
+    "no-implicit-dependencies": [
+      true,
+      "dev"
+    ],
+    "no-require-imports": false,
+    "quotemark": [
+      true,
+      "single",
+      "jsx-double",
+      "avoid-template",
+      "avoid-escape"
+    ]
+  },
   "rules": {
     "file-name-casing": false,
     "import-name": false,
@@ -19,7 +34,7 @@
     "no-import-side-effect": [
       true,
       {
-        "ignore-module": "(\\.html|\\.css)$"
+        "ignore-module": "(\\.html|\\.s?css)$"
       }
     ],
     "no-submodule-imports": false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
-const convPaths = require('convert-tsconfig-paths-to-webpack-aliases').default
+const convPaths = require('convert-tsconfig-paths-to-webpack-aliases').default;
 
 // Needs to be valid JSON. All comments in tsconfig.json must be removed.
-const tsconfig = require('./tsconfig.json')
+const tsconfig = require('./tsconfig.json');
 
-const aliases = convPaths(tsconfig)
+const aliases = convPaths(tsconfig);
 
 // Consumable std. Webpack Export
-module.exports = { resolve: { alias: aliases } }
+module.exports = { resolve: { alias: aliases } };


### PR DESCRIPTION
# Added the TSLint rules for .js files.

- [`no-default-export`](https://palantir.github.io/tslint/rules/no-default-export/): false
- [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/): dependencies or devDependencies
- [`no-require-imports`](https://palantir.github.io/tslint/rules/no-require-imports/): false
- [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/): `single` (`avoid-template`, `avoid-escape`)

# Others update

- Fixed the some code that according to TSLint rules
- Fixed a package dependencies: [extract-text-webpack-plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin)