### PR TITLE
 Fixed a problem that CSS (SASS) has not built on production

### DIFF
--- a/static.config.js
+++ b/static.config.js
@@ -34,18 +34,14 @@ export default {
         options: { importLoaders: 1, minimize: stage === 'prod', sourceMap: false },
       };
       const defaultSassSettings = { loader: 'sass-loader', options: { includePath: ['src/'] } };
-      switch (stage) {
-        case 'dev':
-          return ['style-loader', 'css-loader', 'sass-loader'].map((loader) => ({ loader }));
-        case 'node':
-        case 'prod':
-          return [defaultCssSettings, defaultSassSettings];
-        default:
-          return ExtractTextPlugin.extract({
-            fallback: { loader: 'style-loader', options: { sourceMap: false, hmr: false } },
-            use: [defaultCssSettings, defaultSassSettings],
-          });
+      if (stage === 'dev') {
+        return ['style-loader', 'css-loader', 'sass-loader'].map((loader) => ({ loader }));
       }
+
+      return ExtractTextPlugin.extract({
+        fallback: { loader: 'style-loader', options: { sourceMap: false, hmr: false } },
+        use: [defaultCssSettings, defaultSassSettings],
+      });
     })();
 
     // Add .ts and .tsx extension to resolver
@@ -75,6 +71,8 @@ export default {
         ],
       },
     ];
+    // FIXME: You might need to make the file name universal
+    config.plugins.push(new ExtractTextPlugin('app.scss'));
 
     return config;
   },

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
   ],
   "jsRules": {
     "no-default-export": false,
+    "no-default-import": false,
     "no-implicit-dependencies": [
       true,
       "dev"
@@ -24,6 +25,7 @@
     "file-name-casing": false,
     "import-name": false,
     "no-default-export": false,
+    "no-default-import": false,
     "no-implicit-dependencies": [
       true,
       [


### PR DESCRIPTION
- Fixed a problem that CSS (SASS) has not built on production
- Improved the TSLint rules for webpack settings
  - Removed `no-default-import`