### PR TITLE
chore(idd): record IDD policy and enable the worktree guard

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -3,6 +3,11 @@
   "autopilotSuitability": {
     "floor": 3
   },
+  "ciWait": {
+    "runningTimeout": "PT30M",
+    "generationTimeout": "PT10M",
+    "rerunPolicy": "rerun-once"
+  },
   "claimTiming": {
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
@@ -14,10 +19,11 @@
     "post-fix-validate": "pnpm run lint:fix && pnpm run lint && pnpm run test"
   },
   "helperRuntime": {
-    "profile": "package-manager"
+    "profile": "instructions-only"
   },
   "iddVersion": "0.3.0",
   "issueScope": "roadmap-first",
+  "maintainerApprovalActorPolicy": "owners-and-maintainers-only",
   "markerPrefix": "kit-black",
   "mergePolicy": "fully_autonomous_merge",
   "orphanFirstPolicy": "none",
@@ -26,5 +32,8 @@
   "trustedMarkerActors": ["kurone-kito"],
   "workshop": {
     "exampleRepository": ""
+  },
+  "worktreeGuard": {
+    "enabled": true
   }
 }

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -1,0 +1,110 @@
+# IDD Policy Configuration
+
+This repository uses Issue-Driven Development (IDD), imported from
+[`kurone-kito/idd-skill`](https://github.com/kurone-kito/idd-skill). This
+document is the human-readable record of the policy decisions confirmed
+during onboarding (roadmap #110). The machine-readable mirror lives in
+[`.github/idd/config.json`](../.github/idd/config.json); keep the two
+aligned in the same change.
+
+## Merge Policy
+
+**Policy**: `fully_autonomous_merge`
+
+One trusted agent session may execute the F3 merge after the normal
+claim, freshness, CI, advisory, and review gates pass.
+
+> **Operational caveat.** Every merge to `main` triggers a Netlify
+> production deploy (`.github/workflows/push-main.yml`). The operator
+> accepted the auto-deploy-on-merge tradeoff for maintenance speed.
+
+## Credential Scope
+
+- **Worker credentials**: least-privilege scope sufficient to claim,
+  branch, push, and open PRs.
+- **Merge-capable credentials**: under `fully_autonomous_merge`, one
+  trusted agent session may hold the merge-capable set needed to
+  continue through F3.
+
+## PR Review Policy
+
+**Profile**: `copilot-advisory` (distributed default)
+
+The PR phases keep an advisory review step. In practice this repository
+also receives GitHub Copilot and CodeRabbit reviews; a missing advisory
+review is fail-safe via the generation timeout.
+
+## Review-Thread Resolution Policy
+
+**Policy**: `fast-agent-resolve`
+
+An agent may resolve review threads after acting on accepted, rejected,
+or advisory feedback.
+
+## Critique-Loop Profile
+
+**Profile**: distributed defaults (see
+[`docs/policy-constants.md`](policy-constants.md)).
+
+## Claim Timing
+
+- **claim-stale-age**: `PT24H` (24 h)
+- **claim-heartbeat-interval**: `PT12H` (12 h)
+
+## CI Wait Policy
+
+- **running timeout**: `PT30M` (30 min)
+- **generation timeout**: `PT10M` (10 min)
+- **rerun policy**: `rerun-once`
+
+> **Repository note.** `.github/workflows/push.yml` (build/lint/test)
+> currently does not run on `issue/*` branches because its branch filter
+> uses `'*'`, which does not match branch names containing `/`. Until
+> that is fixed (tracked in #117), IDD PRs are validated by lint + test
+> run locally in the worktree (pre-push-validate) plus CodeQL, Copilot,
+> and CodeRabbit; the build is exercised by the post-merge `main` deploy.
+
+## Issue-Author Approval Gate
+
+- **Gate posture**: `enabled-by-default` (no `skipIssueAuthorApprovalGate`
+  opt-out).
+- **`maintainer-approval-actors` policy**: `owners-and-maintainers-only`.
+- The repository owner self-authorizes as issue author under this policy.
+
+## Helper Runtime Profile
+
+**Profile**: `instructions-only`
+
+The operator preferred `package-manager` (pnpm) during onboarding, but
+the IDD helper package `@kurone-kito/idd-skill` is not published to the
+npm registry, so no reviewed, non-mutable helper spec is resolvable.
+Rather than pin an unreviewed mutable source (a branch tarball / git
+URL), the repository stays on the fail-safe `instructions-only` profile,
+where the written decision tables in `.github/instructions/` are
+canonical. Upgrading to `package-manager` is tracked as a follow-up once
+a reviewed helper spec (a published package or a pinned tarball) is
+available.
+
+## Issue-Authoring Companion
+
+**Status**: installed at `.claude/skills/issue-authoring/`.
+
+## Worktree Guard
+
+**Status**: enabled (`worktreeGuard.enabled: true`).
+
+The opt-in git hooks under `.githooks/` refuse commits and pushes made
+from the **primary** worktree while HEAD is on an implementation branch
+(`issue/*` or `roadmap-audit/*`), enforcing the B1 disposable-worktree
+rule locally. The hooks are pure POSIX sh.
+
+`core.hooksPath` is a local, uncommitted setting, so each clone must opt
+in once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+After that, IDD implementation work must happen in a sibling worktree
+(`git worktree add ../<repo>.<branch> -b <branch> origin/main`), not by
+switching the primary worktree onto the issue branch.


### PR DESCRIPTION
## Summary

Record the IDD policy for this repository and enable the worktree guard
(operator hearing decisions, roadmap #110).

- `.github/idd/config.json`: `worktreeGuard.enabled: true`,
  `maintainerApprovalActorPolicy: owners-and-maintainers-only`, the
  `ciWait` defaults (`PT30M` / `PT10M` / `rerun-once`), and
  `helperRuntime.profile: instructions-only`.
- `docs/idd-policy.md`: human-readable record of every decision plus the
  per-clone `git config core.hooksPath .githooks` setup step.

## Decisions of note

- **Helper runtime → instructions-only (fallback).** The operator
  preferred `package-manager` (pnpm), but `@kurone-kito/idd-skill` is not
  published to npm, so no reviewed non-mutable helper spec is resolvable.
  Pinning an unreviewed mutable source is worse than the fail-safe
  `instructions-only`, where the written decision tables are canonical.
  Upgrade is a follow-up once a reviewed helper spec exists.
- **CI note.** `push.yml` does not run on `issue/*` branches (branch
  filter `'*'` misses slashes); tracked in #117. Recorded in the policy
  doc.

## Verification

- `.github/idd/config.json` is valid JSON and carries the recorded
  policy fields.
- `pnpm run lint` and `pnpm run test` (33 tests) pass locally.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165sFY9VHSDcURTCVqpgibs
