### PR TITLE
docs(idd): add agent entry files pointing at the IDD workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Guidelines for AI Agents
+
+## Immediate rules
+
+- Match the conversational language to the user's language.
+- Write comments and documentation in English unless there is a clear
+  project-specific reason otherwise.
+- If uncertainty, hidden risk, or missing context blocks a safe change,
+  stop and ask a concise question before proceeding.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Codex CLI agents should manually open
+`.github/instructions/idd-overview-core.instructions.md` and the routed
+phase file before starting IDD work.
+
+The repository's recorded IDD policy lives in
+[docs/idd-policy.md](docs/idd-policy.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Guidelines for AI Agents
+
+## Immediate rules
+
+- Match the conversational language to the user's language.
+- Write comments and documentation in English unless there is a clear
+  project-specific reason otherwise.
+- If uncertainty, hidden risk, or missing context blocks a safe change,
+  stop and ask a concise question before proceeding.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview-core.instructions.md`. Open the routed
+phase file manually when the current step changes.
+
+The repository's recorded IDD policy (merge, review, helper runtime,
+worktree guard, and more) lives in [docs/idd-policy.md](docs/idd-policy.md).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,22 @@
+# Guidelines for AI Agents
+
+## Immediate rules
+
+- Match the conversational language to the user's language.
+- Write comments and documentation in English unless there is a clear
+  project-specific reason otherwise.
+- If uncertainty, hidden risk, or missing context blocks a safe change,
+  stop and ask a concise question before proceeding.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Gemini CLI agents should manually open
+`.github/instructions/idd-overview-core.instructions.md` and the routed
+phase file before starting IDD work.
+
+The repository's recorded IDD policy lives in
+[docs/idd-policy.md](docs/idd-policy.md).


### PR DESCRIPTION
## Summary

Add root agent entry files so manually-routed AI agents are pointed at
the IDD workflow (ONBOARDING Step 5, roadmap #110). This repository had
none previously.

- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`: shared immediate rules + an IDD
  Workflow section referencing `docs/idd-workflow.md` and
  `.github/instructions/idd-overview-core.instructions.md`, plus a
  pointer to `docs/idd-policy.md`.

> `docs/idd-policy.md` is created by #113; merge that PR first so the
> link resolves.

## Verification

- Each of `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` references
  `docs/idd-workflow.md`.
- `pnpm run lint` and `pnpm run test` (33 tests) pass locally.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165sFY9VHSDcURTCVqpgibs
