### PR TITLE
fix(lint): stop prettier from scanning husky's generated shims

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,8 @@
 # Ignorefiles
 .*ignore
 
+# Husky (generated shim scripts; nested .gitignore is not read by Prettier)
+.husky/_/
+
 # Pnpm
 pnpm-lock.yaml


### PR DESCRIPTION
## Summary

`pnpm run lint` fails on a clean local checkout because `.husky/_/`
(husky's generated shim scripts, created by the `prepare` script during
`pnpm install`) is excluded from git via a nested `.gitignore`, but
Prettier only reads `.prettierignore` (and the root `.gitignore`) -- it
does not descend into nested `.gitignore` files. CI stays green because
both workflows install with `HUSKY: 0`, so `.husky/_/` never exists
there; the breakage only reproduces locally.

This PR adds a single new entry to `.prettierignore`:

```
.husky/_/
```

Per the issue's "while there" ask, I also confirmed no other
install-generated directory needs the same treatment: `prettier
--file-info` reports `packages/fetcher/dist/bin.mjs` and
`node_modules/.bin/prettier` as already `ignored: true` (covered by the
root `.gitignore`'s `dist` entry, which Prettier *does* read at the
project root, and Prettier's built-in default ignore of `node_modules`,
respectively). No other entries were added.

The `prepare` script and CI's `HUSKY: 0` setting are unchanged.

## Verification

- `pnpm run lint` exits `0` with `.husky/_/` present locally.
- `pnpm run lint:prettier:fix` produces no diff to tracked files.
- `pnpm run test` passes (33 tests).
- `git diff main --stat` touches only `.prettierignore`.

## Scope note

`pnpm install --prefer-frozen-lockfile` on current `main` (`467d18b`)
regenerates `pnpm-lock.yaml` because the root `package.json`'s `vitest`
specifier (`^2.1.9`) disagrees with the `packages/*/package.json`
specifiers (`^3.2.6`) already on `main` -- pre-existing drift unrelated
to this change. That regenerated lockfile was discarded and is not part
of this PR; flagging it here in case it warrants a separate follow-up
issue.

Closes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded generated Husky support files from automated formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->