### PR TITLE
ci: run push.yml on IDD issue/* branches

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,8 @@ name: The CI workflow on push
 on:
   push:
     branches:
-      - '**'
+      - '*'
+      - 'issue/*'
       - '!main'
 permissions:
   contents: read

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: The CI workflow on push
 on:
   push:
     branches:
-      - '*'
+      - '**'
       - '!main'
 permissions:
   contents: read

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -36,9 +36,8 @@ passed:
 
 From this point the repository's own `.github/instructions/` are
 authoritative; the upstream ("theirs") bootstrap flow is no longer
-required. Known follow-ups: #117 (run `push.yml` on `issue/*` branches)
-and the helper-runtime upgrade to `package-manager` once a reviewed
-helper spec is published.
+required. Known follow-ups: the helper-runtime upgrade to
+`package-manager` once a reviewed helper spec is published.
 
 ## Merge Policy
 
@@ -91,11 +90,14 @@ or advisory feedback.
 - **rerun policy**: `rerun-once`
 
 > **Repository note.** `.github/workflows/push.yml` (build/lint/test)
-> currently does not run on `issue/*` branches because its branch filter
-> uses `'*'`, which does not match branch names containing `/`. Until
-> that is fixed (tracked in #117), IDD PRs are validated by lint + test
-> run locally in the worktree (pre-push-validate) plus CodeQL, Copilot,
-> and CodeRabbit; the build is exercised by the post-merge `main` deploy.
+> now runs on `issue/*` branches: its branch filter explicitly lists
+> `'issue/*'` alongside the slash-free `'*'` (fixed in #117 — GitHub
+> Actions branch-filter globs otherwise treat `*` as not matching `/`,
+> and a blanket `'**'` was rejected because it would also match
+> `dependabot/*` branches, which run without repository secrets and
+> would fail the build). IDD PRs now carry real build/lint/test CI
+> signal in addition to lint + test run locally in the worktree
+> (pre-push-validate), CodeQL, Copilot, and CodeRabbit.
 
 ## Issue-Author Approval Gate
 


### PR DESCRIPTION
## Summary

`.github/workflows/push.yml` triggered on `branches: ['*', '!main']`.
GitHub Actions branch-filter globs treat `*` as matching only branch
names **without** a `/`, so IDD implementation branches
(`issue/<number>-<slug>`) never triggered the build/lint/test job —
the IDD CI-wait phase had no real CI signal on these PRs.

This branch is itself an `issue/117-...` branch, so it doubles as the
acceptance-criteria proof once the fix is present in the pushed commit:
the `push.yml` build job (build + lint + test, ubuntu/windows matrix)
should now run here, where today it would not trigger at all.

## Changes

- `.github/workflows/push.yml`: add `'issue/*'` to the `branches:`
  list alongside the existing slash-free `'*'`, so IDD branches trigger
  the workflow while `!main` continues to exclude direct pushes to
  `main`.
  - A broader `'**'` (crossing every `/`) was considered first (it's
    the literal example in the issue) but rejected during self-review:
    it would also start matching every `dependabot/*` branch. GitHub
    withholds repository secrets from `push` events triggered by
    `dependabot[bot]`, and `packages/fetcher/src/env.mts` has no
    fallback for missing `CLIENT_ID`/`CLIENT_SECRET`/`REFRESH_TOKEN`,
    so `pnpm run build` would fail with a Google Calendar 404 (the
    same failure mode #160 describes) on every future dependency bump
    — turning previously check-less Dependabot PRs red. `'issue/*'`
    satisfies the issue's actual acceptance criteria without that
    blast radius; `push-main.yml` is the only other workflow with a
    `branches:` filter and matches the literal `main`, so it is
    unaffected either way.
- `docs/idd-policy.md`: update the two notes that described this gap
  as a known, tracked limitation, since it is now fixed.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 33/33 passing
- [x] Confirmed via `git ls-remote --heads origin` that no other
      branch-naming convention in this repository needs the same fix
      (only `issue/*`, `dependabot/*`, and slash-free names exist)
- [x] Confirmed `push-main.yml` is unaffected (filters on literal
      `main`, not a glob)
- [ ] This PR's own `push.yml` build/lint/test check appearing and
      passing on this PR (self-verifying — watch the checks below)

Closes #117

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01T2bJsjjrfAuWL3GuDvZv49
