### PR TITLE
chore(skills): re-sync issue-authoring skill to upstream v0.6.0

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -20,7 +20,11 @@ Use two stable phases:
    ask only the questions that block safe issue drafting. Keep
    clarification bounded; use the repository-local
    `issueAuthoring.maxClarificationRounds` value when available,
-   otherwise default to 3 rounds.
+   otherwise default to 3 rounds. **Under-clarification stop rule**: if,
+   after bounded clarification, you still cannot name the concrete
+   surface to edit or an objective verification for a candidate task,
+   route it to `needs-decision` or ask — do not publish a
+   confidently-vague `ready` issue. Reliability over speed.
 2. **Decompose and Draft** — restate the request in implementation
    terms, split it into atomic tasks, classify readiness, reuse existing
    issues when safe, and draft the smallest issue shape that preserves
@@ -46,10 +50,13 @@ needs-decision, blocked-by-human, and out-of-scope.
    - roadmap plus sub-issues for multi-task or multi-session work
    - stable non-ready buckets for deferred, needs-decision,
      blocked-by-human, or out-of-scope work
-4. Resolve the target repository marker prefix before drafting hidden
-   dependency markers. Use the prefix documented by the target
-   repository's onboarding or IDD docs, and ask the user instead of
-   guessing when the prefix is not discoverable.
+4. **Prefix-first**: resolve the target repository's marker prefix
+   before emitting any authoring marker — `roadmap-id`, `blocked-by`,
+   `autopilot-suitability`, or `effort`. Use the prefix documented by
+   the target repository's onboarding or IDD docs, and ask the user
+   instead of guessing when the prefix is not discoverable. Never
+   default to this source repository's `idd-skill` prefix in an
+   installed bundle.
 5. Keep dependencies machine-readable and minimal:
    - roadmap identity via
      `<!-- <marker-prefix>-roadmap-id: ... -->`
@@ -62,8 +69,19 @@ needs-decision, blocked-by-human, and out-of-scope.
    - keep independent sibling work in roadmap task lists unless a true
      correctness, availability, or ordering constraint requires a
      dependency edge
-6. When the user explicitly authorizes publication, manage the authoring
-   label for each created or updated issue:
+6. Before publishing a ready orphan, roadmap, or child body, run the
+   `audit-authored-issue` linter against it as the mechanical
+   pre-publish gate — see
+   [Mechanical pre-publish gate](references/contract.md#mechanical-pre-publish-gate)
+   in the bundled contract, including the manual fallback for
+   `instructions-only` installs with no helper runtime. Resolve every
+   reported failure before treating the issue as ready.
+7. Publish each `ready` drafted body directly under the authoring hold
+   once it passes the mechanical gate (step 6) and the critique pass
+   (the Intake and Clarification phase above) — no separate publish
+   approval is needed. Only skip publishing when the current request
+   explicitly asked for a preview instead. Manage the authoring label
+   for each created or updated issue:
    - resolve `issueAuthoring.authoringLabelName`, defaulting to
      `status:authoring`
    - create the label with `gh label create` before first use when the
@@ -76,27 +94,35 @@ needs-decision, blocked-by-human, and out-of-scope.
      before stopping; deletion needs admin permission the authoring
      agent typically lacks (and `docs/permissions.md` forbids for normal
      IDD), so it is not the default path
-   - remove the label from all published issues only after the full set is
-     published, the user confirms the result, and the user explicitly
-     requests release from the authoring hold for IDD execution
-   - leave the label in place if publishing is interrupted before release
-7. Stop at the approval boundary. Drafting issues does not authorize
-   publishing them or starting the IDD execution loop unless the user
-   explicitly asked for that.
+   - held issues under the label ARE the drafts: do in-place body
+     edits, roadmap relationship wiring, and re-lint of already-published
+     bodies on the published issue itself, under the same label
+   - if a session is interrupted before the set is fully wired, leave
+     the label in place — it alone keeps Discover from selecting the
+     unfinished set until a later session finishes the work
+   - remove the label from all published issues only after the release
+     checklist passes (every child referenced from its roadmap's
+     `## Tracks` list, no unsubstituted placeholders, linter green on
+     every published body) and the user explicitly requests release
+     from the authoring hold
+8. Stop at the single approval boundary: release. Publishing under the
+   hold does not by itself authorize starting the IDD execution loop —
+   only the user's explicit release request does.
 
 ## Reference Routing
 
 - For the bundled contract, output schemas, and discoverability guard:
   read [references/contract.md](references/contract.md).
-- For the bundled boundary between pre-approval drafting and the IDD
-  execution loop: read
+- For the bundled two-stage authoring/release contract and the
+  boundary with the IDD execution loop: read
   [references/workflow-boundary.md](references/workflow-boundary.md).
 - For concrete drafting patterns and example prompts: read
   [references/draft-patterns.md](references/draft-patterns.md).
 - When editing this bundle inside the source repository, keep the
-  bundled references synchronized with the canonical maintenance docs in
-  [../../docs/issue-authoring-skill.md](../../docs/issue-authoring-skill.md)
-  and [../../docs/idd-workflow.md](../../docs/idd-workflow.md).
+  bundled references synchronized with the canonical maintenance docs at
+  repo-root `docs/issue-authoring-skill.md` and `docs/idd-workflow.md`
+  (relative links are avoided here since this file is mirrored at a
+  different path depth in `.claude/skills/issue-authoring/`).
 
 ## Output Checklist
 
@@ -111,3 +137,12 @@ needs-decision, blocked-by-human, and out-of-scope.
   new issue.
 - Avoid widening drafting output beyond the user request without saying
   so.
+- Run the `audit-authored-issue` linter (or its manual fallback in
+  `instructions-only` installs) against every drafted ready body and
+  resolve every reported failure before publishing.
+- Name a concrete surface to edit and an objective verification for
+  every `ready` candidate; route anything else to `needs-decision` or
+  ask instead of guessing (the under-clarification stop rule).
+- Resolve the target repository's marker prefix before emitting any
+  authoring marker; never assume this source repository's `idd-skill`
+  prefix in an installed bundle (the prefix-first rule).

--- a/.claude/skills/issue-authoring/agents/openai.yaml
+++ b/.claude/skills/issue-authoring/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: 'Issue Authoring'
-  short_description: 'Draft IDD-ready issues and roadmaps'
-  default_prompt: 'Use $issue-authoring to draft an IDD-ready issue set for this request.'

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -6,13 +6,17 @@ contract in `docs/issue-authoring-skill.md`.
 
 ## Target marker prefix
 
-Resolve the target repository's hidden marker prefix before drafting any
-roadmap or blocked-by marker.
+**Prefix-first**: resolve the target repository's hidden marker prefix
+before emitting _any_ authoring marker — `roadmap-id`, `blocked-by`,
+`autopilot-suitability`, or `effort`. Resolve it once, up front, not as
+an afterthought once a marker is already half-drafted.
 
 - Use the prefix documented by the target repository's onboarding or
   IDD instructions.
 - In this source repository the prefix is `idd-skill`, but installed
-  bundles must not assume that value elsewhere.
+  bundles must not assume that value elsewhere. Never default to
+  `idd-skill` in an installed bundle; use it only when the target
+  repository actually configured that value.
 - If the prefix is not discoverable from the repository docs or user
   context, stop and ask instead of emitting a guessed marker.
 
@@ -58,6 +62,15 @@ locally. Clarification must be bounded; use the repository-local
 otherwise default to 3 rounds. If safe drafting is still impossible
 after that, stop and report the remaining blockers instead of looping
 indefinitely.
+
+**Under-clarification stop rule.** If, after bounded clarification, you
+still cannot name the concrete surface to edit or an objective
+verification for a candidate task, route it to `needs-decision` or ask
+— do not publish a confidently-vague `ready` issue. Reliability over
+speed. This is distinct from the "Under-specified" specificity band
+below: that band judges an already-drafted body's wording, while this
+rule stops publication earlier, during Intake, before a body is even
+drafted.
 
 ### 2. Decompose and Draft
 
@@ -120,6 +133,52 @@ issue that passes those gates can still be under-specified if it leaves
 too much implementation shape implicit. The drafting target is therefore
 "ready and stable for a middle-tier model," not "maximally detailed."
 
+## Executability gate for code spec-units
+
+For a **code spec-unit** — a drafted unit whose acceptance criteria are
+objectively executable (a script, function, or test the drafted issue
+itself specifies) — an authoring session can validate the draft before
+publishing by building a throwaway reference implementation against its
+own stated acceptance check and accepting the draft only if that
+reference implementation passes. This reuses the downstream execution
+loop as an upstream ground-truth gate: it catches drafts whose
+acceptance criteria are internally inconsistent, non-trivially
+unsatisfiable, or otherwise not actually implementable, before a
+downstream executor ever claims the issue. The reference implementation
+is a discarded validation probe, never published — it does not cross the
+Publication boundary below; only the drafted issue itself is published,
+and building the probe does not start the IDD execution loop.
+
+This is a **recommended practice for repositories or domains where a
+drafted code spec-unit has an objectively executable acceptance
+check**, not a change to this repository's own mechanical
+`bin/idd-audit-authored-issue.mjs` checks or a new requirement on this
+repository's own issue-authoring practice — most of this repository's
+issues are multi-file engineering changes without a single executable
+acceptance check to validate against.
+
+- **Weak-model semantic self-review stays advisory.** When a weak
+  authoring model reviews its own draft for semantic quality, treat the
+  verdict as advisory only, never a hard veto on publishing — mirroring
+  the narrow-question guidance for weak-model judgment calls in
+  `docs/idd-workflow.md`'s Weak-model guardrails section.
+- **Decompose and draft want different model traits.** Decomposition
+  (judgment about scope and structure) tolerates a verbose reasoning
+  model; the structured draft step (emitting the exact spec/acceptance-
+  criteria block) is more reliable on a leaner, more literal model,
+  whose chain-of-thought does not compete with the drafted block for
+  token budget. Pick the model per sub-task, not per pipeline, when both
+  are available.
+- **Redraft and re-decomposition are limited rescue mechanisms, not
+  reliable fixes.** A bounded redraft loop tends to re-roll rather than
+  converge, because a weak author regenerates rather than incrementally
+  fixes. Re-decomposing a repeatedly-failing unit is usually low-value
+  too: most authoring failures are hard-but-atomic rather than
+  over-broad, and splitting a hard-but-atomic unit tends to produce
+  incoherent sub-units that do not recompose. Treat a code spec-unit
+  that repeatedly fails this gate as a candidate for `needs-decision` or
+  human/stronger-model authoring instead of looping indefinitely.
+
 ## Reuse-first issue policy
 
 Before creating any new issue, check whether the work already has a
@@ -149,7 +208,14 @@ Then apply these checks in order:
    refine task-list entries there instead of creating a competing
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work
-   out of it rather than widening the original issue further.
+   out of it rather than widening the original issue further. When the
+   issue being split is itself a roadmap child, update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
 4. If an existing issue has an **active claim**, an open PR, or is
    otherwise being actively executed, do **not** edit its body or
    repurpose it (see the claim-state precondition, which exempts
@@ -160,6 +226,35 @@ Then apply these checks in order:
 
 Report when the bundle reuses, extends, or declines to reuse an issue
 so a later session can follow the reasoning.
+
+**Recent-window scan for just-discovered problems.** The checks above
+assume the work already has a candidate home to reuse or extend. When
+instead authoring an ad hoc issue for a problem **just discovered**
+during the current session — a build-breaking regression noticed
+mid-session, for example, rather than a task drafted from an existing
+backlog — run a recent-window duplicate scan immediately before
+publishing: list the newest issues regardless of state and check
+whether a concurrent session already authored the same problem.
+
+```sh
+gh issue list --repo <owner>/<repo> --state all --limit 20
+# or, scoped to a recency window:
+gh issue list --repo <owner>/<repo> --state all --search "created:>=<YYYY-MM-DD>"
+```
+
+A hit routes back into the checks above: extend the discovered issue
+instead of publishing a duplicate. When the race slips past this scan
+anyway (near-simultaneous discovery), the outcome is **anticipated and
+self-resolving, not a coordination failure**: both sessions proceed
+independently through their own claim and implementation cycle;
+whichever PR merges first wins; the other session manually verifies
+the fix already landed on the default branch, then closes its own
+issue and (unmerged) PR as superseded, citing the verifying evidence.
+This is the same manual verify-then-close judgment call the execution
+loop's B2.0 supersession re-check (`idd-work.instructions.md`) applies
+after claim — this scan only adds an earlier, pre-publish checkpoint.
+A fast enough race can still surface even after B2.0; when it does, it
+resolves the same way.
 
 ## Output chooser
 
@@ -393,6 +488,8 @@ Validation expectations:
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
   marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 ### Roadmap issue
 
@@ -420,6 +517,8 @@ Validation expectations:
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
   marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 ### Child issue under a roadmap
 
@@ -444,6 +543,8 @@ Validation expectations:
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
   marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 ## A4.5 Suitability Gate Alignment
 
@@ -472,10 +573,139 @@ Pre-publish validation checklist:
 4. **Human dependency isolation**: Ready issues do not hide unresolved
    decisions, credentials, subjective approvals, or mid-implementation
    human handoffs
+5. **Mechanical audit**: the drafted body passes the
+   `audit-authored-issue` linter for its declared shape (see
+   [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 If any check is uncertain, route the issue to `needs-decision` or
 `blocked-by-human` during drafting instead of publishing a
 marginally-ready issue.
+
+## Mechanical pre-publish gate
+
+Before publishing a drafted `ready` **orphan, roadmap, or child** body
+(the shapes the linter supports — not the non-ready buckets below,
+which are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime is
+available. It mechanically re-checks a subset of the structural rules
+this contract states in prose — the autopilot-suitability marker's
+exactly-one/coherent-value rule, the one-directional check that a
+suitability score of `1` carries the configured `blocked-by-human`
+label (it does not check the reverse: a non-`1` score paired with the
+label still passes), markerPrefix consistency across every authoring
+marker, the declared shape's required section headings, the
+roadmap-id/blocked-by dependency-marker rules, and visible/hidden line
+agreement for the suitability and effort footers — so a weak model does
+not have to hold every rule in its head at once while drafting.
+
+The linter also emits one **advisory, warning-severity-only** finding
+(`prose-dependency`): it flags an issue/PR reference (`#<digits>` or a
+full GitHub issue/PR URL) that appears near coordination language (for
+example "before", "after", "once", "until", "predates", "gate"/"gated",
+"requires", "lands first") with no corresponding encoding for that
+reference as one of the three recognized forms: a `Blocked by #NNN`
+line, a `Depends on #NNN` line, or a task-list checkbox item
+(`- [ ] #NNN`) — the same three forms `extractBlockedByIssueNumbers` /
+`extractDependencyIssueNumbers` already recognize elsewhere in this
+contract. A task-list checkbox counts regardless of which heading it
+sits under, so a roadmap's own `## Tracks` membership list already
+satisfies this — it is not a separate "dependency-only" list. This
+catches the pattern this contract's own
+[Hidden human-dependency validation](#hidden-human-dependency-validation)
+check 4 warns about in prose — a hard precondition stated only in
+narrative text, not encoded as a real dependency marker. A full-URL
+reference is inherently local only when it actually names the current
+repository, since a cross-repo dependency cannot be encoded with these
+repository-local markers at all — flagging it would recommend an
+impossible fix. When the caller supplies the current `owner/repo`
+(`--current-repo`, defaulting to `$GITHUB_REPOSITORY` in CI), a
+full-URL reference naming a different repository is never flagged;
+without that context, a full-URL reference is still flagged by
+default (unchanged behavior) — unless its issue/PR number happens to
+already appear as a local `Blocked by` / `Depends on` / task-list
+marker elsewhere in the body, in which case it is treated as already
+encoded like any other match. A Markdown link's target may carry
+trailing content after the issue/PR number and before the link's
+closing paren — a URL fragment (`#issuecomment-123`), a trailing `/`,
+or a quoted link title (`"..."` or `'...'`) — and the link is still
+recognized as one match; without this, the label's own bare `#NNN`
+would otherwise leak through to the bare-`#` check and be misjudged
+independently of the link's (possibly cross-repo) target. A local
+`owner/repo#N` shorthand (e.g. `kurone-kito/idd-skill#4321`) is also
+recognized, but with the reverse default from the full-URL case above:
+it is flagged only when `--current-repo` is supplied **and**
+case-insensitively matches `owner/repo`; naming a different repository,
+or omitting `--current-repo`, always excludes it, since this shorthand
+was never recognized at all before and a bare `owner/repo` cannot be
+assumed local without confirmation. A reference-style Markdown link
+(`[text][ref]` with a separate `[ref]: target` definition elsewhere in
+the body) is recognized the same way as the inline-link form above,
+including the same `currentRepo`-based local/cross-repo comparison; a
+`ref` with no matching definition is left as literal text and falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter (`\"` inside a `"..."` title, or `\'` inside a `'...'` title)
+without ending the title early and losing the rest of the link. An empty
+or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
+the same as omitting it entirely, rather than as a known repository that
+can never match. A nested/child list item's reference is evaluated
+together with its full ancestor chain's coordination-language text
+instead of being scoped away from it, while a sibling bullet at the same
+indentation — nested or top-level — still starts its own separate scope,
+preserving the tight-list sentence-conflation fix mentioned above. This
+holds for every nested child under a given parent, at any depth — not
+only the first. A continuation line resuming at an ancestor's own
+indentation, after a deeper child has already opened, is attributed to
+that ancestor rather than the deepest open child. A loose list (a blank
+line between sibling items) preserves the same ancestor scope across
+the blank line, as long as the following item's own marker is no deeper
+than whatever is still open at the end of the preceding item — a
+same-depth sibling, or a resumption at a shallower ancestor's own
+level — and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. Unlike every other check above, a
+`prose-dependency` warning never flips `passed` to `false` and never
+changes the linter's exit code: it prompts the author to either
+convert the prose into a proper dependency marker or consciously
+confirm the reference is a mere breadcrumb.
+
+```sh
+node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
+  --marker-prefix <resolved-target-prefix> \
+  --body-file <path-to-drafted-body> [--label <label>]...
+```
+
+Or, for npx/package-manager profiles, the equivalent
+`idd-audit-authored-issue` command. Pass `--stdin` instead of
+`--body-file` when the drafted body is not yet written to disk.
+**Always pass `--marker-prefix`** with the prefix resolved under
+[Target marker prefix](#target-marker-prefix): without it, the linter
+falls back to reading `.github/idd/config.json` from the current
+working directory, and if that file is missing or unreadable — for
+example when running from an installed bundle without a local
+checkout of the target repository's config — it silently defaults to
+this source repository's own `idd-skill` prefix, which produces a
+false pass or fail against the wrong prefix instead of an error.
+
+**No helper runtime available (`instructions-only` profile).** The
+linter cannot run without Node.js and the vendored `scripts/`
+directory, and an `instructions-only` install is a first-class
+supported fallback, not a degraded one. Unavailability is never a
+waiver: manually re-verify the same checks listed above against this
+contract's prose and the [Draft schemas](#required-draft-content)
+before publishing.
+
+A `passed: false` report (or non-zero exit, or a failed manual
+re-verification) means the draft is not ready to publish yet,
+regardless of how complete the narrative reads — fix every reported
+finding and re-run before treating the issue as `ready`. The linter (or
+its manual equivalent) is a mechanical structural check, not a
+substitute for the judgment-based checks above (human-dependency
+isolation, codebase fidelity, reuse-first) — passing it is necessary,
+not sufficient, for `ready`.
 
 ## Autopilot-suitability score
 
@@ -556,11 +786,24 @@ Effort is distinct from the autopilot-suitability score: suitability
 captures _autonomy_ (can an agent finish unattended), while effort
 captures _size_ (a fully-autonomous issue can still be large).
 
-| Hint | Meaning | Typical signals                                                                                     |
-| ---- | ------- | --------------------------------------------------------------------------------------------------- |
-| S    | Small   | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
-| M    | Medium  | A helper plus its callers, or one instruction surface with mirrors and tests                        |
-| L    | Large   | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+| Hint         | Scope                                                                                             | Uncertainty                                                                                        | Example signals                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **S** Small  | Touches one module or a small, contained file set                                                 | Little to no open design decision remains once the plan is drafted                                 | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| **M** Medium | Touches a helper plus its callers, or one instruction surface together with its mirrors and tests | At most one open design decision remains, resolvable during planning without a separate hold       | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| **L** Large  | Touches a new helper family, or spans a multi-file rewrite across several instruction surfaces    | Two or more open design decisions remain, or one decision whose resolution could reshape the scope | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+**Calibration note.** Observed agent token usage or wall-clock duration
+from previously completed issues may be used to sanity-check a chosen
+band, but those are calibration observations only, never the unit
+itself: model speed shifts release to release, and concurrent agent
+runs distort wall-clock comparison. Do not anchor a hint to a specific
+token count or duration.
+
+**Mis-scope routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a mis-scope smell: the draft
+likely bundles multiple intents. Return to
+[Decompose and Draft](#2-decompose-and-draft) and split at intent level
+instead of publishing one oversized issue labeled `L`.
 
 The hint is recorded as a **footer at the end of the issue body** — a
 visible line paired with a hidden, prefix-aware machine marker, beside
@@ -598,7 +841,41 @@ Binding rules:
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.
 
+## Authoring hold and release
+
+Issue authoring uses a two-stage contract: drafting and publishing
+happen together under an authoring hold; release from that hold is the
+only approval boundary.
+
+- **Stage 1 — author-and-publish.** Once a drafted `ready` body passes
+  the mechanical `audit-authored-issue` gate (see
+  [Mechanical pre-publish gate](#mechanical-pre-publish-gate)) and the
+  critique pass, publish it directly under the configured authoring
+  label (`issueAuthoring.authoringLabelName`, defaulting to
+  `status:authoring`) — no separate user approval of the drafted body
+  is required. The label doubles as the draft marker for the held
+  issue and the claim-suppression lock that keeps Discover from
+  selecting it: held issues ARE the drafts, so in-place edits, roadmap
+  relationship wiring, and re-lint of already-published bodies all
+  happen under that same lock. If a session is interrupted before the
+  set is fully wired, leave the label in place — that alone keeps
+  Discover from selecting the unfinished set until a later session
+  finishes the work.
+- **Stage 2 — release.** Before removing the authoring label, run a
+  release checklist: every child issue is referenced from its parent
+  roadmap's `## Tracks` list; no unsubstituted placeholder remains in
+  any published body; the `audit-authored-issue` linter (or its manual
+  fallback) is green on every published body in the set. Remove the
+  label only after that checklist passes and the user explicitly
+  requests release from the authoring hold. Release is a human action;
+  nothing in this bundle auto-releases a held issue set.
+
 ## Publication boundary
 
-Drafting issues does not authorize publishing them or starting the IDD
-execution loop unless the user explicitly asked for that next step.
+Publishing a drafted `ready` body under the authoring hold does not
+need a separate user approval once it passes the mechanical
+`audit-authored-issue` gate and the critique pass — see
+[Authoring hold and release](#authoring-hold-and-release) above for the
+full two-stage contract. Removing the authoring label and starting the
+IDD execution loop both require the user's explicit hold-release
+request; nothing else authorizes either.

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -16,10 +16,12 @@ chooser for output shapes.
 ## Output chooser
 
 Draft an orphan issue only when one autonomous task can finish the work
-and the target repository is discoverable through `issue-scope:
-orphan-first`. If the repository uses `orphan-first-policy:
+and the target repository discovers orphans (`issue-scope:
+roadmap-first`, the default, via the orphan fallback, or
+`orphan-first`). If the repository uses `orphan-first-policy:
 maintainer-approved`, include a post-publication approval step after the
-final issue content is stable. If a public repository uses
+final issue content is stable. If the repository sets `issue-scope:
+roadmap` (roadmap-only) or a public repository uses
 `orphan-first-policy: public-disabled`, draft a roadmap package instead.
 
 If the repository keeps the broader secure-by-default issue-author
@@ -41,6 +43,25 @@ sequencing, parallel tracks, or multi-session handoff.
 
 Draft only stable non-ready buckets when the work still depends on a
 human decision, missing asset, or unclear verification.
+
+## Under-clarification stop rule
+
+Before drafting a `ready` issue, confirm you can name a concrete surface
+to edit and an objective verification for it. If, after bounded
+clarification, you still cannot, route the candidate to `needs-decision`
+or ask — do not publish a confidently-vague `ready` issue. Reliability
+over speed.
+
+This is an Intake-phase gate on your own confidence, not a wording
+judgment on an already-written draft — it is distinct from the
+"Under-specified" band in the next section, which assesses a body that
+has already been drafted.
+
+**Example**: "Improve the error handling in the API layer" fails this
+check — no concrete surface, no objective verification — even before
+you consider how detailed to write the body. Ask which endpoint or
+module, and what the observable failure mode is, or route the request
+to `needs-decision` instead of guessing at a plausible-sounding scope.
 
 ## Specificity target
 
@@ -76,6 +97,48 @@ Before you publish a ready issue, confirm:
 - removing one concrete detail would make the issue feel high-range-only,
   while adding more detail would start turning it into a lightweight
   model script
+
+## Mechanical pre-publish gate
+
+Before you publish a drafted **ready orphan, roadmap, or child** body
+(scoped to those ready shapes — non-ready buckets like
+`blocked-by-human` are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime
+is available. It mechanically catches shape and marker mistakes — a
+missing or duplicated autopilot-suitability footer, a wrong
+markerPrefix, a missing required heading for the declared shape, a
+malformed dependency marker — that a confident narrative can otherwise
+mask:
+
+```sh
+node scripts/audit-authored-issue.mjs --shape orphan \
+  --marker-prefix <resolved-target-prefix> --body-file draft.md
+```
+
+**Always pass `--marker-prefix`** with the prefix resolved under
+[contract.md's Target marker prefix](contract.md#target-marker-prefix):
+without it, the linter falls back to reading
+`.github/idd/config.json` from the current working directory, and
+silently defaults to this source repository's own `idd-skill` prefix
+when that file is missing or unreadable — producing a false pass or
+fail against the wrong prefix instead of an error.
+
+Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
+instead of `--body-file` when the draft is not yet on disk, and
+`--label <name>` (repeatable) to pass proposed labels for the check
+that a suitability score of `1` carries the configured
+`blocked-by-human` label (default `status:blocked-by-human`; use
+`--config <path>` to point at a policy that overrides the label name —
+this check is also one-directional, it does not flag the reverse, a
+non-`1` score paired with the label). Fix every reported finding and
+re-run before publishing; a `passed: false` report means the draft is
+not ready yet, regardless of how complete the narrative reads.
+
+**No helper runtime available (`instructions-only` profile):** the
+linter cannot run. `instructions-only` is a first-class supported
+fallback, not a waiver — manually re-verify the same checks against
+[contract.md's Mechanical pre-publish gate](contract.md#mechanical-pre-publish-gate)
+before publishing instead.
 
 ## Hidden human-dependency quick check
 
@@ -248,9 +311,12 @@ Blocked by #445
 Now Discover and A4.5 defer `#450` until every sibling merges, so it is
 claimed only when its acceptance criteria can actually pass.
 
-Resolve `<marker-prefix>` from the target repository's onboarding or IDD
-docs before publishing the draft. Use `idd-skill` only when the target
-repository actually configured that prefix.
+**Prefix-first**: resolve `<marker-prefix>` from the target repository's
+onboarding or IDD docs before emitting any of these markers —
+`roadmap-id`, `blocked-by`, `autopilot-suitability`, or `effort` — not
+just the dependency markers shown above. Never default to `idd-skill`
+in an installed bundle; use it only when the target repository actually
+configured that prefix.
 
 ## Human-dependency isolation examples
 
@@ -524,9 +590,15 @@ verification shape, not a rigid edit order.
 
 ## Publication boundary
 
-If the user asked for drafts only, stop after reporting the issue set,
-assumptions, and non-ready buckets.
+Publish each `ready` body directly under the authoring hold once it
+passes the mechanical gate and the critique pass — this is the default
+outcome of drafting, and it needs no separate publish approval. Stop
+after publishing (and applying/creating the authoring label) unless
+the user also separately requests release from the authoring hold —
+release is what authorizes starting the IDD execution loop, so a
+request phrased as "start the IDD execution loop" counts as that same
+release request, not a separate path around it.
 
-If the user explicitly asked to publish issues, create or update them
-and then stop unless they also separately asked to start the IDD
-execution loop.
+If the user asked for drafts only (a preview before anything is
+created), honor that instead: stop after reporting the issue set,
+assumptions, and non-ready buckets, without publishing.

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -1,23 +1,27 @@
 # Workflow Boundary
 
-This bundle handles pre-approval issue drafting only.
+This bundle handles issue authoring end to end under the authoring
+hold: drafting and publishing are one continuous stage with no
+per-step approval, and release from the authoring hold is the single
+approval boundary that hands off to IDD execution.
 
-## Handoff sequence
+## Two-stage contract
 
-The issue-authoring bundle fits into a three-phase handoff:
+### Stage 1: Author-and-publish (under the hold)
 
-### Phase 1: Drafting (this bundle)
-
-- Skill drafts issues in the target repository
-- Issues move through readiness buckets: `deferred` → `ready` or
-  → escalation bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
-- User approves the issue set before any publication
-
-### Phase 2: Publishing (user-authorized handoff)
-
-- User explicitly asks for publication
-- Bundled skill resolves the authoring label from
-  `issueAuthoring.authoringLabelName`, defaulting to `status:authoring`
+- Skill drafts issues in the target repository. Each candidate moves
+  through the readiness buckets: `deferred` → `ready` or an escalation
+  bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
+- Before publishing a `ready` body, bundled skill runs the mechanical
+  `audit-authored-issue` gate and the critique pass (both unchanged
+  and still mandatory)
+- Bundled skill then publishes directly under the configured authoring
+  label (`issueAuthoring.authoringLabelName`, defaulting to
+  `status:authoring`) — **no prior user approval of the drafted body
+  is required**. If the current request asked only for a preview
+  (drafts to look at before anything is created), bundled skill stops
+  after reporting the proposed set instead of publishing; publishing
+  is otherwise the default outcome of drafting, not an opt-in step
 - If the label does not exist in the target repository, bundled skill
   creates it with `gh label create` before first use; label creation or
   application failure blocks publishing
@@ -30,31 +34,36 @@ The issue-authoring bundle fits into a three-phase handoff:
   issue before stopping; deletion needs admin permission the authoring
   agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
   so it is not the default path
-- User verifies the published issues look correct
-- Bundled skill removes the authoring label from all published issues only
-  after the full issue set is published, the user confirms the result, and
-  the user explicitly requests release from the authoring hold for IDD
-  execution
-- If publishing is interrupted before release, the authoring label remains
-  in place as the IDD discover guard signal
-- Published issues remain on hold until user explicitly requests IDD execution
+- **The held issue IS the draft.** In-place body edits, roadmap
+  relationship wiring (children first, then roadmaps once the real
+  issue numbers exist), and re-lint of already-published bodies all
+  happen on the published issue, under the same label — not in a
+  session-local buffer that a later session cannot see
+- **Interrupted-session guard.** If a Stage 1 session stops before the
+  set is fully wired and stable, the authoring label stays on every
+  issue it already published. The label alone is what keeps Discover
+  from selecting an unfinished set, so a later session (or the same
+  session, resumed) can find and finish the work with no extra
+  bookkeeping
 
-### Phase 3: Execution (separate IDD loop)
+### Stage 2: Release (the single approval boundary)
 
-- User explicitly asks to start the IDD execution loop
-- Target repository's `.github/instructions/idd-discover.instructions.md`
-  takes over
-- IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
-- Suitable issues are claimed, worked, and merged
-
-**Approval boundaries**:
-
-- **After drafting** (Phase 1 → Phase 2): User must explicitly approve the
-  issue set
-- **After publishing** (Phase 2 → Phase 3): User must explicitly request IDD
-  execution
-- **No implicit progression**: Each handoff requires explicit user request.
-  The bundle must not auto-transition to publishing or execution.
+- The user's explicit hold-release request is the only approval this
+  bundle's workflow requires, and it authorizes IDD execution for the
+  released issues
+- Before removing the authoring label, bundled skill runs a release
+  checklist that absorbs the rigor of the dropped middle step:
+  - every child issue is referenced from its parent roadmap's
+    `## Tracks` list
+  - no unsubstituted placeholder (a leftover `#TBD`, template
+    stand-in, or similar) remains in any published body
+  - the `audit-authored-issue` linter (or its manual fallback under
+    `instructions-only`) is green on every published body in the set
+- Bundled skill removes the authoring label from all published issues
+  only after the release checklist passes and the user's release
+  request is explicit
+- Release remains a human action; nothing in this bundle auto-releases
+  a held issue set
 
 ## A4.5 Gate Timing
 
@@ -99,11 +108,16 @@ time and report the specific failure (unclear, invalid, duplicate).
 - start the Discover -> Claim -> Work loop implicitly
 - treat bundled references as a replacement for repository execution
   instructions
-- publish issues unless the user explicitly asked for publishing
+- publish a body that has not passed the mechanical
+  `audit-authored-issue` gate and the critique pass
+- remove the authoring label from any issue without an explicit
+  release request
 
 ## Handoff to execution
 
-After the user approves the issue set, wait for a separate request to
-publish the issues or start the IDD execution loop. Only then should
-the workflow hand off to the repository's normal entry file and routed
-`.github/instructions/*.instructions.md` phase files.
+Once the user's explicit release request removes the authoring label
+from every issue in the released set, execution is authorized: the
+repository's normal entry file and routed
+`.github/instructions/*.instructions.md` phase files (Discover, Claim,
+Work) may pick up the released issues. This bundle does not itself
+start that loop.

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,9 @@
 
 # Pnpm
 pnpm-lock.yaml
+
+### THE REPOSITORY SPECIFIES ################################################
+
+# Vendored Claude Code skill bundles (re-synced verbatim from upstream;
+# reformatting on every re-sync makes the diff noisy for no benefit)
+.claude/skills/

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,8 +10,6 @@
 # Pnpm
 pnpm-lock.yaml
 
-### THE REPOSITORY SPECIFIES ################################################
-
 # Vendored Claude Code skill bundles (re-synced verbatim from upstream;
 # reformatting on every re-sync makes the diff noisy for no benefit)
 .claude/skills/


### PR DESCRIPTION
## Summary

Re-sync `.claude/skills/issue-authoring/` from upstream
`kurone-kito/idd-skill` at tag `v0.6.0`, closing the drift since the
0.3.0 import (roadmap #110).

- Byte-for-byte sync of `SKILL.md`, `references/contract.md`,
  `references/draft-patterns.md`, and `references/workflow-boundary.md`
  from `skills/issue-authoring/` at `v0.6.0`.
- Delete `.claude/skills/issue-authoring/agents/openai.yaml` — upstream
  dropped it from distribution at this tag.
- Add `.claude/skills/` to `.prettierignore` so the vendored bundle
  stops being reformatted on every future re-sync (matches the
  existing `pnpm-lock.yaml` / `.husky/_/` repo-local entries under the
  same header).

No changes to `cspell.config.yml` — the re-synced text introduced no
new flagged words against the current dictionary.

## Background

This is a track of roadmap #122 (re-import idd-skill at upstream
v0.6.0), independent of the other tracks and claimable in parallel.
The four re-synced files were independently byte-diffed against a
fresh fetch of the upstream tag during self-review; all match exactly,
and the stated line-count deltas in #125 (SKILL.md +54/−19, contract.md
+288/−11, draft-patterns.md +83/−11, workflow-boundary.md +57/−43) hold
precisely.

Closes #125

## Test plan

- [x] `pnpm run lint` passes (cspell, eslint, markdown, oxlint,
      prettier, stylelint all clean)
- [x] `pnpm run test` passes (33/33)
- [x] `.claude/skills/issue-authoring/SKILL.md` still opens with valid
      frontmatter (`name: issue-authoring` + `description:`)
- [x] `.claude/skills/issue-authoring/agents/openai.yaml` no longer
      exists
- [x] `pnpm run lint:prettier:fix` produces no diff under
      `.claude/skills/`
- [x] Diff scope confirmed limited to
      `.claude/skills/issue-authoring/**` and `.prettierignore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-stage issue authoring and release workflow.
  * Added bounded clarification, repository-aware marker handling, and pre-publication validation.
  * Added support for editing and relinting published drafts while preserving their authoring status.
  * Added duplicate scanning, roadmap routing, and guidance for decomposing issues.

* **Documentation**
  * Updated authoring contracts, workflow guidance, draft patterns, and release procedures.
  * Documented preview-only behavior and explicit release requirements.

* **Chores**
  * Excluded Claude skill bundles from formatting checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->