### PR TITLE
fix(web): actually minify the production CSS

### DIFF
--- a/packages/web/postcss.config.mjs
+++ b/packages/web/postcss.config.mjs
@@ -1,4 +1,7 @@
 export default {
-  plugins: { autoprefixer: {}, tailwindcss: {} },
-  ...(process.env.NODE_ENV === 'production' ? { cssnano: {} } : {}),
+  plugins: {
+    autoprefixer: {},
+    tailwindcss: {},
+    ...(process.env.NODE_ENV === 'production' ? { cssnano: {} } : {}),
+  },
 };


### PR DESCRIPTION
## Summary

`packages/web/postcss.config.mjs` spread the conditional `cssnano`
entry as a **sibling of `plugins`**, not inside it, so PostCSS never
saw the key and production CSS was never minified even though
`cssnano@^7.0.6` was already a `packages/web` devDependency. This
moves the conditional entry inside `plugins` so PostCSS actually
loads it.

## Investigation note (issue's second defect did not reproduce)

The issue also proposed that `process.env.NODE_ENV` is unset during
`pnpm run build` because `NODE_ENV: production` in
`.github/workflows/push-main.yml` / `push.yml` is set on the Netlify
deploy step, not on the `pnpm run build` step. I verified this
empirically before deciding whether to also touch the workflow files:
I temporarily instrumented `postcss.config.mjs` to print
`process.env.NODE_ENV` and ran the full monorepo build and dev server
locally (Vite 6.0.11 / vinxi 0.5.1, this repo's pinned versions).

- `pnpm run build` (`vinxi build` → `vite build` under the hood) logs
  `NODE_ENV = "production"` for all three build passes (client, ssr,
  server-fns) with **no** `NODE_ENV` set in the invoking shell.
- `pnpm run start` (`vinxi dev` → `vite dev`) logs
  `NODE_ENV = "development"`.

This matches Vite's documented behavior of auto-setting
`process.env.NODE_ENV` based on the `build`/`serve` command when it
is not already set. So `process.env.NODE_ENV === 'production'` is
already a signal that is correct in every environment (local, CI, or
otherwise) without any workflow changes — the acceptance criteria's
preferred outcome ("prefer a signal that is correct in every
environment over adding NODE_ENV to one CI step"). I left the two
workflow files untouched; the change is limited to
`packages/web/postcss.config.mjs`.

## Verification

- `pnpm run lint && pnpm run test` pass (33 tests).
- Full local production build (`pnpm run build`, real Google Calendar
  credentials, network-reachable sandbox) before/after comparison of
  the emitted client CSS bundle:
  - Before (bug present): `client-CtwbSFzp.css` — **73373 bytes**
  - After (fixed): `client-B4Z8UvEo.css` — **71277 bytes** (‑2096
    bytes, ‑2.9%)
  - The fixed output shows cssnano-specific normalization (e.g.
    `--tw-border-spacing-x: 0` → `--tw-border-spacing-x:0`, selector
    reordering) that was absent before.
- Autoprefixer output is unaffected: 44 `-webkit-*` occurrences in the
  built CSS both before and after.
- `pnpm run start` (dev) still resolves `NODE_ENV=development`, so
  `cssnano` stays excluded and dev CSS remains unminified, unchanged
  from current behavior.
- **Spot-check of the largest emitted CSS file**
  (`packages/web/dist/_build/assets/client-*.css`, the fixed build):
  the whole file is a single line (`wc -l` → 1), contains zero runs of
  two-or-more consecutive spaces and zero tab characters (source-
  formatting whitespace absent), and contains exactly one `/* */`
  comment: Tailwind's own `/*! tailwindcss v3.4.17 | MIT License |
  https://tailwindcss.com*/` banner. That is an intentional
  `/*! ... */` "important" comment, which cssnano (like every common
  CSS/JS minifier) preserves by default for license attribution — it
  is not a leftover source-formatting comment, and no other comment is
  present.

## Scope

Only `packages/web/postcss.config.mjs` changed.
`pnpm-lock.yaml` shows pre-existing, unrelated lockfile drift from
`pnpm install --prefer-frozen-lockfile` (known root/package `vitest`
version mismatch); left uncommitted per repository policy.

Closes #148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CSS processing configuration for improved compatibility and streamlined production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
