### PR TITLE
fix(a11y): restore table semantics on the schedule table

### DIFF
--- a/packages/web/src/components/atoms/calendar/Table.tsx
+++ b/packages/web/src/components/atoms/calendar/Table.tsx
@@ -18,10 +18,8 @@ export interface TableProps extends Readonly<ParentProps> {
  * @returns The component.
  */
 export const Table: Component<TableProps> = (props) => (
-  <table
-    class="table-xs table w-full border-separate border-spacing-x-0.5 border-spacing-y-1 sm:border-spacing-y-1.5 sm:pr-[10%] md:border-spacing-x-1.5 md:pr-[15%] lg:border-spacing-0.5 lg:pr-0 [&_*]:whitespace-nowrap [&_*]:text-nowrap [&_*]:break-keep [&_*]:text-[2.3cqi] lg:[&_*]:text-[1.9cqi]"
-    role="grid"
-  >
+  <table class="table-xs table w-full border-separate border-spacing-x-0.5 border-spacing-y-1 sm:border-spacing-y-1.5 sm:pr-[10%] md:border-spacing-x-1.5 md:pr-[15%] lg:border-spacing-0.5 lg:pr-0 [&_*]:whitespace-nowrap [&_*]:text-nowrap [&_*]:break-keep [&_*]:text-[2.3cqi] lg:[&_*]:text-[1.9cqi]">
+    <caption class="sr-only">予定表</caption>
     <colgroup>
       <col class="w-1 tracking-tight" />
       <col class="w-28 tracking-tighter" />
@@ -29,9 +27,9 @@ export const Table: Component<TableProps> = (props) => (
     </colgroup>
     <thead class="[&_th]:bg-base-300/80 [&_th]:rounded-badge [&_th]:p-[1cqi]">
       <tr class="text-center font-bold">
-        <th>{props.date}</th>
-        <th>{props.time}</th>
-        <th>{props.detail}</th>
+        <th scope="col">{props.date}</th>
+        <th scope="col">{props.time}</th>
+        <th scope="col">{props.detail}</th>
       </tr>
     </thead>
     <tbody class="[&_.release]:!bg-secondary/80 [&_.release]:text-secondary-content [&_.streaming]:!bg-accent/80 [&_.streaming]:text-accent-content [&_td]:bg-base-300/80 [&_td]:rounded-badge [&_.date]:text-center [&_.sat]:!bg-blue-500/60 [&_.sun]:!bg-red-500/60 [&_.time]:text-center [&_td]:px-[2cqi] [&_td]:py-[1.8cqi]">


### PR DESCRIPTION
## Summary

The schedule table declared `role="grid"`, an interactive widget role
that promises arrow-key cell navigation, a managed focus point, and
the `aria-rowindex`/`aria-colindex` contract — this static,
`data.json`-rendered table implements none of that, so the default
table semantics a screen reader would otherwise expose (row/column
announcement, header association, table navigation) were suppressed.

- Removed `role="grid"` so the implicit `table` role applies.
- Added `scope="col"` to the three `<th>` header cells, since `rowSpan`
  is used on the date column's body cells (`atoms/calendar/Row.tsx`,
  untouched here) and heuristic header association should not be
  relied on.
- Gave the table an accessible name via a visually-hidden `<caption>`
  (`class="sr-only"`, Tailwind's stock utility — no config change
  needed), text `予定表`.

## Accessible-name mechanism and why

The issue suggested `aria-labelledby` referencing "the existing
heading in `molecules/calendar/Frame.tsx`" as an alternative. That
premise turned out to be incorrect: `Frame.tsx` only wraps `<Table>`
and a disclaimer paragraph — it has no heading. The actual heading
(`予定表: {dateSpan}`) lives in a *sibling* component,
`molecules/calendar/Header.tsx`, rendered alongside (not inside)
`Frame.tsx` by their shared parent `Calendar.tsx`. Wiring
`aria-labelledby` to that real heading would require editing
`Header.tsx`, which is outside the acceptance criteria's stated file
scope (`Table.tsx`, and `Frame.tsx` only "if the name comes from an
existing heading"). A self-contained `<caption>` stays within that
scope, so it was used instead. The caption text `予定表` reuses the
exact term already used for this table elsewhere (`Header.tsx`'s
`予定表:`, and `organisms/Calendar.tsx`'s `heading="#VTuber予定表"`)
rather than inventing new copy; it is Japanese-only like the rest of
this deliberately `lang="ja"` calendar section (translating it is a
separate, out-of-scope locale-metadata concern).

## Visual-unchanged verification

Storybook's dev server does not currently start in this environment
(`storybook-solidjs-vite`'s preset throws `ReferenceError: module is
not defined` under the pinned Node runtime — a pre-existing
infrastructure issue unrelated to this change), so the check was done
against a full local production build instead:

- `pnpm run build` (`packages/web`) succeeded, and the prerendered
  `packages/web/dist/index.html` was inspected directly: the emitted
  `<table>` markup shows no `role` attribute, `scope="col"` on all
  three `<th>`, and `<caption class="sr-only">予定表</caption>` as the
  table's first child (valid per the HTML content model:
  `caption?, colgroup*, thead?, tbody+`).
- The compiled CSS confirms `sr-only`'s definition
  (`position:absolute; width:1px; height:1px; ... clip:rect(0,0,0,0)`),
  the standard evergreen-safe visually-hidden pattern, so the caption
  is present for assistive tech but removed from visual flow —
  nothing else in the markup changed, so the rendered layout is
  unchanged.
- `Table.stories.tsx`'s existing `Default` story needed no changes
  (its props are unchanged), and remains available for a manual visual
  spot-check once Storybook's runtime issue is fixed separately.

## Test coverage

No new tests were added. `Table.tsx` is a presentational,
JSX+Tailwind-only atom with no existing test file; this repository's
convention is that such atoms are covered by Storybook rather than
unit/component tests, and adding a first test here would also expand
this PR's change scope beyond `Table.tsx`'s markup itself. `pnpm run
lint` and `pnpm run test` both pass unchanged (33/33 tests).

## Out of scope (per the issue)

- Translating the Japanese column labels or the new caption text — the
  calendar section is deliberately Japanese-only (`lang="ja"` on an
  ancestor).
- `colgroup`, the class-driven colour coding, and `Row.tsx`'s `rowSpan`
  behavior — left untouched as instructed.

Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Added a visually hidden Japanese caption to the calendar table.
  - Improved table semantics with column-scoped header cells.
  - Removed the unnecessary grid role for more accurate screen reader interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->