### PR TITLE
ci: skip the scheduled deploy when calendar data is unchanged

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -5,13 +5,62 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 15/3 * * *'
+    - cron: '0 */3 * * *'
   workflow_dispatch:
 permissions:
   contents: read
   pull-requests: write
 jobs:
+  detect-changes:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.compare.outputs.changed }}
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - name: Stages the pushed branch
+        uses: actions/checkout@v7
+      - name: Pre-prepare the Node.js environment
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+      - name: Install the latest corepack explicitly
+        run: npm install --force -g corepack@latest
+      - name: Enable the corepack because of the pnpm
+        run: corepack enable
+      - name: Post-prepare the Node.js environment
+        uses: actions/setup-node@v7
+        with:
+          cache: ${{ !env.ACT && 'pnpm' || '' }}
+          node-version-file: .node-version
+      - env:
+          HUSKY: 0
+        name: Install the dependencies
+        run: pnpm install --prefer-frozen-lockfile
+      - name: Build the lib and fetcher workspaces
+        run: pnpm --filter @kurone-kito/kit.black-lib --filter @kurone-kito/kit.black-fetcher run build
+      - name: Ensure the local .env file exists
+        run: touch .env
+      - id: compare
+        env:
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          ID_OTHERS: ${{ secrets.ID_OTHERS }}
+          ID_RELEASE: ${{ secrets.ID_RELEASE }}
+          ID_STREAMING: ${{ secrets.ID_STREAMING }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          TZ: Asia/Tokyo
+        name: Compare the fresh fetch against the live data
+        run: node --env-file=.env packages/fetcher/dist/binDetectChange.mjs
   deploy:
+    needs: detect-changes
+    if: >-
+      !cancelled() && (github.event_name != 'schedule' ||
+      needs.detect-changes.result != 'success' ||
+      needs.detect-changes.outputs.changed == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Set git to use LF

--- a/packages/fetcher/src/binDetectChange.mts
+++ b/packages/fetcher/src/binDetectChange.mts
@@ -1,0 +1,33 @@
+import { appendFileSync } from 'node:fs';
+import {
+  fetchFreshDataText,
+  fetchLiveDataText,
+  isChanged,
+} from './detectChange.mjs';
+
+/** The live published calendar data URL. */
+const LIVE_URL = 'https://kit.black/data.json';
+
+/**
+ * Writes the `changed` output for GitHub Actions (`$GITHUB_OUTPUT`),
+ * falling back to stdout when run outside of GitHub Actions.
+ * @param changed Whether the calendar data changed.
+ */
+const writeOutput = (changed: boolean): void => {
+  const line = `changed=${changed}`;
+  const file = process.env['GITHUB_OUTPUT'];
+  if (file) appendFileSync(file, `${line}\n`);
+  else console.log(line);
+};
+
+// Fail open: any failure here (fetch, auth, network, or an unexpected
+// exception) is treated as "changed" so the caller always builds and
+// deploys rather than silently skipping on a detection error.
+try {
+  const fresh = await fetchFreshDataText();
+  const live = await fetchLiveDataText(LIVE_URL);
+  writeOutput(live === undefined || isChanged(fresh, live));
+} catch (error) {
+  console.error(error);
+  writeOutput(true);
+}

--- a/packages/fetcher/src/detectChange.mts
+++ b/packages/fetcher/src/detectChange.mts
@@ -1,0 +1,64 @@
+import { WEEKDATES, weekRange } from '@kurone-kito/kit.black-lib';
+import { fetchAllRawEventsFactory } from './fetchRaw.mjs';
+import { toEventsFactory } from './parseEvent.mjs';
+import { toRowMapper } from './toRow.mjs';
+
+/**
+ * Normalizes JSON text for a whitespace-insensitive comparison.
+ * @param text The text to normalize.
+ * @returns The trimmed text.
+ */
+export const normalize = (text: string): string => text.trim();
+
+/**
+ * Determines whether the fresh calendar data differs from the live
+ * published data.
+ * @param fresh The freshly fetched data, as JSON text.
+ * @param live The live published data, as JSON text.
+ * @returns `true` when the two differ.
+ */
+export const isChanged = (fresh: string, live: string): boolean =>
+  normalize(fresh) !== normalize(live);
+
+/**
+ * Fetches the fresh calendar data as JSON text, in the same shape the
+ * fetcher's `kb-fetcher` binary prints (and thus that `prebuild:fetcher`
+ * writes to `src/data.json`).
+ *
+ * This call and the later production build's own `prebuild:fetcher` call
+ * are two independent Google Calendar API requests made minutes apart.
+ * A calendar edit landing between them can produce a false "unchanged"
+ * verdict for a single cycle; this is intentionally accepted (fail-open
+ * favors availability over precision) and self-heals at the next
+ * scheduled run.
+ * @returns The fresh calendar data.
+ */
+export const fetchFreshDataText = async (): Promise<string> => {
+  const fetchAllRawEvents = fetchAllRawEventsFactory();
+  const span = weekRange(new Date(), WEEKDATES);
+  const toEvents = toEventsFactory(span);
+  const raw = await fetchAllRawEvents(span);
+  return JSON.stringify(toEvents(raw).map(toRowMapper), undefined, 2);
+};
+
+/**
+ * Fetches the live published calendar data, bypassing CDN caches.
+ * @param url The URL of the live data.
+ * @returns The live data text, or `undefined` when it could not be
+ * fetched (non-OK response, network error, or any other failure).
+ */
+export const fetchLiveDataText = async (
+  url: string,
+): Promise<string | undefined> => {
+  try {
+    // The unique query string is the CDN-cache bypass: a fresh URL on
+    // every call is a guaranteed cache miss, without depending on a
+    // `cache` fetch option that this Node runtime's `RequestInit` type
+    // does not declare.
+    const bypass = `${url}?_=${Date.now()}`;
+    const res = await fetch(bypass);
+    return res.ok ? await res.text() : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/fetcher/src/detectChange.test.mts
+++ b/packages/fetcher/src/detectChange.test.mts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isChanged, normalize } from './detectChange.mjs';
+
+describe('normalize', () => {
+  it('should trim leading and trailing whitespace', () =>
+    expect(normalize('\n  [1,2,3]  \n')).toBe('[1,2,3]'));
+});
+
+describe('isChanged', () => {
+  it('should be false when the texts are identical', () =>
+    expect(isChanged('[1,2,3]', '[1,2,3]')).toBe(false));
+
+  it('should be false when the texts differ only by surrounding whitespace', () =>
+    expect(isChanged('[1,2,3]\n', '\n[1,2,3]')).toBe(false));
+
+  it('should be true when the texts differ', () =>
+    expect(isChanged('[1,2,3]', '[1,2,4]')).toBe(true));
+});

--- a/packages/fetcher/src/fetchRaw.mts
+++ b/packages/fetcher/src/fetchRaw.mts
@@ -34,12 +34,17 @@ export const fetchRawEventsFactory =
   async (
     params: Except<
       SetRequired<calendar_v3.Params$Resource$Events$List, 'calendarId'>,
-      'singleEvents' | 'timeZone'
+      'orderBy' | 'singleEvents' | 'timeZone'
     >,
   ): Promise<readonly calendar_v3.Schema$Event[]> => {
     const { data } = await client.events.list({
       singleEvents: true,
       timeZone: 'Asia/Tokyo',
+      // `orderBy: 'startTime'` requires `singleEvents: true` (set
+      // above) and keeps equal-epoch ties from flapping between
+      // fetches, which would otherwise cause false "changed" verdicts
+      // in the schedule-deploy change detector.
+      orderBy: 'startTime',
       ...params,
     });
     const { items = [] } = data;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,6 +20,7 @@
     "prebuild:yaml": "js-yaml src/constants.yaml > src/constants.json",
     "build": "vinxi build",
     "build:storybook": "storybook build",
+    "postbuild": "cp src/data.json dist/data.json",
     "clean": "rimraf -g \"*.tgz\" \"*.tsbuildinfo\" .output .vinxi dist node_modules/.cache \"src/*.json\" storybook-static",
     "serve": "serve dist",
     "prestart": "pnpm run prebuild",


### PR DESCRIPTION
## Summary

`push-main.yml` rebuilds and redeploys production on a cron
(previously 3×/day) even when the fetched calendar data is identical
to what is already live. This PR makes the scheduled deploy
change-aware and widens the cron, per the calendar-deploy-efficiency
roadmap (#132).

- **Publish `/data.json`**: `packages/web/package.json` gets a
  `postbuild` script that copies `src/data.json` (the fetcher's
  prebuild output) into `dist/data.json`, so the deployed site serves
  the exact display-projection data the build consumed.
- **Determinism hardening**: `packages/fetcher/src/fetchRaw.mts` now
  passes `orderBy: 'startTime'` to `events.list`, so equal-epoch ties
  can't flap between fetches and cause false "changed" verdicts.
- **Change-detection script**: new `packages/fetcher/src/detectChange.mts`
  (pure, unit-tested compare logic) and `binDetectChange.mts` (the CI
  entrypoint) fetch the fresh calendar data through the same pipeline
  `kb-fetcher` uses, compare it against the live published
  `/data.json` (cache-busted per request), and write a
  `changed=true|false` GitHub Actions output. Every failure path
  (non-200 live fetch, first-deploy 404, network error, fetcher/auth
  error) is caught and treated as `changed=true`; the script always
  exits 0.
- **`push-main.yml`**: a new `detect-changes` job runs only on
  `schedule` events, builds just the `lib`+`fetcher` workspaces, and
  runs the compare script. `deploy` now `needs: detect-changes` and
  only skips when the event *is* `schedule`, that job *did* succeed,
  and it reported `changed=false` — any other combination (push,
  workflow_dispatch, or a failed/skipped detection job) still builds
  and deploys. The `!cancelled()` prefix is required: GitHub Actions
  implicitly ANDs a custom `if:` with `success()` unless a
  status-check function is present, so without it a skipped
  `detect-changes` (the normal case on `push`) would silently skip
  `deploy` too.
- **Cron**: widened from `0 15/3 * * *` (3 runs/day, JST
  00:00/03:00/06:00 only) to `0 */3 * * *` (8 runs/day), since skipped
  unchanged builds make the extra runs nearly free and closes the
  daytime-edit latency gap.

## Verification

- `pnpm run lint && pnpm run test` pass (37/37 tests, including 4 new
  ones for the compare logic).
- Ran a real local production build (this environment has working
  calendar credentials and network egress): confirmed
  `packages/web/dist/data.json` is byte-identical to
  `packages/web/src/data.json`, and that it's fully covered by the
  existing `dist` gitignore entry and `clean` script (no new entries
  needed).
- Ran `binDetectChange` directly against the **live** production site.
  `https://kit.black/data.json` doesn't exist yet (this is its first
  deploy), so the live fetch returned 404 — this exercised the
  "first-deploy 404" fail-open path for real and correctly produced
  `changed=true`. Separately confirmed the 200-response branch against
  a URL that does resolve (`https://kit.black/`), so both branches of
  `fetchLiveDataText` were exercised against real production, not just
  mocks.
- This PR itself is a `push` event on merge, so the very first deploy
  after merge will build unconditionally and publish `/data.json` for
  the first time — the change-detection job only starts skipping
  builds from the next scheduled run onward.

## Out of scope

The 60-day cron auto-disable keepalive is a separate, explicitly
blocked-on-this-issue sibling track (#131) — it needs the job topology
this PR introduces to land first, since the keepalive step has to live
inside it to survive build-skips.

Closes #130
