### PR TITLE
ci: keep push-main.yml's schedule trigger from auto-disabling

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -8,7 +8,6 @@ on:
     - cron: '0 */3 * * *'
   workflow_dispatch:
 permissions:
-  actions: write
   contents: read
   pull-requests: write
 jobs:
@@ -17,12 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.compare.outputs.changed }}
+    permissions:
+      actions: write
+      contents: read
     steps:
       - continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Keep the scheduled workflow enabled
-        run: gh api -X PUT repos/${{ github.repository }}/actions/workflows/push-main.yml/enable
+        run: gh api --include -X PUT repos/${{ github.repository }}/actions/workflows/push-main.yml/enable
       - name: Set git to use LF
         run: |
           git config --global core.autocrlf false

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -8,6 +8,7 @@ on:
     - cron: '0 */3 * * *'
   workflow_dispatch:
 permissions:
+  actions: write
   contents: read
   pull-requests: write
 jobs:
@@ -17,6 +18,11 @@ jobs:
     outputs:
       changed: ${{ steps.compare.outputs.changed }}
     steps:
+      - continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: Keep the scheduled workflow enabled
+        run: gh api -X PUT repos/${{ github.repository }}/actions/workflows/push-main.yml/enable
       - name: Set git to use LF
         run: |
           git config --global core.autocrlf false


### PR DESCRIPTION
## Summary

Adds an in-workflow keepalive to `.github/workflows/push-main.yml` so
the `schedule` trigger that drives the calendar deploy never hits
GitHub's 60-day inactivity auto-disable.

- Grants `actions: write` alongside the existing `contents: read` and
  `pull-requests: write` permission scopes.
- Adds a `Keep the scheduled workflow enabled` step as the **first**
  step of the `detect-changes` job (the job that already runs on every
  `schedule`-triggered run, independent of whether `deploy` ends up
  skipped by change detection). It calls the "enable a workflow" REST
  endpoint via `gh api -X PUT
  repos/${{ github.repository }}/actions/workflows/push-main.yml/enable`
  using the built-in `GITHUB_TOKEN` — no PAT, no external
  infrastructure.
- The step is `continue-on-error: true`: a keepalive failure marks the
  step as failed (visible in the run UI) but does not fail the
  `detect-changes` job, so `deploy`'s existing
  `needs.detect-changes.result != 'success'` gating logic is
  unaffected either way.

This is the second, now-unblocked track of the calendar-deploy roadmap
(#132); the first track (#130, PR #176) introduced the
`detect-changes`/`deploy` job split this change builds on.

## Verification

- `pnpm run lint` — clean (cspell, eslint, oxlint, prettier,
  markdownlint, stylelint).
- `pnpm run test` — 37/37 passing.
- `actionlint .github/workflows/push-main.yml` — clean.
- The 60-day-scale behavior and the real endpoint call cannot be
  exercised pre-merge (`schedule` only fires on the default branch on
  GitHub-hosted repos). Per the issue's own acceptance criteria, the
  objective post-merge check is the next scheduled run's log showing
  the "Keep the scheduled workflow enabled" step complete with an
  HTTP 204 response — the same precedent set by the sibling PR #176
  for this same workflow file.

Closes #131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions.
  * Added a best-effort mechanism to re-enable the main publishing workflow after scheduled checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->