### PR TITLE
fix(web): correct the transposed work card image dimensions

### DIFF
--- a/packages/web/src/components/molecules/WorkCard.tsx
+++ b/packages/web/src/components/molecules/WorkCard.tsx
@@ -19,9 +19,6 @@ export interface WorkCardProps
   /** The label for more information button. */
   readonly labelMore: JSX.Element;
 
-  /** The landscape image URL. */
-  readonly landscapeSrc?: string;
-
   /** The release year text. */
   readonly released: JSX.Element;
 }
@@ -37,42 +34,17 @@ export const WorkCard: Component<WorkCardProps> = (props) => {
     <li class="card bg-base-300 lg:card-side shadow-xl">
       <Show when={others.src}>
         <figure class="aspect-video !items-start lg:aspect-[128/207] lg:h-full lg:w-auto lg:max-w-72 xl:aspect-square xl:max-w-96">
-          <Show
-            fallback={
-              <img
-                alt={others.alt}
-                class="w-full"
-                decoding="async"
-                fetchpriority="low"
-                height={1024}
-                loading="lazy"
-                src={others.src}
-                width={1656}
-              />
-            }
-            when={others.landscapeSrc}
-          >
-            <img
-              alt={others.alt}
-              class="block w-full lg:hidden"
-              decoding="async"
-              fetchpriority="low"
-              height={1280}
-              loading="lazy"
-              src={others.landscapeSrc}
-              width={720}
-            />
-            <img
-              alt={others.alt}
-              class="hidden w-full lg:block"
-              decoding="async"
-              fetchpriority="low"
-              height={1024}
-              loading="lazy"
-              src={others.src}
-              width={1656}
-            />
-          </Show>
+          {/* Work images (assets/works/*.webp) are portrait, 1024x1656. */}
+          <img
+            alt={others.alt}
+            class="w-full"
+            decoding="async"
+            fetchpriority="low"
+            height={1656}
+            loading="lazy"
+            src={others.src}
+            width={1024}
+          />
         </figure>
       </Show>
       <div class="card-body lg:basis-0">


### PR DESCRIPTION
## Summary

`WorkCard.tsx` declared `width={1656} height={1024}` on its work-card
`<img>` elements, but all four work assets
(`packages/web/src/assets/works/*.webp`) are `1024x1656` portrait
images — independently re-verified via `file` against the WebP
headers, matching the issue's measurement. Since the browser reserves
layout space from `width`/`height` before the image decodes, the
swapped values caused a layout shift on every work card, on every page
load.

## Changes

- Corrected the fallback `<img>` to `width={1024}` / `height={1656}`.
- **Removed the `landscapeSrc` prop and its branch entirely**, rather
  than fixing its dimensions. Rationale: it was dead code — no caller
  ever passed it (`organisms/Works.tsx` passes only `src`, and
  `WorkCard.stories.ts` never sets it either, confirmed via
  repo-wide grep) — so its `Show` branch never executed. Its own
  declared `720x1280` was itself transposed for a landscape variant
  that has no corresponding asset; "fixing" it would mean inventing
  plausible dimensions for something that doesn't exist. Removing it
  collapses the nested `<Show>` split into one unconditional `<img>`,
  matching the existing single-`<img>`-per-`<Show>` pattern already
  used in `atoms/cards/Activity.tsx` and `atoms/cards/Event.tsx`.
- Added a short comment naming the asset set the hardcoded dimensions
  describe (portrait work images, 1024×1656 WebP), per the issue's
  guidance. Dimensions aren't sourced directly from the assets because
  `WorkCard` only receives `src` as an opaque string prop from
  `Works.tsx` — deriving pixel size at this layer would need new build
  tooling or width/height plumbed through the caller, both out of this
  single-file-scoped issue.
- No new test file added: `packages/web/src` has no per-component test
  precedent (its one test file is a placeholder), and web component
  test coverage is separately scoped under #164. This issue's own
  acceptance criteria also restrict changes to `WorkCard.tsx` (plus
  callers/story only if the prop removal touched them, which it
  doesn't here).

Scope: `packages/web/src/components/molecules/WorkCard.tsx` only — no
other files changed.

## Verification

- `pnpm run lint` — passes clean (cspell, eslint, oxlint, prettier,
  stylelint, markdownlint all 0 errors).
- `pnpm run test` — 33/33 assertions pass across 6 suites. One
  unrelated suite (`packages/fetcher/src/detectChange.test.mts`) fails
  to resolve `@kurone-kito/kit.black-lib`'s package entry in this local
  environment; confirmed **pre-existing** by reproducing the identical
  failure on unmodified `origin/main` (`b2a2584`) in the same
  environment. This local shell runs Node v23.6.1, below the repo's
  declared `>=24.2.0` floor, while GitHub Actions CI (which uses the
  correct pinned Node version) passed on that exact commit per PR
  #178's merged checks. Unrelated to this change; not fixed here.

Closes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated work card images to use a consistent portrait layout.
  * Removed landscape image handling for a more uniform visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->