### PR TITLE
fix(web): color japanese public holidays like sundays in the calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prestart": "pnpm run prebuild",
     "start": "pnpm run --parallel -r start",
     "stylelint": "stylelint --aei --cache --cache-location node_modules/.cache/stylelint/ \"./**/*.css\"",
-    "test": "vitest run"
+    "test": "pnpm run -r test"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@holiday-jp/holiday_jp": "^2.5.1",
     "@kurone-kito/kit.black-lib": "workspace:^",
     "googleapis": "^144.0.0"
   },

--- a/packages/fetcher/src/holiday.mts
+++ b/packages/fetcher/src/holiday.mts
@@ -25,8 +25,16 @@ const jstDateFormatter = new Intl.DateTimeFormat('en-US', {
  */
 export const toJstCalendarDate = (epoch: number): Date => {
   const parts = jstDateFormatter.formatToParts(new Date(epoch));
-  const get = (type: 'day' | 'month' | 'year'): number =>
-    Number(parts.find((part) => part.type === type)?.value);
+  const get = (type: 'day' | 'month' | 'year'): number => {
+    const part = parts.find((p) => p.type === type);
+    if (!part) {
+      // Guard against a silent NaN / Invalid Date: if Intl ever omits
+      // a requested part, fail loudly instead of letting holiday
+      // detection degrade to a silent false negative.
+      throw new Error(`Intl.DateTimeFormat did not return a "${type}" part`);
+    }
+    return Number(part.value);
+  };
   return new Date(get('year'), get('month') - 1, get('day'));
 };
 

--- a/packages/fetcher/src/holiday.mts
+++ b/packages/fetcher/src/holiday.mts
@@ -1,0 +1,41 @@
+import holidayJp from '@holiday-jp/holiday_jp';
+
+/** The formatter that extracts the JST calendar date parts from an epoch. */
+const jstDateFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'numeric',
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+});
+
+/**
+ * Convert the epoch to the JST calendar date, expressed as a `Date`
+ * whose **local** year/month/day match the JST calendar date.
+ *
+ * `@holiday-jp/holiday_jp`'s `isHoliday` reads back `Date#getFullYear`
+ * / `getMonth` / `getDate`, which resolve in the host process's local
+ * time zone. Passing the raw epoch straight in would therefore answer
+ * for the wrong calendar date whenever the host does not run in JST
+ * (for example UTC, this repository's `push.yml` default). Deriving
+ * the JST year/month/day first and rebuilding a local `Date` from
+ * those parts keeps the lookup correct no matter what time zone the
+ * process runs under.
+ * @param epoch The epoch time, in milliseconds.
+ * @returns The date whose local calendar date is the JST calendar date.
+ */
+export const toJstCalendarDate = (epoch: number): Date => {
+  const parts = jstDateFormatter.formatToParts(new Date(epoch));
+  const get = (type: 'day' | 'month' | 'year'): number =>
+    Number(parts.find((part) => part.type === type)?.value);
+  return new Date(get('year'), get('month') - 1, get('day'));
+};
+
+/**
+ * Determine whether the epoch falls on a Japanese public holiday, in
+ * JST, regardless of the host process's time zone.
+ * @param epoch The epoch time, in milliseconds.
+ * @returns `true` when the JST calendar date is a Japanese public
+ * holiday.
+ */
+export const isJpHoliday = (epoch: number): boolean =>
+  holidayJp.isHoliday(toJstCalendarDate(epoch));

--- a/packages/fetcher/src/holiday.test.mts
+++ b/packages/fetcher/src/holiday.test.mts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { isJpHoliday, toJstCalendarDate } from './holiday.mjs';
+
+afterEach(() => vi.restoreAllMocks());
 
 describe('toJstCalendarDate', () => {
   it.each([
@@ -10,6 +12,19 @@ describe('toJstCalendarDate', () => {
   ])('epoch %d -> local Date(%d, %d, %d)', (epoch, year, month, day) =>
     expect(toJstCalendarDate(epoch)).toEqual(new Date(year, month, day)),
   );
+
+  it('fails loudly instead of silently coercing a missing part to NaN', () => {
+    // If Intl.DateTimeFormat#formatToParts ever omits a requested part,
+    // the guard should throw rather than let holiday detection degrade
+    // to a silent false negative (Number(undefined) === NaN).
+    vi.spyOn(Intl.DateTimeFormat.prototype, 'formatToParts').mockReturnValue([
+      { type: 'month', value: '1' },
+      { type: 'day', value: '1' },
+    ]);
+    expect(() => toJstCalendarDate(Date.now())).toThrow(
+      /did not return a "year" part/,
+    );
+  });
 });
 
 describe('isJpHoliday', () => {

--- a/packages/fetcher/src/holiday.test.mts
+++ b/packages/fetcher/src/holiday.test.mts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { isJpHoliday, toJstCalendarDate } from './holiday.mjs';
+
+describe('toJstCalendarDate', () => {
+  it.each([
+    // A time that is still 2026-01-01 in JST but already 2025-12-31
+    // in UTC — the exact trap this helper exists to avoid.
+    [Date.parse('2026-01-01T00:30:00+09:00'), 2026, 0, 1],
+    [Date.parse('2026-01-02T12:00:00+09:00'), 2026, 0, 2],
+  ])('epoch %d -> local Date(%d, %d, %d)', (epoch, year, month, day) =>
+    expect(toJstCalendarDate(epoch)).toEqual(new Date(year, month, day)),
+  );
+});
+
+describe('isJpHoliday', () => {
+  it.each([
+    // 元日 (New Year's Day), noon JST -- unambiguous, same calendar
+    // date in both JST and UTC.
+    ['2026-01-01T12:00:00+09:00', true],
+    // The day after New Year's Day is not a holiday.
+    ['2026-01-02T12:00:00+09:00', false],
+    // 元日 2028, observed 00:30 JST -- 2027-12-31T15:30:00Z in UTC, a
+    // Friday and not a holiday. A time-zone-naive lookup (raw epoch
+    // fed straight into `holiday_jp`) would answer `false` here; the
+    // correct JST-aware answer is `true`.
+    ['2028-01-01T00:30:00+09:00', true],
+  ])('%s -> %s', (iso, expected) =>
+    expect(isJpHoliday(Date.parse(iso))).toBe(expected),
+  );
+
+  it('answers the same JST-boundary case regardless of the host time zone', () => {
+    // This assertion is meaningful precisely because `toJstCalendarDate`
+    // derives the JST date via an explicit `timeZone: 'Asia/Tokyo'`
+    // formatter rather than the host's local time zone, so it holds
+    // under `TZ=UTC` (this repository's `push.yml` default) and under
+    // `TZ=Asia/Tokyo` (the production build) alike.
+    const epoch = Date.parse('2027-12-31T15:30:00Z');
+    expect(isJpHoliday(epoch)).toBe(true);
+  });
+});

--- a/packages/fetcher/src/toRow.mts
+++ b/packages/fetcher/src/toRow.mts
@@ -16,9 +16,12 @@ export const toRowMapper: Mapper<EventDetail, EventDetailRow> = (
 ) => {
   const { date: dt, epoch, time, title: children, type } = item;
   const week = formatWeek(epoch);
-  const holiday = isJpHoliday(epoch) ? true : undefined;
   const equalsDate = (e: EventDetail) => e.date === dt;
   const date = index === array.findIndex(equalsDate) ? dt : undefined;
+  // Only the row that renders the date cell (see the same `date` gate
+  // above) needs `holiday`: computing it for every same-day row would
+  // repeat the JST lookup and bloat data.json with an unused field.
+  const holiday = date && isJpHoliday(epoch) ? true : undefined;
   const span = array.filter(equalsDate).length;
   const dateSpan = date && span > 1 ? span : undefined;
   return { children, date, dateSpan, holiday, time, type, week } as const;

--- a/packages/fetcher/src/toRow.mts
+++ b/packages/fetcher/src/toRow.mts
@@ -1,4 +1,5 @@
 import { Mapper, formatWeek } from '@kurone-kito/kit.black-lib';
+import { isJpHoliday } from './holiday.mjs';
 import type { EventDetail, EventDetailRow } from './types.mjs';
 
 /**
@@ -15,9 +16,10 @@ export const toRowMapper: Mapper<EventDetail, EventDetailRow> = (
 ) => {
   const { date: dt, epoch, time, title: children, type } = item;
   const week = formatWeek(epoch);
+  const holiday = isJpHoliday(epoch) ? true : undefined;
   const equalsDate = (e: EventDetail) => e.date === dt;
   const date = index === array.findIndex(equalsDate) ? dt : undefined;
   const span = array.filter(equalsDate).length;
   const dateSpan = date && span > 1 ? span : undefined;
-  return { children, date, dateSpan, time, type, week } as const;
+  return { children, date, dateSpan, holiday, time, type, week } as const;
 };

--- a/packages/fetcher/src/toRow.test.mts
+++ b/packages/fetcher/src/toRow.test.mts
@@ -53,4 +53,15 @@ describe('toRowMapper', () => {
     expect(rowB.dateSpan).toBeUndefined();
     expect(rowA.week).toBe('thu');
   });
+
+  it('omits holiday on a same-day row that does not render the date cell', () => {
+    // Only the first-occurrence row renders <td class="date">, so only
+    // that row needs holiday -- mirrors the existing dateSpan gate.
+    const a = event({ date: '01/01' });
+    const b = event({ date: '01/01' });
+    const rowA = toRowMapper(a, 0, [a, b]);
+    const rowB = toRowMapper(b, 1, [a, b]);
+    expect(rowA.holiday).toBe(true);
+    expect(rowB.holiday).toBeUndefined();
+  });
 });

--- a/packages/fetcher/src/toRow.test.mts
+++ b/packages/fetcher/src/toRow.test.mts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { EventDetail } from './types.mjs';
+import { toRowMapper } from './toRow.mjs';
+
+/**
+ * Build a minimal event fixture.
+ * @param overrides The properties to override.
+ * @returns The event.
+ */
+const event = (overrides: Partial<EventDetail> = {}): EventDetail => ({
+  date: '01/01',
+  epoch: Date.parse('2026-01-01T12:00:00+09:00'),
+  title: 'New Year',
+  type: 'others',
+  ...overrides,
+});
+
+describe('toRowMapper', () => {
+  it('sets holiday: true for a Japanese public holiday date', () => {
+    const row = toRowMapper(event(), 0, [event()]);
+    expect(row.holiday).toBe(true);
+  });
+
+  it('omits holiday for a non-holiday date', () => {
+    const nonHoliday = event({
+      date: '01/02',
+      epoch: Date.parse('2026-01-02T12:00:00+09:00'),
+    });
+    const row = toRowMapper(nonHoliday, 0, [nonHoliday]);
+    expect(row.holiday).toBeUndefined();
+  });
+
+  it('detects a holiday whose JST date crosses the UTC day boundary', () => {
+    // 2028-01-01T00:30 JST (元日) is 2027-12-31T15:30Z in UTC -- a
+    // Friday and not a holiday if the lookup were TZ-naive.
+    const boundary = event({
+      date: '01/01',
+      epoch: Date.parse('2027-12-31T15:30:00Z'),
+    });
+    const row = toRowMapper(boundary, 0, [boundary]);
+    expect(row.holiday).toBe(true);
+    expect(row.week).toBe('sat');
+  });
+
+  it('still computes date, dateSpan, and week as before', () => {
+    const a = event({ date: '01/01' });
+    const b = event({ date: '01/01' });
+    const rowA = toRowMapper(a, 0, [a, b]);
+    const rowB = toRowMapper(b, 1, [a, b]);
+    expect(rowA.date).toBe('01/01');
+    expect(rowA.dateSpan).toBe(2);
+    expect(rowB.date).toBeUndefined();
+    expect(rowB.dateSpan).toBeUndefined();
+    expect(rowA.week).toBe('thu');
+  });
+});

--- a/packages/fetcher/src/types.mts
+++ b/packages/fetcher/src/types.mts
@@ -38,6 +38,14 @@ export interface EventDetailRow extends Pick<EventDetail, 'time' | 'type'> {
    */
   readonly dateSpan?: number | undefined;
 
+  /**
+   * Whether the date is a Japanese public holiday.
+   *
+   * `true` only on a holiday; omitted entirely otherwise, keeping
+   * `data.json` minimal and diff-friendly.
+   */
+  readonly holiday?: true | undefined;
+
   /** The week. */
   readonly week?: Week | undefined;
 }

--- a/packages/web/src/components/atoms/calendar/Row.stories.ts
+++ b/packages/web/src/components/atoms/calendar/Row.stories.ts
@@ -17,6 +17,9 @@ export default {
     week: '',
   },
   argTypes: {
+    holiday: {
+      control: { type: 'boolean' },
+    },
     type: {
       control: { type: 'select' },
       options: ['others', 'release', 'streaming'],

--- a/packages/web/src/components/atoms/calendar/Row.test.tsx
+++ b/packages/web/src/components/atoms/calendar/Row.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Row } from './Row.js';
+
+afterEach(() => cleanup());
+
+/**
+ * Render a {@link Row} and return its date cell.
+ * @param props The properties to pass to {@link Row}.
+ * @returns The date cell element, or `null` when not rendered.
+ */
+const renderDateCell = (
+  props: Parameters<typeof Row>[0],
+): HTMLElement | null => {
+  const { container } = render(() => <Row {...props} />);
+  return container.querySelector('.date');
+};
+
+describe('Row', () => {
+  it('renders the holiday class, not the week class, on a holiday date cell', () => {
+    const cell = renderDateCell({ date: '01/01', holiday: true, week: 'thu' });
+    expect(cell).toHaveClass('holiday');
+    expect(cell).not.toHaveClass('thu');
+  });
+
+  it('renders the holiday class, not sat, on a holiday Saturday', () => {
+    const cell = renderDateCell({ date: '01/01', holiday: true, week: 'sat' });
+    expect(cell).toHaveClass('holiday');
+    expect(cell).not.toHaveClass('sat');
+  });
+
+  it('still renders the sun class for a non-holiday Sunday', () => {
+    const cell = renderDateCell({ date: '01/04', week: 'sun' });
+    expect(cell).toHaveClass('sun');
+    expect(cell).not.toHaveClass('holiday');
+  });
+
+  it('still renders the sat class for a non-holiday Saturday', () => {
+    const cell = renderDateCell({ date: '01/03', week: 'sat' });
+    expect(cell).toHaveClass('sat');
+    expect(cell).not.toHaveClass('holiday');
+  });
+});

--- a/packages/web/src/components/atoms/calendar/Row.test.tsx
+++ b/packages/web/src/components/atoms/calendar/Row.test.tsx
@@ -7,13 +7,16 @@ afterEach(() => cleanup());
 /**
  * Render a {@link Row} and return its date cell.
  * @param props The properties to pass to {@link Row}.
- * @returns The date cell element, or `null` when not rendered.
+ * @returns The date cell element.
  */
-const renderDateCell = (
-  props: Parameters<typeof Row>[0],
-): HTMLElement | null => {
+const renderDateCell = (props: Parameters<typeof Row>[0]): HTMLElement => {
   const { container } = render(() => <Row {...props} />);
-  return container.querySelector('.date');
+  const cell = container.querySelector('.date');
+  // Fail with a clear "no .date cell rendered" error here, rather than
+  // a less-informative matcher error at the call site if the component
+  // ever stops rendering a date cell for the given props.
+  expect(cell).not.toBeNull();
+  return cell as HTMLElement;
 };
 
 describe('Row', () => {

--- a/packages/web/src/components/atoms/calendar/Row.tsx
+++ b/packages/web/src/components/atoms/calendar/Row.tsx
@@ -26,7 +26,12 @@ export const Row: Component<RowProps> = (props) => {
   const concProps = mergeProps(defaultProps, props);
   type CL = ReadonlyRecord<string, boolean>;
   const tc = { [concProps.type]: !!concProps.type } as const satisfies CL;
-  const wc = { [concProps.week]: !!concProps.week } as const satisfies CL;
+  // A holiday always wins the date cell's color, decided here rather
+  // than by CSS cascade order — so a holiday Saturday never also
+  // receives `.sat` styling.
+  const wc = concProps.holiday
+    ? ({ holiday: true } as const satisfies CL)
+    : ({ [concProps.week]: !!concProps.week } as const satisfies CL);
   return (
     <tr>
       <Show when={props.date}>

--- a/packages/web/src/components/atoms/calendar/Table.tsx
+++ b/packages/web/src/components/atoms/calendar/Table.tsx
@@ -32,7 +32,7 @@ export const Table: Component<TableProps> = (props) => (
         <th scope="col">{props.detail}</th>
       </tr>
     </thead>
-    <tbody class="[&_.release]:!bg-secondary/80 [&_.release]:text-secondary-content [&_.streaming]:!bg-accent/80 [&_.streaming]:text-accent-content [&_td]:bg-base-300/80 [&_td]:rounded-badge [&_.date]:text-center [&_.sat]:!bg-blue-500/60 [&_.sun]:!bg-red-500/60 [&_.time]:text-center [&_td]:px-[2cqi] [&_td]:py-[1.8cqi]">
+    <tbody class="[&_.release]:!bg-secondary/80 [&_.release]:text-secondary-content [&_.streaming]:!bg-accent/80 [&_.streaming]:text-accent-content [&_td]:bg-base-300/80 [&_td]:rounded-badge [&_.date]:text-center [&_.holiday]:!bg-red-500/60 [&_.sat]:!bg-blue-500/60 [&_.sun]:!bg-red-500/60 [&_.time]:text-center [&_td]:px-[2cqi] [&_td]:py-[1.8cqi]">
       {props.children}
     </tbody>
   </table>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   packages/fetcher:
     dependencies:
+      '@holiday-jp/holiday_jp':
+        specifier: ^2.5.1
+        version: 2.5.1
       '@kurone-kito/kit.black-lib':
         specifier: workspace:^
         version: link:../lib
@@ -1255,6 +1258,9 @@ packages:
   '@eslint/plugin-kit@0.2.5':
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@holiday-jp/holiday_jp@2.5.1':
+    resolution: {integrity: sha512-KuXfzsp0xlP830WDZRbsHj99wJzamx4fS55usUJFz+oHZmZ4gJfVdyiyv/rIWK+O7RgfHSi5j5Ajy0ZK/Vlnyg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -7758,6 +7764,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.10.0
       levn: 0.4.1
+
+  '@holiday-jp/holiday_jp@2.5.1': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
## Summary

Colors Japanese public holidays like Sundays in the schedule calendar
(color only — no holiday-name text or legend entry, per the operator's
explicit decision recorded on the issue).

- `packages/fetcher`: adds `@holiday-jp/holiday_jp` and a new
  `holiday.mts` helper that determines the JST calendar date from an
  epoch (via `Intl` with `timeZone: 'Asia/Tokyo'`, then a fresh local
  `Date` from those parts) before checking `holiday_jp.isHoliday`,
  since that library reads back the `Date`'s *local* getters and would
  answer incorrectly under a non-JST host process (this repo's
  `push.yml` CI runs UTC). `EventDetailRow` gains an optional
  `holiday?: true` field (omitted, not `false`, on non-holidays, to
  keep `data.json` minimal), set by `toRowMapper`.
- `packages/web`: `Row.tsx` emits a `holiday` class on the date cell
  *instead of* the week class when set — decided in class-emission
  logic, not CSS cascade order, so a holiday Saturday cannot also
  receive `.sat` styling. `Table.tsx` styles `.holiday` the same as
  `.sun`. `Row.stories.ts` gets a `holiday` toggle control.
- Tests: `holiday.test.mts` and `toRow.test.mts` cover the JST-vs-UTC
  boundary case (an epoch that's a holiday Saturday in JST but the
  previous day/weekday in UTC), and `Row.test.tsx` covers the
  class-emission behavior with `@solidjs/testing-library`.

`detectChange.mts` (the #130 display projection) needs no change — it
serializes `toRowMapper`'s output directly, so `holiday` flows through
automatically.

### Included infra fix (own commit)

Root's `"test"` script called `vitest run` directly, which orchestrates
`vitest.workspace.json` using root's own stale `vitest@2.1.9`
devDependency — independent of each package's own pin
(`packages/web` pins `^3.2.6`). This repo's first real Solid-rendering
test (`Row.test.tsx`) exposed that the version-2 workspace orchestrator
resolves `solid-js` to its **server** build instead of the DOM build,
crashing with "Client-only API called on the server side" — even though
the identical test passes when vitest runs from inside `packages/web`
directly. Changed `"test": "vitest run"` to `"test": "pnpm run -r
test"`, matching the existing `"build": "pnpm run -r build"`
convention. Verified green locally under both `TZ=UTC` and
`TZ=Asia/Tokyo`. This is a latent, pre-existing gap (no prior web test
exercised real component rendering) required to land this issue's
component tests, and would have hit #164 identically. Left the now-
unused root `vitest` devDependency and `vitest.workspace.json` in place
(still usable for IDE test-runner integration) — removing them is a
smaller, separate cleanup out of this issue's scope.

### Verification

- `pnpm run lint && pnpm run test` green, both `TZ=UTC` and
  `TZ=Asia/Tokyo`.
- Full local production build succeeds (real `.env` credentials). This
  week's real calendar data has no holidays, so I additionally
  substituted a fixture `data.json` with a holiday Saturday and
  rebuilt just `vinxi build`: the prerendered HTML emitted
  `class="date holiday"` (not `sat`), and the compiled CSS carried
  `.holiday{background-color:#ef444499!important}` — confirming
  holiday-wins-over-Saturday end to end.
- Storybook's dev server is broken in this environment (pre-existing,
  unrelated); the fixture-build check above substitutes for a manual
  Storybook look at the new `holiday` control.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes under `TZ=UTC`
- [x] `pnpm run test` passes under `TZ=Asia/Tokyo`
- [x] Full production build succeeds
- [x] Fixture-data build confirms `.holiday` class + red styling wins
      over `.sat` on a holiday Saturday
- [ ] CI (build/lint/test on `issue/*`) green

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
