### PR TITLE
fix(a11y): make the activities carousel keyboard-operable

### DIFF
--- a/packages/web/src/components/atoms/CarouselItem.tsx
+++ b/packages/web/src/components/atoms/CarouselItem.tsx
@@ -17,7 +17,7 @@ export interface CarouselItemProps
 export const CarouselItem: Component<CarouselItemProps> = (props) => {
   const [local, rest] = splitProps(props, ['class']);
   return (
-    <div class={twMerge('aspect-video', local.class)}>
+    <div class={twMerge('aspect-video', local.class)} role="listitem">
       <img
         class="rounded-box saturate-100 transition-[filter] duration-500 hover:saturate-100 lg:saturate-[.33]"
         decoding="async"

--- a/packages/web/src/components/molecules/Carousel.stories.ts
+++ b/packages/web/src/components/molecules/Carousel.stories.ts
@@ -17,6 +17,7 @@ export default {
   args: {
     class: '',
     items: Array.from({ length: 10 }, (_, i) => [src, `${i}`] as const),
+    label: 'Example carousel',
   },
   component: Carousel,
 } satisfies Meta<Target>;

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -14,8 +14,13 @@ export interface SceneCarouselProps {
   /** The items. */
   readonly items: readonly Item[];
 
-  /** The accessible name that describes what the carousel contains. */
-  readonly label?: string | undefined;
+  /**
+   * The accessible name that describes what the carousel contains.
+   * Required because the container is keyboard-focusable
+   * (`tabindex="0"`); an unnamed focusable region is an accessibility
+   * regression.
+   */
+  readonly label: string;
 }
 
 /**

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -13,6 +13,9 @@ export interface SceneCarouselProps {
 
   /** The items. */
   readonly items: readonly Item[];
+
+  /** The accessible name that describes what the carousel contains. */
+  readonly label?: string | undefined;
 }
 
 /**
@@ -23,10 +26,13 @@ export interface SceneCarouselProps {
 export const Carousel: Component<SceneCarouselProps> = (props) => (
   <div class="bg-base-100 px-0.5 py-12">
     <figure
+      aria-label={props.label}
       class={twMerge(
-        'carousel carousel-center aspect-[19/9] h-auto w-full space-x-4 px-4 md:aspect-[27/9] xl:aspect-[28/9] 2xl:aspect-[43/9]',
+        'carousel carousel-center focus-visible:outline-primary aspect-[19/9] h-auto w-full space-x-4 px-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:aspect-[27/9] xl:aspect-[28/9] 2xl:aspect-[43/9]',
         props.class,
       )}
+      role="list"
+      tabindex="0"
     >
       <Index each={props.items}>
         {(index) => (

--- a/packages/web/src/components/organisms/ActivitiesCarousel.tsx
+++ b/packages/web/src/components/organisms/ActivitiesCarousel.tsx
@@ -14,6 +14,7 @@ import sceneSleepyMeetup from '../../assets/activities/sleepy-meetup.webp';
 import uiUxMeetup from '../../assets/activities/ui-ux-meetup.webp';
 import type { Item } from '../molecules/Carousel.js';
 import { Carousel } from '../molecules/Carousel.js';
+import { useTranslator } from '../../modules/createI18N.js';
 
 /** The activities. */
 const activities = [
@@ -36,6 +37,13 @@ const activities = [
  * The activities carousel.
  * @returns The component.
  */
-export const ActivitiesCarousel: Component = () => (
-  <Carousel class="m-safe" items={activities} />
-);
+export const ActivitiesCarousel: Component = () => {
+  const t = useTranslator();
+  return (
+    <Carousel
+      class="m-safe"
+      items={activities}
+      label={t('activitiesCarousel')}
+    />
+  );
+};

--- a/packages/web/src/i18n/en.ts
+++ b/packages/web/src/i18n/en.ts
@@ -2,6 +2,7 @@ import type { Resources } from './types.js';
 
 const resources: Resources = {
   activities: 'Kuroné Kito’s main activities',
+  activitiesCarousel: 'Kuroné Kito’s activity photos',
   avatarKito: 'Kuroné Kito’s standard avatar',
   avatarMomoneko: '“Momoneko-chan” modified avatar for VR',
   author: 'Kuroné Kito',

--- a/packages/web/src/i18n/ja.ts
+++ b/packages/web/src/i18n/ja.ts
@@ -2,6 +2,7 @@ import type { Resources } from './types.js';
 
 const resources: Resources = {
   activities: '黒音キトの主な活動内容',
+  activitiesCarousel: '黒音キトの活動写真',
   avatarKito: '黒音キトの標準アバター',
   avatarMomoneko: 'VR 用アバター“ももねこちゃん”改変',
   author: '黒音キト',

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -6,6 +6,7 @@ export type Resources = ReadonlyRecord<ResourcesKeys, string>;
 /** Type definition for the resources keys. */
 export type ResourcesKeys =
   | 'activities'
+  | 'activitiesCarousel'
   | 'author'
   | 'avatarKito'
   | 'avatarMomoneko'


### PR DESCRIPTION
## Summary

The activities carousel (`packages/web/src/components/molecules/Carousel.tsx`)
was operable by mouse drag and touch swipe only. This PR makes it
keyboard-operable and gives it correct accessibility semantics:

- The scroll container (`<figure>`) is now focusable (`tabindex="0"`) so
  browsers grant native left/right arrow-key scrolling once focused.
- The container gets an accessible name via `aria-label`, sourced from a
  new `activitiesCarousel` i18n key in both `en` and `ja` dictionaries
  (`packages/web/src/i18n/{types,en,ja}.ts`), following the same
  `useTranslator()` pattern already used elsewhere (e.g. `ToggleTheme`).
- The container and each `CarouselItem` now carry `role="list"` /
  `role="listitem"` so a screen reader announces each slide's position
  within the set (e.g. "1 of 13"), without disturbing the daisyUI
  `carousel` / `carousel-item` class contract.
- A `focus-visible` outline (`outline` + `outline-2` +
  `outline-offset-2` + `outline-primary`) makes the new keyboard focus
  stop visible without affecting mouse/touch interaction.
- No JavaScript carousel library or previous/next buttons were added;
  the fix relies on native browser scroll-on-focus behavior, per the
  issue's explicit non-goals.

## Overlap with #155

Sibling issue #155 (route hardcoded English accessibility labels through
i18n) is still open. This PR adds its own new i18n key
(`activitiesCarousel`) rather than depending on #155's key set, so there
is no key collision either way #155 lands.

## Test plan

- [x] `pnpm run lint` passes (cspell, eslint, markdownlint, oxlint,
      prettier, stylelint)
- [x] `pnpm run test` passes (53 tests across `lib`, `fetcher`, `web`)
- [x] `pnpm run build` succeeds; verified the prerendered `/`, `/en/`,
      `/ja/` HTML contains the correctly localized `aria-label`,
      `role="list"`, `role="listitem"` (×13), and `tabindex="0"`
      attributes on the carousel
- [x] Visual layout, aspect ratios, and drag/swipe behavior are
      unchanged (class-list changes are additive only)
- [x] No new runtime dependency (`package.json` untouched)

Closes #157
