### PR TITLE
feat(web): upload production sourcemaps to Sentry from the deploy build

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -101,6 +101,9 @@ jobs:
           ID_RELEASE: ${{ secrets.ID_RELEASE }}
           ID_STREAMING: ${{ secrets.ID_STREAMING }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           TZ: Asia/Tokyo
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
         name: Run the build

--- a/packages/web/app.config.mts
+++ b/packages/web/app.config.mts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { parse } from 'node:path';
 import { defineConfig } from '@solidjs/start/config';
-import { createSentryVitePlugins } from './sentryVitePlugin.mjs';
+import { applyClientSentryConfig } from './sentryVitePlugin.mjs';
 import vite from './vite.config.mjs';
 
 /**
@@ -39,16 +39,9 @@ export default defineConfig({
   // The client router is the only one shipped to production behind
   // `netlify-static` (the `server` / `server-function` routers only run
   // at prerender time), so the Sentry sourcemap-upload plugin and the
-  // sourcemap generation it needs are scoped to that router alone.
-  vite: ({ router }) =>
-    router === 'client'
-      ? {
-          ...vite,
-          build: { sourcemap: Boolean(process.env['SENTRY_AUTH_TOKEN']) },
-          plugins: [
-            ...(vite.plugins ?? []),
-            ...createSentryVitePlugins(process.env),
-          ],
-        }
-      : vite,
+  // sourcemap generation it needs are scoped to that router alone. See
+  // `applyClientSentryConfig`'s own unit tests for coverage of this
+  // branch, since this file's `defineConfig` call has side effects that
+  // make it unsuitable to import directly from a test.
+  vite: ({ router }) => applyClientSentryConfig(router, vite, process.env),
 });

--- a/packages/web/app.config.mts
+++ b/packages/web/app.config.mts
@@ -1,6 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { parse } from 'node:path';
 import { defineConfig } from '@solidjs/start/config';
+import { createSentryVitePlugins } from './sentryVitePlugin.mts';
 import vite from './vite.config.mjs';
 
 /**
@@ -35,5 +36,19 @@ export default defineConfig({
     prerender: { autoSubfolderIndex: false, routes: [] },
     preset: 'netlify-static',
   },
-  vite,
+  // The client router is the only one shipped to production behind
+  // `netlify-static` (the `server` / `server-function` routers only run
+  // at prerender time), so the Sentry sourcemap-upload plugin and the
+  // sourcemap generation it needs are scoped to that router alone.
+  vite: ({ router }) =>
+    router === 'client'
+      ? {
+          ...vite,
+          build: { sourcemap: Boolean(process.env['SENTRY_AUTH_TOKEN']) },
+          plugins: [
+            ...(vite.plugins ?? []),
+            ...createSentryVitePlugins(process.env),
+          ],
+        }
+      : vite,
 });

--- a/packages/web/app.config.mts
+++ b/packages/web/app.config.mts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { parse } from 'node:path';
 import { defineConfig } from '@solidjs/start/config';
-import { createSentryVitePlugins } from './sentryVitePlugin.mts';
+import { createSentryVitePlugins } from './sentryVitePlugin.mjs';
 import vite from './vite.config.mjs';
 
 /**

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@kurone-kito/kit.black-fetcher": "workspace:^",
     "@kurone-kito/typescript-config": "^0.17.2",
+    "@sentry/vite-plugin": "^5.4.0",
     "@solidjs/testing-library": "^0.8.10",
     "@storybook/addon-essentials": "^8.5.3",
     "@storybook/addon-interactions": "^8.5.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,7 @@
     "prebuild:yaml": "js-yaml src/constants.yaml > src/constants.json",
     "build": "vinxi build",
     "build:storybook": "storybook build",
-    "postbuild": "cp src/data.json dist/data.json",
+    "postbuild": "cp src/data.json dist/data.json && rimraf -g \"dist/**/*.map\"",
     "clean": "rimraf -g \"*.tgz\" \"*.tsbuildinfo\" .output .vinxi dist node_modules/.cache \"src/*.json\" storybook-static",
     "serve": "serve dist",
     "prestart": "pnpm run prebuild",

--- a/packages/web/sentryVitePlugin.mts
+++ b/packages/web/sentryVitePlugin.mts
@@ -1,0 +1,55 @@
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+
+/** The subset of `process.env` the Sentry sourcemap upload reads. */
+export interface SentryVitePluginEnv {
+  /**
+   * The Sentry auth token. Skips the plugin entirely when empty or
+   * undefined.
+   */
+  readonly SENTRY_AUTH_TOKEN?: string;
+  /** The Sentry organization slug. */
+  readonly SENTRY_ORG?: string;
+  /** The Sentry project slug. */
+  readonly SENTRY_PROJECT?: string;
+  /**
+   * The commit SHA to key the Sentry release to, so scheduled rebuilds of
+   * an unchanged commit group under the same release instead of piling up
+   * new ones. Falls back to the plugin's own git-HEAD auto-detection when
+   * absent (e.g. local builds).
+   */
+  readonly GITHUB_SHA?: string;
+}
+
+/**
+ * Builds the Vite plugin list that uploads production sourcemaps to
+ * Sentry for the client build.
+ *
+ * No-ops (returns an empty array — no plugin registered at all) when
+ * `SENTRY_AUTH_TOKEN` is empty or undefined, so builds without the token —
+ * local dev, CI on pull requests, and any environment lacking the secret —
+ * perform no upload attempt, no warning, and no build failure.
+ * @param env The environment variables to read the upload configuration
+ * from, typically `process.env`.
+ * @returns The Vite plugins to add; empty when the token is absent.
+ */
+export const createSentryVitePlugins = ({
+  SENTRY_AUTH_TOKEN: authToken,
+  SENTRY_ORG: org,
+  SENTRY_PROJECT: project,
+  GITHUB_SHA: release,
+}: SentryVitePluginEnv) =>
+  authToken
+    ? sentryVitePlugin({
+        authToken,
+        org,
+        project,
+        release: release ? { name: release } : undefined,
+        sourcemaps: {
+          // The build never publishes sourcemaps to Netlify: delete every
+          // map this build produced, in both the vinxi per-router staging
+          // directories and (defensively) the final `dist/` output, once
+          // the upload above has completed.
+          filesToDeleteAfterUpload: ['.vinxi/**/*.map', 'dist/**/*.map'],
+        },
+      })
+    : [];

--- a/packages/web/sentryVitePlugin.mts
+++ b/packages/web/sentryVitePlugin.mts
@@ -1,5 +1,8 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
-import type { Plugin } from 'vite';
+import type { Plugin, UserConfig } from 'vite';
+
+/** The SolidStart per-router `vite` config callback's `router` argument. */
+export type SolidStartRouter = 'client' | 'server' | 'server-function';
 
 /** The subset of `process.env` the Sentry sourcemap upload reads. */
 export interface SentryVitePluginEnv {
@@ -54,3 +57,32 @@ export const createSentryVitePlugins = ({
         },
       })
     : [];
+
+/**
+ * Applies the Sentry sourcemap-upload plugin and the sourcemap generation
+ * it needs to a base Vite config, scoped to the `client` router only.
+ *
+ * Under the `netlify-static` preset, the `server` / `server-function`
+ * routers only run at prerender time and never ship to production, so
+ * registering the upload plugin there would triple the upload/release
+ * work for output nothing in production ever executes. Routers other
+ * than `client` receive the base config completely unchanged.
+ * @param router The SolidStart router this Vite config is being built
+ * for.
+ * @param baseVite The base Vite config shared across all routers.
+ * @param env The environment variables to read the upload configuration
+ * from, typically `process.env`.
+ * @returns The per-router Vite config.
+ */
+export const applyClientSentryConfig = (
+  router: SolidStartRouter,
+  baseVite: UserConfig,
+  env: SentryVitePluginEnv,
+): UserConfig =>
+  router === 'client'
+    ? {
+        ...baseVite,
+        build: { sourcemap: Boolean(env.SENTRY_AUTH_TOKEN) },
+        plugins: [...(baseVite.plugins ?? []), ...createSentryVitePlugins(env)],
+      }
+    : baseVite;

--- a/packages/web/sentryVitePlugin.mts
+++ b/packages/web/sentryVitePlugin.mts
@@ -1,4 +1,5 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
+import type { Plugin } from 'vite';
 
 /** The subset of `process.env` the Sentry sourcemap upload reads. */
 export interface SentryVitePluginEnv {
@@ -6,18 +7,18 @@ export interface SentryVitePluginEnv {
    * The Sentry auth token. Skips the plugin entirely when empty or
    * undefined.
    */
-  readonly SENTRY_AUTH_TOKEN?: string;
+  readonly SENTRY_AUTH_TOKEN?: string | undefined;
   /** The Sentry organization slug. */
-  readonly SENTRY_ORG?: string;
+  readonly SENTRY_ORG?: string | undefined;
   /** The Sentry project slug. */
-  readonly SENTRY_PROJECT?: string;
+  readonly SENTRY_PROJECT?: string | undefined;
   /**
    * The commit SHA to key the Sentry release to, so scheduled rebuilds of
    * an unchanged commit group under the same release instead of piling up
    * new ones. Falls back to the plugin's own git-HEAD auto-detection when
    * absent (e.g. local builds).
    */
-  readonly GITHUB_SHA?: string;
+  readonly GITHUB_SHA?: string | undefined;
 }
 
 /**
@@ -37,13 +38,13 @@ export const createSentryVitePlugins = ({
   SENTRY_ORG: org,
   SENTRY_PROJECT: project,
   GITHUB_SHA: release,
-}: SentryVitePluginEnv) =>
+}: SentryVitePluginEnv): Plugin[] =>
   authToken
     ? sentryVitePlugin({
         authToken,
-        org,
-        project,
-        release: release ? { name: release } : undefined,
+        ...(org ? { org } : {}),
+        ...(project ? { project } : {}),
+        ...(release ? { release: { name: release } } : {}),
         sourcemaps: {
           // The build never publishes sourcemaps to Netlify: delete every
           // map this build produced, in both the vinxi per-router staging

--- a/packages/web/sentryVitePlugin.test.mts
+++ b/packages/web/sentryVitePlugin.test.mts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSentryVitePlugins } from './sentryVitePlugin.mts';
+
+const { sentryVitePluginMock } = vi.hoisted(() => ({
+  sentryVitePluginMock: vi.fn(() => [{ enforce: 'pre', name: 'sentry-vite' }]),
+}));
+
+vi.mock('@sentry/vite-plugin', () => ({
+  sentryVitePlugin: sentryVitePluginMock,
+}));
+
+beforeEach(() => {
+  sentryVitePluginMock.mockClear();
+});
+
+describe('createSentryVitePlugins', () => {
+  it('returns no plugins and does not call the upload plugin when the token is undefined', () => {
+    const result = createSentryVitePlugins({ SENTRY_AUTH_TOKEN: undefined });
+    expect(result).toEqual([]);
+    expect(sentryVitePluginMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no plugins and does not call the upload plugin when the token is empty', () => {
+    const result = createSentryVitePlugins({ SENTRY_AUTH_TOKEN: '' });
+    expect(result).toEqual([]);
+    expect(sentryVitePluginMock).not.toHaveBeenCalled();
+  });
+
+  it('activates the upload plugin with the expected options when the token is set', () => {
+    const result = createSentryVitePlugins({
+      GITHUB_SHA: 'abc123',
+      SENTRY_AUTH_TOKEN: 'token',
+      SENTRY_ORG: 'kurone-kito',
+      SENTRY_PROJECT: 'kit-black',
+    });
+    expect(sentryVitePluginMock).toHaveBeenCalledTimes(1);
+    expect(sentryVitePluginMock).toHaveBeenCalledWith({
+      authToken: 'token',
+      org: 'kurone-kito',
+      project: 'kit-black',
+      release: { name: 'abc123' },
+      sourcemaps: {
+        filesToDeleteAfterUpload: ['.vinxi/**/*.map', 'dist/**/*.map'],
+      },
+    });
+    expect(result).toEqual([{ enforce: 'pre', name: 'sentry-vite' }]);
+  });
+
+  it('omits the release name and falls back to git auto-detection when GITHUB_SHA is absent', () => {
+    createSentryVitePlugins({ SENTRY_AUTH_TOKEN: 'token' });
+    expect(sentryVitePluginMock).toHaveBeenCalledWith(
+      expect.objectContaining({ release: undefined }),
+    );
+  });
+});

--- a/packages/web/sentryVitePlugin.test.mts
+++ b/packages/web/sentryVitePlugin.test.mts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createSentryVitePlugins } from './sentryVitePlugin.mjs';
+import {
+  applyClientSentryConfig,
+  createSentryVitePlugins,
+} from './sentryVitePlugin.mjs';
 
 const { sentryVitePluginMock } = vi.hoisted(() => ({
   sentryVitePluginMock: vi.fn(() => [{ enforce: 'pre', name: 'sentry-vite' }]),
@@ -53,6 +56,52 @@ describe('createSentryVitePlugins', () => {
       sourcemaps: {
         filesToDeleteAfterUpload: ['.vinxi/**/*.map', 'dist/**/*.map'],
       },
+    });
+  });
+});
+
+describe('applyClientSentryConfig', () => {
+  const baseVite = { plugins: [{ name: 'markdown-it' }] };
+
+  it('leaves the server router config completely unchanged', () => {
+    const result = applyClientSentryConfig('server', baseVite, {
+      SENTRY_AUTH_TOKEN: 'token',
+    });
+    expect(result).toBe(baseVite);
+    expect(sentryVitePluginMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves the server-function router config completely unchanged', () => {
+    const result = applyClientSentryConfig('server-function', baseVite, {
+      SENTRY_AUTH_TOKEN: 'token',
+    });
+    expect(result).toBe(baseVite);
+    expect(sentryVitePluginMock).not.toHaveBeenCalled();
+  });
+
+  it('disables sourcemap generation and adds no plugin for the client router when the token is absent', () => {
+    const result = applyClientSentryConfig('client', baseVite, {
+      SENTRY_AUTH_TOKEN: undefined,
+    });
+    expect(result).toEqual({
+      ...baseVite,
+      build: { sourcemap: false },
+      plugins: [{ name: 'markdown-it' }],
+    });
+    expect(sentryVitePluginMock).not.toHaveBeenCalled();
+  });
+
+  it('enables sourcemap generation and appends the upload plugin for the client router when the token is set', () => {
+    const result = applyClientSentryConfig('client', baseVite, {
+      SENTRY_AUTH_TOKEN: 'token',
+    });
+    expect(result).toEqual({
+      ...baseVite,
+      build: { sourcemap: true },
+      plugins: [
+        { name: 'markdown-it' },
+        { enforce: 'pre', name: 'sentry-vite' },
+      ],
     });
   });
 });

--- a/packages/web/sentryVitePlugin.test.mts
+++ b/packages/web/sentryVitePlugin.test.mts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createSentryVitePlugins } from './sentryVitePlugin.mts';
+import { createSentryVitePlugins } from './sentryVitePlugin.mjs';
 
 const { sentryVitePluginMock } = vi.hoisted(() => ({
   sentryVitePluginMock: vi.fn(() => [{ enforce: 'pre', name: 'sentry-vite' }]),
@@ -46,10 +46,13 @@ describe('createSentryVitePlugins', () => {
     expect(result).toEqual([{ enforce: 'pre', name: 'sentry-vite' }]);
   });
 
-  it('omits the release name and falls back to git auto-detection when GITHUB_SHA is absent', () => {
+  it('omits the release, org, and project options and falls back to the plugin defaults when only the token is set', () => {
     createSentryVitePlugins({ SENTRY_AUTH_TOKEN: 'token' });
-    expect(sentryVitePluginMock).toHaveBeenCalledWith(
-      expect.objectContaining({ release: undefined }),
-    );
+    expect(sentryVitePluginMock).toHaveBeenCalledWith({
+      authToken: 'token',
+      sourcemaps: {
+        filesToDeleteAfterUpload: ['.vinxi/**/*.map', 'dist/**/*.map'],
+      },
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@kurone-kito/typescript-config':
         specifier: ^0.17.2
         version: 0.17.2(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(typescript-eslint-language-service@5.0.5(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(typescript@5.7.3)
+      '@sentry/vite-plugin':
+        specifier: ^5.4.0
+        version: 5.4.0(rollup@4.34.1)
       '@solidjs/testing-library':
         specifier: ^0.8.10
         version: 0.8.10(@solidjs/router@0.15.3(solid-js@1.9.4))(solid-js@1.9.4)
@@ -8039,7 +8042,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -8103,7 +8106,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8131,7 +8134,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -8497,7 +8500,7 @@ snapshots:
       estree-walker: 2.0.2
       fdir: 6.4.3(picomatch@4.0.2)
       is-reference: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       picomatch: 4.0.2
     optionalDependencies:
       rollup: 4.34.1
@@ -8506,7 +8509,7 @@ snapshots:
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.1)
       estree-walker: 2.0.2
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.34.1
 
@@ -8529,7 +8532,7 @@ snapshots:
   '@rollup/plugin-replace@6.0.2(rollup@4.34.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.1)
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.34.1
 
@@ -8630,7 +8633,7 @@ snapshots:
       dotenv: 17.4.2
       find-up: 5.0.0
       glob: 13.0.6
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.34.1
     transitivePeerDependencies:
@@ -12664,7 +12667,7 @@ snapshots:
 
   minizlib@3.0.1:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
       rimraf: 5.0.10
 
   mkdirp@1.0.4: {}
@@ -14146,7 +14149,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.0.1
       mkdirp: 3.0.1
       yallist: 5.0.0
@@ -14357,7 +14360,7 @@ snapshots:
       estree-walker: 3.0.3
       fast-glob: 3.3.3
       local-pkg: 1.0.0
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       mlly: 1.7.4
       pathe: 2.0.2
       picomatch: 4.0.2
@@ -14442,7 +14445,7 @@ snapshots:
   unwasm@0.3.9:
     dependencies:
       knitwork: 1.2.0
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       mlly: 1.7.4
       pathe: 1.1.2
       pkg-types: 1.3.1


### PR DESCRIPTION
## Summary

Adds build-time, token-gated Sentry sourcemap upload for the production
client build (`packages/web`), so production stack traces are readable
despite minification, and the same commit's scheduled rebuilds group
under one Sentry release.

- New `packages/web/sentryVitePlugin.mts` — a pure `createSentryVitePlugins(env)`
  helper wrapping `sentryVitePlugin` from `@sentry/vite-plugin` (the
  underlying plugin, since `@sentry/solidstart`'s `exports` field has no
  `withSentry`/`sourceMapsUploadOptions` helper at the installed version).
  Returns `[]` — no plugin registered at all — when `SENTRY_AUTH_TOKEN` is
  empty or undefined, so builds without the token (local dev, PR CI, any
  environment lacking the secret) are byte-for-byte unchanged: no
  sourcemap generation, no upload attempt, no warning, no failure.
- `packages/web/app.config.mts` now uses SolidStart's per-router function
  form for the `vite` option (`({ router }) => ...`) instead of a plain
  object, so the Sentry plugin and `build.sourcemap: true` apply **only**
  to the `client` router. Under the `netlify-static` preset the
  `server`/`server-function` routers are prerender-time-only and never
  ship to production, so scoping avoids tripling upload/build cost and
  duplicate release-finalize calls across all three vinxi router builds.
- The release is keyed to `GITHUB_SHA` when present, falling back to the
  plugin's own git-HEAD auto-detection for local/manual builds.
- `sourcemaps.filesToDeleteAfterUpload` targets both vinxi's per-router
  staging directories (`.vinxi/**/*.map`) and the final `dist/` output
  (`dist/**/*.map`) defensively, so sourcemaps are never shipped to
  Netlify.
- `.github/workflows/push-main.yml` passes `SENTRY_AUTH_TOKEN`,
  `SENTRY_ORG`, and `SENTRY_PROJECT` to the `deploy` job's build step
  (the `detect-changes` job doesn't build the web app, so it doesn't
  need them).
- `@sentry/vite-plugin` added as an explicit `packages/web` devDependency
  — it was previously only reachable as an unlisted nested transitive
  dependency of `@sentry/solidstart`; pnpm's strict `node_modules` did
  not symlink it into `packages/web/node_modules`.

## Known limitation

The authenticated upload path itself (and therefore the
`filesToDeleteAfterUpload` glob's real effectiveness) cannot be exercised
in this environment — there are no real Sentry credentials, and that
option only runs after a *successful* upload. Per the parent roadmap
(#136)'s own success criteria, full live activation is an explicitly
deferred **human-verified check**, after #137 (Sentry project creation)
closes and a real production deploy runs. This PR verifies everything it
can locally: the token-less no-op path (confirmed via a real local
`pnpm run build` — unchanged `dist/` layout, zero `.map` files, identical
7.4M output size to the pre-change baseline), and the activation-gating
logic via a mocked unit test (`sentryVitePlugin.test.mts`).

## Test plan

- [x] `pnpm run build` locally without `SENTRY_AUTH_TOKEN` — unchanged
      `dist/` layout and size, zero `.map` files.
- [x] `pnpm exec tsc --noEmit` clean (this repo has no wired typecheck
      script, so this was run manually — surfaced and fixed real
      `exactOptionalPropertyTypes` issues during self-review).
- [x] `pnpm run lint && pnpm run test` pass.
- [ ] Live Sentry event/sourcemap verification — deferred to the
      roadmap's human-verified activation check after #137 closes.

Closes #139
