### PR TITLE
fix(lib): make the schedule window time-zone independent

### DIFF
--- a/packages/lib/src/datetime.mts
+++ b/packages/lib/src/datetime.mts
@@ -9,25 +9,81 @@ export type Week = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
 /** The length of the week dates. */
 export const WEEKDATES = 7;
 
+/**
+ * The single time zone this module's scheduling logic is anchored to.
+ * Every formatter and every date computation below shares this constant
+ * so the zone is never duplicated as a second, driftable literal.
+ */
+export const TIMEZONE = 'Asia/Tokyo';
+
 /** The date formatter. */
 const dateFormatter = new Intl.DateTimeFormat('en-ZA', {
   month: 'numeric',
   day: 'numeric',
-  timeZone: 'Asia/Tokyo',
+  timeZone: TIMEZONE,
 });
 
 /** The time formatter. */
 const timeFormatter = new Intl.DateTimeFormat('en-ZA', {
   minute: 'numeric',
   hour: 'numeric',
-  timeZone: 'Asia/Tokyo',
+  timeZone: TIMEZONE,
 });
 
 /** The week formatter. */
 const weekFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
-  timeZone: 'Asia/Tokyo',
+  timeZone: TIMEZONE,
 });
+
+/**
+ * The calendar-day-key formatter: renders any instant as its `TIMEZONE`
+ * calendar date in `YYYY-MM-DD` form (the `en-CA` locale orders its
+ * numeric date fields that way), independent of the host process's own
+ * time zone.
+ */
+const dayKeyFormatter = new Intl.DateTimeFormat('en-CA', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  timeZone: TIMEZONE,
+});
+
+/**
+ * The UTC-offset formatter: renders `TIMEZONE`'s numeric UTC offset (for
+ * example `+09:00`) for a given instant, so the offset is always derived
+ * from `TIMEZONE` rather than hard-coded a second time.
+ */
+const offsetFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: TIMEZONE,
+  timeZoneName: 'longOffset',
+});
+
+/**
+ * Get the calendar-day key of the date, expressed in `TIMEZONE`.
+ * @param date The date to key.
+ * @returns The `YYYY-MM-DD` calendar day, in `TIMEZONE`.
+ */
+const dayKeyOf = (date: Date): string => dayKeyFormatter.format(date);
+
+/**
+ * Get the numeric UTC offset of `TIMEZONE` at the given instant (for
+ * example `+09:00`).
+ * @param date The instant to resolve the offset for.
+ * @returns The numeric UTC offset, in `±HH:MM` form.
+ */
+const offsetOf = (date: Date): string => {
+  const part = offsetFormatter
+    .formatToParts(date)
+    .find((p) => p.type === 'timeZoneName');
+  if (!part) {
+    // Guard against a silent NaN / Invalid Date: if Intl ever omits the
+    // requested part, fail loudly instead of returning a mis-anchored
+    // instant.
+    throw new Error('Intl.DateTimeFormat did not return a UTC offset');
+  }
+  return part.value.replace('GMT', '');
+};
 
 /**
  * Format the date.
@@ -65,31 +121,38 @@ export const formatTimeRange = (
 ): string => {
   const dateFrom = new Date(from);
   const dateTo = new Date(to);
-  const overDate = dateFrom.getDate() !== dateTo.getDate();
+  const overDate = dayKeyOf(dateFrom) !== dayKeyOf(dateTo);
   return `${formatTime(from)}〜${overDate ? '翌' : ''}${formatTime(to)}`;
 };
 
 /**
  * Get the date obtained by adding the specified date.
+ *
+ * `TIMEZONE` observes no daylight-saving transitions, so one calendar
+ * day is always exactly 86,400,000 ms; adding whole days as milliseconds
+ * is therefore equivalent to `TIMEZONE` calendar-day arithmetic for any
+ * input instant, regardless of the host process's own time zone.
  * @param date The date to add.
  * @param days The days to add.
  * @returns The date obtained by adding the specified date.
  */
-export const plusDate = (date: DateParsable, days: number): Date => {
-  const clone = new Date(date);
-  clone.setDate(clone.getDate() + days);
-  return clone;
-};
+export const plusDate = (date: DateParsable, days: number): Date =>
+  new Date(new Date(date).getTime() + days * 86_400_000);
 
 /**
- * Truncate the date.
+ * Truncate the date to `TIMEZONE` midnight of its `TIMEZONE` calendar
+ * day, regardless of the host process's own time zone.
  * @param date The date to truncate.
  * @returns The truncated date.
  */
 export const truncateTime = (date: DateParsable): Date => {
-  const clone = new Date(date);
-  clone.setHours(0, 0, 0, 0);
-  return clone;
+  const instant = new Date(date);
+  const dayKey = dayKeyOf(instant);
+  const offset = offsetOf(instant);
+  // `dayKey` is `YYYY-MM-DD` and `offset` is `±HH:MM`, together an
+  // ISO-8601 date-time string with an explicit offset, which `Date`
+  // parses identically on every host time zone.
+  return new Date(`${dayKey}T00:00:00${offset}`);
 };
 
 /**

--- a/packages/lib/src/datetime.mts
+++ b/packages/lib/src/datetime.mts
@@ -13,6 +13,17 @@ export const WEEKDATES = 7;
  * The single time zone this module's scheduling logic is anchored to.
  * Every formatter and every date computation below shares this constant
  * so the zone is never duplicated as a second, driftable literal.
+ *
+ * Known, accepted limitation: `TIMEZONE` observed daylight-saving time
+ * from 1948 through 1951, and used a non-`HH:MM` local-mean-time offset
+ * (`+09:18:59`) before 1888, when Japan adopted a standard zone. Neither
+ * historical period is special-cased below, so `truncateTime` throws on
+ * a pre-1888 instant and `plusDate` briefly loses calendar-day alignment
+ * across the 1948-1951 transitions. This is out of scope: every real
+ * caller in this monorepo (`packages/fetcher/src/bin.mts`,
+ * `packages/fetcher/src/parseEvent.mts`,
+ * `packages/web/src/components/organisms/Calendar.tsx`) always passes
+ * the current date, never a historical one.
  */
 export const TIMEZONE = 'Asia/Tokyo';
 
@@ -110,16 +121,16 @@ export const formatWeek = (date: DateParsable): Week =>
   weekFormatter.format(new Date(date)).toLowerCase() as Week;
 
 /**
- * Format the date.
+ * Format a time range.
  *
  * The `翌` (next-day) marker compares `TIMEZONE` calendar-day keys, not
  * host-local day-of-month: two instants in different months that share
  * the same day-of-month (for example July 5 and August 5) are correctly
  * treated as different days, which a bare day-of-month comparison would
  * have missed.
- * @param from The date to format.
- * @param to The date to format.
- * @returns The formatted date.
+ * @param from The start of the range to format.
+ * @param to The end of the range to format.
+ * @returns The formatted time range.
  */
 export const formatTimeRange = (
   from: DateParsable,
@@ -132,15 +143,17 @@ export const formatTimeRange = (
 };
 
 /**
- * Get the date obtained by adding the specified date.
+ * Get the date obtained by adding the specified number of days.
  *
- * `TIMEZONE` observes no daylight-saving transitions, so one calendar
- * day is always exactly 86,400,000 ms; adding whole days as milliseconds
- * is therefore equivalent to `TIMEZONE` calendar-day arithmetic for any
- * input instant, regardless of the host process's own time zone.
+ * `TIMEZONE` has observed no daylight-saving transitions since 1951, so
+ * one calendar day is exactly 86,400,000 ms for every instant any real
+ * caller in this monorepo passes (see the historical-limitation note on
+ * `TIMEZONE`); adding whole days as milliseconds is equivalent to
+ * `TIMEZONE` calendar-day arithmetic for those instants, regardless of
+ * the host process's own time zone.
  * @param date The date to add.
  * @param days The days to add.
- * @returns The date obtained by adding the specified date.
+ * @returns The date obtained by adding the specified number of days.
  */
 export const plusDate = (date: DateParsable, days: number): Date =>
   new Date(new Date(date).getTime() + days * 86_400_000);
@@ -152,7 +165,10 @@ export const plusDate = (date: DateParsable, days: number): Date =>
  * Unlike the previous host-local implementation, an unparsable `date`
  * now throws a `RangeError` (via `Intl.DateTimeFormat`) instead of
  * silently producing an `Invalid Date`, so a malformed schedule input
- * fails loudly rather than propagating a `NaN` instant.
+ * fails loudly rather than propagating a `NaN` instant. A pre-1888
+ * `date` also throws (see the historical-limitation note on
+ * `TIMEZONE`), since Japan's local-mean-time offset before that year
+ * cannot be expressed as the `±HH:MM` this function builds.
  * @param date The date to truncate.
  * @returns The truncated date.
  */

--- a/packages/lib/src/datetime.mts
+++ b/packages/lib/src/datetime.mts
@@ -111,6 +111,12 @@ export const formatWeek = (date: DateParsable): Week =>
 
 /**
  * Format the date.
+ *
+ * The `翌` (next-day) marker compares `TIMEZONE` calendar-day keys, not
+ * host-local day-of-month: two instants in different months that share
+ * the same day-of-month (for example July 5 and August 5) are correctly
+ * treated as different days, which a bare day-of-month comparison would
+ * have missed.
  * @param from The date to format.
  * @param to The date to format.
  * @returns The formatted date.
@@ -142,6 +148,11 @@ export const plusDate = (date: DateParsable, days: number): Date =>
 /**
  * Truncate the date to `TIMEZONE` midnight of its `TIMEZONE` calendar
  * day, regardless of the host process's own time zone.
+ *
+ * Unlike the previous host-local implementation, an unparsable `date`
+ * now throws a `RangeError` (via `Intl.DateTimeFormat`) instead of
+ * silently producing an `Invalid Date`, so a malformed schedule input
+ * fails loudly rather than propagating a `NaN` instant.
  * @param date The date to truncate.
  * @returns The truncated date.
  */

--- a/packages/lib/src/datetime.test.mts
+++ b/packages/lib/src/datetime.test.mts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
 import type { DateParsable } from './datetime.mjs';
 import {
   formatDate,
@@ -71,10 +71,21 @@ describe('plusDate', () => {
   );
 });
 
+// `truncateTime`, `weekDates`, and `weekRange` are anchored to JST
+// (`Asia/Tokyo`) regardless of the host process's own time zone, so
+// their fixtures use `Z`-suffixed (or otherwise TZ-unambiguous) inputs
+// and `+09:00`-anchored expected values throughout — a naive,
+// un-suffixed string on either side would be parsed under the *host's*
+// local time zone by the `Date` constructor itself, which is outside
+// these functions' control and would make the fixture's own expected
+// value host-TZ-dependent rather than a reliable regression check.
 describe('truncateTime', () => {
   it.each([
-    ['2021-08-10T11:45:14.191', new Date('2021-08-10T00:00')],
-    [new Date('2021-08-10T11:45:14.191'), new Date('2021-08-10T00:00')],
+    ['2021-08-10T11:45:14.191Z', new Date('2021-08-10T00:00:00+09:00')],
+    [
+      new Date('2021-08-10T11:45:14.191Z'),
+      new Date('2021-08-10T00:00:00+09:00'),
+    ],
   ])('%s -> "%s"', (date, expected) =>
     expect(truncateTime(date)).toEqual(expected),
   );
@@ -83,27 +94,27 @@ describe('truncateTime', () => {
 describe('weekDates', () => {
   it.each([
     [
-      '2021-08-10T11:45:14.191',
+      '2021-08-10T11:45:14.191Z',
       [
-        new Date('2021-08-10T00:00'),
-        new Date('2021-08-11T00:00'),
-        new Date('2021-08-12T00:00'),
-        new Date('2021-08-13T00:00'),
-        new Date('2021-08-14T00:00'),
-        new Date('2021-08-15T00:00'),
-        new Date('2021-08-16T00:00'),
+        new Date('2021-08-10T00:00:00+09:00'),
+        new Date('2021-08-11T00:00:00+09:00'),
+        new Date('2021-08-12T00:00:00+09:00'),
+        new Date('2021-08-13T00:00:00+09:00'),
+        new Date('2021-08-14T00:00:00+09:00'),
+        new Date('2021-08-15T00:00:00+09:00'),
+        new Date('2021-08-16T00:00:00+09:00'),
       ],
     ],
     [
-      '2021-09-19T11:45:14.810',
+      '2021-09-19T11:45:14.810Z',
       [
-        new Date('2021-09-19T00:00'),
-        new Date('2021-09-20T00:00'),
-        new Date('2021-09-21T00:00'),
-        new Date('2021-09-22T00:00'),
-        new Date('2021-09-23T00:00'),
-        new Date('2021-09-24T00:00'),
-        new Date('2021-09-25T00:00'),
+        new Date('2021-09-19T00:00:00+09:00'),
+        new Date('2021-09-20T00:00:00+09:00'),
+        new Date('2021-09-21T00:00:00+09:00'),
+        new Date('2021-09-22T00:00:00+09:00'),
+        new Date('2021-09-23T00:00:00+09:00'),
+        new Date('2021-09-24T00:00:00+09:00'),
+        new Date('2021-09-25T00:00:00+09:00'),
       ],
     ],
   ])('%s -> "%s"', (date, expected) =>
@@ -114,16 +125,51 @@ describe('weekDates', () => {
 describe('weekRange', () => {
   it.each([
     [
-      '2021-08-10T11:45:14.191',
+      '2021-08-10T11:45:14.191Z',
       6,
-      [new Date('2021-08-10T00:00'), new Date('2021-08-16T00:00')],
+      [
+        new Date('2021-08-10T00:00:00+09:00'),
+        new Date('2021-08-16T00:00:00+09:00'),
+      ],
     ],
     [
-      '2021-09-19T11:45:14.810',
+      '2021-09-19T11:45:14.810Z',
       6,
-      [new Date('2021-09-19T00:00'), new Date('2021-09-25T00:00')],
+      [
+        new Date('2021-09-19T00:00:00+09:00'),
+        new Date('2021-09-25T00:00:00+09:00'),
+      ],
     ],
   ])('%s, %s -> "%s"', (date, range, expected) =>
     expect(weekRange(date, range)).toEqual(expected),
+  );
+});
+
+describe('time zone independence', () => {
+  const originalTz = process.env.TZ;
+
+  afterEach(() => {
+    process.env.TZ = originalTz;
+  });
+
+  it.each(['UTC', 'Asia/Tokyo', 'America/Los_Angeles'])(
+    'weekRange and weekDates return the same instants regardless of TZ=%s',
+    (tz) => {
+      process.env.TZ = tz;
+      const start = '2021-08-10T11:45:14.191Z';
+      expect(weekRange(start, 6)).toEqual([
+        new Date('2021-08-10T00:00:00+09:00'),
+        new Date('2021-08-16T00:00:00+09:00'),
+      ]);
+      expect(weekDates(start)).toEqual([
+        new Date('2021-08-10T00:00:00+09:00'),
+        new Date('2021-08-11T00:00:00+09:00'),
+        new Date('2021-08-12T00:00:00+09:00'),
+        new Date('2021-08-13T00:00:00+09:00'),
+        new Date('2021-08-14T00:00:00+09:00'),
+        new Date('2021-08-15T00:00:00+09:00'),
+        new Date('2021-08-16T00:00:00+09:00'),
+      ]);
+    },
   );
 });

--- a/packages/lib/src/datetime.test.mts
+++ b/packages/lib/src/datetime.test.mts
@@ -48,6 +48,15 @@ describe('formatTimeRange', () => {
     ],
     [new Date('2021-08-10T11:45:14.191Z'), 1_628_682_314_191, '20:45〜翌20:45'],
     [1_628_595_914_191, '2021-08-11T11:45:14.191Z', '20:45〜翌20:45'],
+    // Cross-month, same day-of-month: a host-local `getDate()` comparison
+    // (the pre-fix implementation) would have read both as day "5" and
+    // missed the 翌 marker despite these instants being 31 days apart.
+    // Comparing JST calendar-day keys instead gets this right.
+    [
+      '2021-07-05T11:45:14.191Z',
+      new Date('2021-08-05T11:45:14.191Z'),
+      '20:45〜翌20:45',
+    ],
   ])('%s, %s -> "%s"', (from, to, expected) =>
     expect(formatTimeRange(from, to)).toBe(expected),
   );
@@ -149,7 +158,11 @@ describe('time zone independence', () => {
   const originalTz = process.env.TZ;
 
   afterEach(() => {
-    process.env.TZ = originalTz;
+    // `process.env.x = undefined` coerces to the string `"undefined"`
+    // rather than truly unsetting the variable, so delete it explicitly
+    // when it was unset before this suite ran.
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
   });
 
   it.each(['UTC', 'Asia/Tokyo', 'America/Los_Angeles'])(

--- a/packages/lib/src/datetime.test.mts
+++ b/packages/lib/src/datetime.test.mts
@@ -98,6 +98,9 @@ describe('truncateTime', () => {
   ])('%s -> "%s"', (date, expected) =>
     expect(truncateTime(date)).toEqual(expected),
   );
+
+  it('should throw on an unparsable date', () =>
+    expect(() => truncateTime('not-a-date')).toThrow(RangeError));
 });
 
 describe('weekDates', () => {


### PR DESCRIPTION
## Summary

`packages/lib/src/datetime.mts` mixed host-local time-zone semantics
with JST-pinned formatters: `truncateTime` used `setHours(0,0,0,0)`
and `plusDate` used `setDate(getDate()+days)`, both of which read and
write `Date` fields in the **host process's local time zone**, while
the module's `Intl.DateTimeFormat` formatters were already pinned to
`Asia/Tokyo`. Since `packages/fetcher/src/bin.mts` derives the entire
published week window via `weekRange(new Date(), WEEKDATES)`, which
seven days get published depended on the build machine's local TZ,
while the labels rendered for them were always JST — the two disagree
near the JST day boundary. `formatTimeRange`'s `overDate`/`翌`
(next-day) marker had the same host-local defect
(`dateFrom.getDate() !== dateTo.getDate()`), found via the issue's own
"grep, don't assume" instruction.

**Fix**: extract a single exported `TIMEZONE = 'Asia/Tokyo'` constant,
shared by every formatter and by the date arithmetic. `truncateTime`
now derives the JST calendar day via `Intl.DateTimeFormat` and
reconstructs the exact JST-midnight instant from an ISO-8601
date-time-with-offset string. `plusDate` adds whole days as
milliseconds — safe because JST observes no daylight-saving
transitions, so one calendar day is always exactly 86,400,000 ms.
`formatTimeRange` now compares JST calendar-day keys instead of
host-local day-of-month (this also fixes a latent bug: two instants a
month apart sharing the same day-of-month, e.g. Jul 5 and Aug 5, used
to be wrongly read as the same day). All four exported signatures
(`truncateTime`, `plusDate`, `weekDates`, `weekRange`) are unchanged;
`formatTimeRange`'s signature is unchanged too. No file outside
`packages/lib` needed editing.

**Tests**: the `truncateTime`/`weekDates`/`weekRange` fixtures
previously used un-suffixed local-time strings on *both* the input and
expected sides (e.g. `'2021-08-10T11:45:14.191'` vs.
`new Date('2021-08-10T00:00')`), which only passed because both sides
shared the same host-local interpretation — a symmetry that breaks now
that `truncateTime` is JST-anchored instead of host-local. Rewrote
those fixtures to `Z`-suffixed / offset-anchored instants on both
sides; same 25 original test cases, now correctly host-TZ-independent
rather than accidentally host-dependent. `plusDate`'s existing
fixtures were already instant-anchored and needed no changes. Added:
a `TZ=UTC` / `TZ=Asia/Tokyo` / `TZ=America/Los_Angeles` regression
suite proving `weekRange`/`weekDates` return identical instants
regardless of host time zone; a cross-month `formatTimeRange` case
that would have failed under the old `getDate()`-based comparison; and
a regression test pinning `truncateTime`'s new fail-fast behavior on
unparsable input (`RangeError` instead of a silently propagated
`Invalid Date`). Verified locally under `TZ=UTC`,
`TZ=America/Los_Angeles`, and the sandbox's default `TZ=Asia/Tokyo`.

**Workflow TZ situation (deliberately unchanged)**: `TZ: Asia/Tokyo`
still appears on `push-main.yml`'s `detect-changes`/`compare` step,
`push-main.yml`'s `deploy` job's "Run the build" step, and
`push.yml`'s `deploy` job's "Run the build" step. None of these are
touched by this PR. They are no longer *required* for the schedule
window's correctness — `weekRange`/`weekDates` are now host-TZ-
independent — but `packages/web/src/components/organisms/Footer.tsx`
still renders `new Date().getFullYear()` at build/prerender time using
genuine host-local semantics, unrelated to this issue and out of this
PR's scope. Removing `TZ: Asia/Tokyo` from the build steps would be an
unscoped, unrelated behavior change (a real, if rare, regression risk
right around the JST/UTC New Year boundary, given the production
workflow's `0 */3 * * *` cron). Per the issue's own instruction ("keep
it and state in the PR body why it is still wanted"), it stays. No
`TZ` was added to `push.yml`'s test/lint `build` job, which already
had none — that job's `pnpm run test` now exercises exactly the
UTC-host code path this PR fixes.

## Test plan

- [x] `pnpm run build` (fresh worktree, once)
- [x] `pnpm run lint` (clean)
- [x] `pnpm run test` — 33/33 in `packages/lib` (30 in
      `datetime.test.mts`), 20/20 in `packages/fetcher`, 16/16 in
      `packages/web`
- [x] `pnpm run test` re-run under `TZ=UTC` and
      `TZ=America/Los_Angeles` shell overrides — all green
- [x] Two rounds of self-review (C1/C6) with fixes applied and
      re-verified

Closes #161