### PR TITLE
fix(fetcher): validate inputs and fail with an actionable message

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     ]
   },
   "scripts": {
-    "prebuild": "nodetouch .env",
     "build": "pnpm run -r build",
     "clean": "pnpm run --no-bail \"/^clean:.+/\"",
     "clean:root": "rimraf -g .eslintcache \"*.tgz\" \"*.tsbuildinfo\" \"node_modules/.cache/**/*\"",
@@ -41,7 +40,6 @@
     "pnpm:devPreinstall": "pnpm dlx mkdirp packages/fetcher/dist && pnpm dlx shx head -n 1 packages/fetcher/src/bin.mts > packages/fetcher/dist/bin.mjs",
     "prepare": "husky",
     "prettier": "prettier --cache --log-level=warn \"./**/*\"",
-    "prestart": "pnpm run prebuild",
     "start": "pnpm run --parallel -r start",
     "stylelint": "stylelint --aei --cache --cache-location node_modules/.cache/stylelint/ \"./**/*.css\"",
     "test": "pnpm run -r test"
@@ -76,7 +74,6 @@
     "stylelint": "^16.14.1",
     "stylelint-config-standard": "^36.0.1",
     "stylelint-config-tailwindcss": "^0.0.7",
-    "touch": "^3.1.1",
     "typescript": "~5.7.3",
     "typescript-eslint-language-service": "^5.0.5",
     "vitest": "^2.1.9"

--- a/packages/fetcher/src/bin.mts
+++ b/packages/fetcher/src/bin.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --enable-source-maps --env-file=../../.env
+#!/usr/bin/env node --enable-source-maps --env-file-if-exists=../../.env
 
 import { WEEKDATES, weekRange } from '@kurone-kito/kit.black-lib';
 import { fetchAllRawEventsFactory } from './fetchRaw.mjs';

--- a/packages/fetcher/src/env.mts
+++ b/packages/fetcher/src/env.mts
@@ -4,12 +4,26 @@ import type { EventType } from './constants.mjs';
 import { eventTypes } from './constants.mjs';
 
 /**
+ * Read a required environment variable, failing fast with an
+ * actionable message when it is missing.
+ * @param name The environment variable name.
+ * @returns The variable's value.
+ * @throws {Error} When the variable is unset or empty.
+ */
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+};
+
+/**
  * get the calendar IDs for each event type from the environment variables.
  * @returns the calendar IDs for each event type.
+ * @throws {Error} When any `ID_<EVENT_TYPE>` variable is unset or empty.
  */
 export const getCalendarIds = (): ReadonlyRecord<EventType, string> =>
   eventTypes.reduce<Partial<ReadonlyRecord<EventType, string>>>((acc, cur) => {
-    const id = process.env[`ID_${cur.toUpperCase()}`];
+    const id = requireEnv(`ID_${cur.toUpperCase()}`);
     return { ...acc, [cur]: `c_${id}@group.calendar.google.com` };
   }, {}) as ReadonlyRecord<EventType, string>;
 
@@ -23,9 +37,11 @@ const keys = [
 /**
  * Get the input to the JWT arguments from the environment variables.
  * @returns the input to the JWT arguments.
+ * @throws {Error} When `CLIENT_ID`, `CLIENT_SECRET`, or `REFRESH_TOKEN`
+ * is unset or empty.
  */
 export const getJwtInput = (): JWTInput =>
   keys.reduce<JWTInput>(
-    (acc, key) => ({ ...acc, [key]: process.env[key.toUpperCase()] }),
+    (acc, key) => ({ ...acc, [key]: requireEnv(key.toUpperCase()) }),
     { type: 'authorized_user' },
   );

--- a/packages/fetcher/src/env.mts
+++ b/packages/fetcher/src/env.mts
@@ -11,7 +11,7 @@ import { eventTypes } from './constants.mjs';
  * @throws {Error} When the variable is unset or empty.
  */
 const requireEnv = (name: string): string => {
-  const value = process.env[name];
+  const value = process.env[name]?.trim();
   if (!value) throw new Error(`Missing required environment variable: ${name}`);
   return value;
 };

--- a/packages/fetcher/src/env.test.mts
+++ b/packages/fetcher/src/env.test.mts
@@ -48,6 +48,13 @@ describe('getCalendarIds validation', () => {
       'Missing required environment variable: ID_STREAMING',
     );
   });
+
+  it('throws naming the missing variable when an ID is whitespace-only', () => {
+    vi.stubEnv('ID_STREAMING', '   ');
+    expect(() => getCalendarIds()).toThrow(
+      'Missing required environment variable: ID_STREAMING',
+    );
+  });
 });
 
 describe('getJwtInput validation', () => {

--- a/packages/fetcher/src/env.test.mts
+++ b/packages/fetcher/src/env.test.mts
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { getCalendarIds, getJwtInput } from './env.mjs';
 
 beforeAll(() => {
@@ -29,4 +37,26 @@ describe('jwtInput', () => {
       client_secret: '[client-secret]',
       refresh_token: '[refresh-token]',
     }));
+});
+
+describe('getCalendarIds validation', () => {
+  afterEach(() => vi.stubEnv('ID_STREAMING', '[id-streaming]'));
+
+  it('throws naming the missing variable when an ID is unset', () => {
+    vi.stubEnv('ID_STREAMING', '');
+    expect(() => getCalendarIds()).toThrow(
+      'Missing required environment variable: ID_STREAMING',
+    );
+  });
+});
+
+describe('getJwtInput validation', () => {
+  afterEach(() => vi.stubEnv('CLIENT_ID', '[client-id]'));
+
+  it('throws naming the missing variable when a credential is unset', () => {
+    vi.stubEnv('CLIENT_ID', '');
+    expect(() => getJwtInput()).toThrow(
+      'Missing required environment variable: CLIENT_ID',
+    );
+  });
 });

--- a/packages/fetcher/src/env.test.mts
+++ b/packages/fetcher/src/env.test.mts
@@ -66,4 +66,11 @@ describe('getJwtInput validation', () => {
       'Missing required environment variable: CLIENT_ID',
     );
   });
+
+  it('throws naming the missing variable when a credential is whitespace-only', () => {
+    vi.stubEnv('CLIENT_ID', '   ');
+    expect(() => getJwtInput()).toThrow(
+      'Missing required environment variable: CLIENT_ID',
+    );
+  });
 });

--- a/packages/fetcher/src/parseEvent.mts
+++ b/packages/fetcher/src/parseEvent.mts
@@ -55,7 +55,11 @@ export const toEventFactory =
    * `date` set. Rather than throwing and failing the entire batch on
    * one malformed event, this skips the event: it logs a warning to
    * `stderr` naming the event so the drop is visible in the build log,
-   * and returns `undefined` so the caller can filter it out.
+   * and returns `undefined` so the caller can filter it out. A skipped
+   * event's date is no longer represented, so
+   * {@link createVacationEventsFactory} may synthesize a vacation-day
+   * placeholder for that date instead -- an accepted side effect of
+   * skipping rather than a separate bug.
    * @param raw The raw event.
    * @returns The event, or `undefined` if the event has no resolvable
    * start time.

--- a/packages/fetcher/src/parseEvent.mts
+++ b/packages/fetcher/src/parseEvent.mts
@@ -69,7 +69,7 @@ export const toEventFactory =
     const { dateTime, date } = start ?? {};
     const epoch = new Date((dateTime || date) ?? '').getTime();
     if (Number.isNaN(epoch)) {
-      const label = summary ?? raw.id ?? '(unknown)';
+      const label = summary || raw.id || '(unknown)';
       console.warn(`Skipping event with no resolvable start time: ${label}`);
       return undefined;
     }

--- a/packages/fetcher/src/parseEvent.mts
+++ b/packages/fetcher/src/parseEvent.mts
@@ -50,13 +50,25 @@ export const toEventFactory =
   (type: EventType) =>
   /**
    * Convert the raw event to the event.
+   *
+   * `calendar_v3.Schema$Event.start` may have neither `dateTime` nor
+   * `date` set. Rather than throwing and failing the entire batch on
+   * one malformed event, this skips the event: it logs a warning to
+   * `stderr` naming the event so the drop is visible in the build log,
+   * and returns `undefined` so the caller can filter it out.
    * @param raw The raw event.
-   * @returns The event.
+   * @returns The event, or `undefined` if the event has no resolvable
+   * start time.
    */
-  (raw: calendar_v3.Schema$Event): EventDetail => {
+  (raw: calendar_v3.Schema$Event): EventDetail | undefined => {
     const { end, start, summary } = raw;
     const { dateTime, date } = start ?? {};
     const epoch = new Date((dateTime || date) ?? '').getTime();
+    if (Number.isNaN(epoch)) {
+      const label = summary ?? raw.id ?? '(unknown)';
+      console.warn(`Skipping event with no resolvable start time: ${label}`);
+      return undefined;
+    }
     const time = date ? undefined : formatTimeRange(epoch, end?.dateTime ?? '');
     return { date: formatDate(epoch), epoch, time, title: summary ?? '', type };
   };
@@ -75,7 +87,12 @@ export const toEventsFactory = (span: ReadonlyTuple<Date, 2>) => {
     source: ReadonlyMap<EventType, readonly calendar_v3.Schema$Event[]>,
   ): readonly EventDetail[] => {
     const all = eventTypes.flatMap(
-      (t) => source.get(t)?.filter(isAvailableRaw).map(toEventFactory(t)) ?? [],
+      (t) =>
+        source
+          .get(t)
+          ?.filter(isAvailableRaw)
+          .map(toEventFactory(t))
+          .filter((e): e is EventDetail => e !== undefined) ?? [],
     );
     const merged = [...all, ...createVacationEvents(all)];
     return merged

--- a/packages/fetcher/src/parseEvent.mts
+++ b/packages/fetcher/src/parseEvent.mts
@@ -69,7 +69,7 @@ export const toEventFactory =
     const { dateTime, date } = start ?? {};
     const epoch = new Date((dateTime || date) ?? '').getTime();
     if (Number.isNaN(epoch)) {
-      const label = summary || raw.id || '(unknown)';
+      const label = summary?.trim() || raw.id || '(unknown)';
       console.warn(`Skipping event with no resolvable start time: ${label}`);
       return undefined;
     }

--- a/packages/fetcher/src/parseEvent.test.mts
+++ b/packages/fetcher/src/parseEvent.test.mts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { calendar_v3 } from 'googleapis';
+import { toEventFactory } from './parseEvent.mjs';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('toEventFactory', () => {
+  it('maps a timed event to an EventDetail', () => {
+    const raw: calendar_v3.Schema$Event = {
+      end: { dateTime: '2026-01-01T13:00:00+09:00' },
+      id: 'timed-event',
+      start: { dateTime: '2026-01-01T12:00:00+09:00' },
+      summary: 'New Year',
+    };
+    const event = toEventFactory('others')(raw);
+    expect(event).toEqual({
+      date: '01/01',
+      epoch: Date.parse('2026-01-01T12:00:00+09:00'),
+      time: '12:00〜13:00',
+      title: 'New Year',
+      type: 'others',
+    });
+  });
+
+  it('maps an all-day event (date only, no dateTime) to an EventDetail with no time', () => {
+    const raw: calendar_v3.Schema$Event = {
+      id: 'all-day-event',
+      start: { date: '2026-01-01' },
+      summary: 'Holiday',
+    };
+    const event = toEventFactory('others')(raw);
+    expect(event?.time).toBeUndefined();
+    expect(event?.title).toBe('Holiday');
+  });
+
+  it('skips an event whose start has neither dateTime nor date, without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      id: 'malformed-event',
+      start: {},
+      summary: 'Malformed',
+    };
+    expect(() => toEventFactory('others')(raw)).not.toThrow();
+    expect(toEventFactory('others')(raw)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed'));
+  });
+
+  it('skips an event with no start object at all, without throwing', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = { id: 'no-start-event' };
+    expect(() => toEventFactory('others')(raw)).not.toThrow();
+    expect(toEventFactory('others')(raw)).toBeUndefined();
+  });
+});

--- a/packages/fetcher/src/parseEvent.test.mts
+++ b/packages/fetcher/src/parseEvent.test.mts
@@ -64,4 +64,17 @@ describe('toEventFactory', () => {
       expect.stringContaining('empty-summary-event'),
     );
   });
+
+  it('falls back to the event id when summary is whitespace-only', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      id: 'whitespace-summary-event',
+      start: {},
+      summary: '   ',
+    };
+    toEventFactory('others')(raw);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('whitespace-summary-event'),
+    );
+  });
 });

--- a/packages/fetcher/src/parseEvent.test.mts
+++ b/packages/fetcher/src/parseEvent.test.mts
@@ -51,4 +51,17 @@ describe('toEventFactory', () => {
     expect(() => toEventFactory('others')(raw)).not.toThrow();
     expect(toEventFactory('others')(raw)).toBeUndefined();
   });
+
+  it('falls back to the event id when summary is an empty string', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      id: 'empty-summary-event',
+      start: {},
+      summary: '',
+    };
+    toEventFactory('others')(raw);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('empty-summary-event'),
+    );
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       stylelint-config-tailwindcss:
         specifier: ^0.0.7
         version: 0.0.7(stylelint@16.14.1(typescript@5.7.3))(tailwindcss@3.4.17)
-      touch:
-        specifier: ^3.1.1
-        version: 3.1.1
       typescript:
         specifier: ~5.7.3
         version: 5.7.3
@@ -6657,10 +6654,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  touch@3.1.1:
-    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
-    hasBin: true
-
   tough-cookie@5.1.0:
     resolution: {integrity: sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==}
     engines: {node: '>=16'}
@@ -8165,13 +8158,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@kesills/eslint-config-airbnb-typescript@20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@kesills/eslint-config-airbnb-typescript@20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@stylistic/eslint-plugin': 2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.2)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
     optionalDependencies:
       typescript: 5.7.3
 
@@ -8195,14 +8188,14 @@ snapshots:
       '@eslint/js': 9.19.0
       '@eslint/json': 0.9.1
       '@eslint/markdown': 6.2.2
-      '@kesills/eslint-config-airbnb-typescript': 20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
+      '@kesills/eslint-config-airbnb-typescript': 20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@stylistic/eslint-plugin': 2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
       eslint-config-prettier: 9.1.0(eslint@9.19.0(jiti@2.4.2))
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
       eslint-plugin-editorconfig: 4.0.3
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2))
       eslint-plugin-jsdoc: 50.6.3(eslint@9.19.0(jiti@2.4.2))
@@ -10762,7 +10755,7 @@ snapshots:
       eslint: 9.19.0(jiti@2.4.2)
       semver: 7.7.1
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.19.0(jiti@2.4.2)
@@ -10799,7 +10792,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@9.4.0)
@@ -10815,14 +10808,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10852,7 +10845,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14225,8 +14218,6 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  touch@3.1.1: {}
 
   tough-cookie@5.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

`packages/fetcher` used to accept whatever it was given and only
discover a bad input several layers later, as an unrelated-looking
failure. This PR validates its two input surfaces and makes the
malformed-event case degrade gracefully instead of crashing the whole
run:

- **Env vars**: `getCalendarIds()` and `getJwtInput()` (`env.mts`) now
  read every value through a shared `requireEnv()` helper that trims
  and checks for emptiness, throwing `Missing required environment
  variable: <NAME>` before any network call. This closes the path
  where a missing `ID_STREAMING` silently produced the literal
  `c_undefined@group.calendar.google.com` and failed later as an
  opaque Google 404, and the equivalent path for `CLIENT_ID` /
  `CLIENT_SECRET` / `REFRESH_TOKEN` producing an opaque auth error.
- **Malformed events**: `toEventFactory` (`parseEvent.mts`) now
  detects an event whose `start` has neither `dateTime` nor `date`
  (an unparsable epoch), logs a warning to stderr naming the event,
  and returns `undefined` instead of letting `Intl.DateTimeFormat`
  throw `RangeError: Invalid time value` and take down the whole
  batch. `toEventsFactory` filters the skipped events out. Documented
  the accepted side effect: a skipped event's date may then get a
  vacation-day placeholder from `createVacationEventsFactory`, since
  the date now looks empty.
- **`.env`-free clean checkouts**: `bin.mts`'s shebang switched from
  `--env-file=../../.env` (errors when the file is absent) to
  `--env-file-if-exists=../../.env`, so a clean checkout with no
  `.env` but real environment variables supplied builds successfully
  — verified locally by moving `.env` aside, exporting the same
  values into the shell, and running a full `pnpm run build` from
  that state. The now-unnecessary root `prebuild: "nodetouch .env"`
  workaround (plus the `prestart` script that chained to it) and the
  `touch` devDependency are removed.

**Design choice** (per the issue's ask to decide deliberately):
validation lives in `getCalendarIds()` / `getJwtInput()` themselves,
not in `bin.mts`. Both are also used as defaults inside
`fetchRaw.mts` (`getCalendar()`, `fetchAllRawEventsFactory()`), so
putting the check at the function boundary gives every caller — the
CLI and any future direct consumer — the same fail-fast guarantee,
while keeping the functions plain sync functions that are easy to
unit test with `vi.stubEnv`.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run test` (fetcher: 27 tests, including new throw-on-missing/whitespace-only env cases and new `toEventFactory` skip-and-warn cases)
- [x] Local production build (`pnpm run build`) from a clean checkout with `.env` moved aside and the same values exported as real environment variables instead — confirms the literal acceptance criterion
- [x] Manually confirmed an unset `ID_STREAMING` throws `Missing required environment variable: ID_STREAMING` with exit code 1, before any network call

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed calendar events without valid start times are now skipped instead of causing processing failures.
  * Events with missing or empty configuration values now produce clear validation errors.
  * Timed and all-day events continue to be handled correctly.

* **Improvements**
  * Environment configuration is loaded only when available, simplifying setup.
  * Improved warnings identify events that cannot be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->