### PR TITLE
test(fetcher): cover the event-shaping and row-shaping logic

### DIFF
--- a/packages/fetcher/src/fetchRaw.test.mts
+++ b/packages/fetcher/src/fetchRaw.test.mts
@@ -86,17 +86,23 @@ describe('fetchAllRawEventsFactory', () => {
     );
   });
 
-  it('passes the calendar id derived from the matching ID_<TYPE> env var', async () => {
+  it('passes the calendar id derived from the matching ID_<TYPE> env var for each event type', async () => {
     const { client, list } = stubClient([]);
     const fetchAllRawEvents = fetchAllRawEventsFactory(client);
     const since = new Date('2026-01-01T00:00:00+09:00');
     const until = new Date('2026-01-08T00:00:00+09:00');
     await fetchAllRawEvents([since, until]);
-    expect(list).toHaveBeenCalledWith(
-      expect.objectContaining({
-        calendarId: 'c_[id-others]@group.calendar.google.com',
-      }),
-    );
+    // Assert all three calls individually, in the fixed `eventTypes`
+    // order the factory awaits them in (`others`, `release`,
+    // `streaming`) -- asserting only one call (as a previous revision
+    // did) would still pass if the calendar ids were reused or swapped
+    // across types, since every call in that case would satisfy a
+    // single `toHaveBeenCalledWith` check.
+    expect(list.mock.calls.map(([params]) => params.calendarId)).toEqual([
+      'c_[id-others]@group.calendar.google.com',
+      'c_[id-release]@group.calendar.google.com',
+      'c_[id-streaming]@group.calendar.google.com',
+    ]);
   });
 
   it('returns an empty array for a type whose response has no items', async () => {

--- a/packages/fetcher/src/fetchRaw.test.mts
+++ b/packages/fetcher/src/fetchRaw.test.mts
@@ -1,0 +1,120 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type { calendar_v3 } from 'googleapis';
+import {
+  fetchAllRawEventsFactory,
+  fetchRawEventsFactory,
+} from './fetchRaw.mjs';
+
+/**
+ * Build a stub `calendar_v3.Calendar` client whose `events.list` method
+ * resolves with the given items, without performing any network I/O.
+ * Both factories under test accept a client through their existing
+ * parameter, so no mocking framework beyond `vi.fn` is needed.
+ * @param items The `data.items` the stub response should resolve with.
+ * @returns The stub client and the underlying `list` mock, for
+ * assertions on call arguments and call count.
+ */
+const stubClient = (items: readonly calendar_v3.Schema$Event[] | undefined) => {
+  const list = vi.fn().mockResolvedValue({ data: { items } });
+  const client = { events: { list } } as unknown as calendar_v3.Calendar;
+  return { client, list };
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('fetchRawEventsFactory', () => {
+  it('always sends singleEvents, the Japan time zone, and startTime ordering', async () => {
+    const { client, list } = stubClient([]);
+    const fetchRawEvents = fetchRawEventsFactory(client);
+    await fetchRawEvents({
+      calendarId: 'primary',
+      timeMax: 'b',
+      timeMin: 'a',
+    });
+    expect(list).toHaveBeenCalledWith({
+      calendarId: 'primary',
+      orderBy: 'startTime',
+      singleEvents: true,
+      timeMax: 'b',
+      timeMin: 'a',
+      timeZone: 'Asia/Tokyo',
+    });
+  });
+
+  it('returns an empty array when the response has no items', async () => {
+    const { client } = stubClient(undefined);
+    const fetchRawEvents = fetchRawEventsFactory(client);
+    const result = await fetchRawEvents({ calendarId: 'primary' });
+    expect(result).toEqual([]);
+  });
+
+  it('returns the response items unchanged', async () => {
+    const events: readonly calendar_v3.Schema$Event[] = [
+      { id: 'e1' },
+      { id: 'e2' },
+    ];
+    const { client } = stubClient(events);
+    const fetchRawEvents = fetchRawEventsFactory(client);
+    const result = await fetchRawEvents({ calendarId: 'primary' });
+    expect(result).toEqual(events);
+  });
+});
+
+describe('fetchAllRawEventsFactory', () => {
+  // `fetchAllRawEventsFactory` calls `getCalendarIds()` unconditionally
+  // in its body, so the `ID_<TYPE>` variables must be stubbed even
+  // though the calendar client itself is injected below. The client
+  // parameter defaults to `getCalendar()`, but a default parameter only
+  // evaluates when the argument is omitted; every test here always
+  // passes an explicit stub client, so `getCalendar()` (and the JWT
+  // env vars it needs) never runs and does not need stubbing.
+  beforeAll(() => {
+    vi.stubEnv('ID_OTHERS', '[id-others]');
+    vi.stubEnv('ID_RELEASE', '[id-release]');
+    vi.stubEnv('ID_STREAMING', '[id-streaming]');
+  });
+
+  afterAll(() => vi.unstubAllEnvs());
+
+  it('fans out across all three event types and returns a Map keyed by type', async () => {
+    const { client, list } = stubClient([]);
+    const fetchAllRawEvents = fetchAllRawEventsFactory(client);
+    const since = new Date('2026-01-01T00:00:00+09:00');
+    const until = new Date('2026-01-08T00:00:00+09:00');
+    const result = await fetchAllRawEvents([since, until]);
+    expect(list).toHaveBeenCalledTimes(3);
+    expect([...result.keys()].toSorted()).toEqual(
+      ['others', 'release', 'streaming'].toSorted(),
+    );
+  });
+
+  it('passes the calendar id derived from the matching ID_<TYPE> env var', async () => {
+    const { client, list } = stubClient([]);
+    const fetchAllRawEvents = fetchAllRawEventsFactory(client);
+    const since = new Date('2026-01-01T00:00:00+09:00');
+    const until = new Date('2026-01-08T00:00:00+09:00');
+    await fetchAllRawEvents([since, until]);
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarId: 'c_[id-others]@group.calendar.google.com',
+      }),
+    );
+  });
+
+  it('returns an empty array for a type whose response has no items', async () => {
+    const { client } = stubClient(undefined);
+    const fetchAllRawEvents = fetchAllRawEventsFactory(client);
+    const since = new Date('2026-01-01T00:00:00+09:00');
+    const until = new Date('2026-01-08T00:00:00+09:00');
+    const result = await fetchAllRawEvents([since, until]);
+    expect(result.get('others')).toEqual([]);
+  });
+});

--- a/packages/fetcher/src/fetchRaw.test.mts
+++ b/packages/fetcher/src/fetchRaw.test.mts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { calendar_v3 } from 'googleapis';
 import {
   fetchAllRawEventsFactory,
@@ -27,8 +19,6 @@ const stubClient = (items: readonly calendar_v3.Schema$Event[] | undefined) => {
   const client = { events: { list } } as unknown as calendar_v3.Calendar;
   return { client, list };
 };
-
-afterEach(() => vi.restoreAllMocks());
 
 describe('fetchRawEventsFactory', () => {
   it('always sends singleEvents, the Japan time zone, and startTime ordering', async () => {

--- a/packages/fetcher/src/parseEvent.test.mts
+++ b/packages/fetcher/src/parseEvent.test.mts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { calendar_v3 } from 'googleapis';
-import { toEventFactory } from './parseEvent.mjs';
+import { MAX_EVENTS } from './constants.mjs';
+import type { EventType } from './constants.mjs';
+import {
+  createVacationEventsFactory,
+  isAvailableRaw,
+  toEventFactory,
+  toEventsFactory,
+} from './parseEvent.mjs';
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -76,5 +83,170 @@ describe('toEventFactory', () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('whitespace-summary-event'),
     );
+  });
+
+  it('renders the 翌 (next-day) marker when the event crosses a JST midnight', () => {
+    const raw: calendar_v3.Schema$Event = {
+      end: { dateTime: '2026-01-02T00:30:00+09:00' },
+      id: 'midnight-event',
+      start: { dateTime: '2026-01-01T23:30:00+09:00' },
+      summary: 'Late Night',
+    };
+    const event = toEventFactory('others')(raw);
+    expect(event).toEqual({
+      date: '01/01',
+      epoch: Date.parse('2026-01-01T23:30:00+09:00'),
+      time: '23:30〜翌00:30',
+      title: 'Late Night',
+      type: 'others',
+    });
+  });
+});
+
+describe('isAvailableRaw', () => {
+  it('excludes a cancelled event', () => {
+    const raw: calendar_v3.Schema$Event = {
+      id: 'cancelled',
+      status: 'cancelled',
+    };
+    expect(isAvailableRaw(raw)).toBe(false);
+  });
+
+  it('keeps an event whose status is not cancelled', () => {
+    const raw: calendar_v3.Schema$Event = {
+      id: 'confirmed',
+      status: 'confirmed',
+    };
+    expect(isAvailableRaw(raw)).toBe(true);
+  });
+
+  it('keeps an event with no status field at all', () => {
+    const raw: calendar_v3.Schema$Event = { id: 'no-status' };
+    expect(isAvailableRaw(raw)).toBe(true);
+  });
+});
+
+describe('createVacationEventsFactory', () => {
+  // JST midnight of 2026-01-01, expressed with a fixed offset so the
+  // assertion does not depend on the host process's own time zone.
+  const since = Date.parse('2026-01-01T00:00:00+09:00');
+
+  it('creates one vacation row for every date in the 7-day window when there are no events', () => {
+    const createVacationEvents = createVacationEventsFactory(since);
+    const rows = createVacationEvents([]);
+    expect(rows.map((r) => r.date).toSorted()).toEqual([
+      '01/01',
+      '01/02',
+      '01/03',
+      '01/04',
+      '01/05',
+      '01/06',
+      '01/07',
+    ]);
+    for (const row of rows) {
+      expect(row.title).toBe('(💤おやすみ)');
+      expect(row.type).toBe('others');
+    }
+  });
+
+  it('omits a vacation row for a date that already has an event', () => {
+    const createVacationEvents = createVacationEventsFactory(since);
+    const existing = {
+      date: '01/03',
+      epoch: 0,
+      title: 'Something',
+      type: 'others' as const,
+    };
+    const rows = createVacationEvents([existing]);
+    expect(rows).toHaveLength(6);
+    expect(rows.some((r) => r.date === '01/03')).toBe(false);
+  });
+
+  it('anchors the vacation row epoch to that date’s JST midnight', () => {
+    const createVacationEvents = createVacationEventsFactory(since);
+    const rows = createVacationEvents([]);
+    const jan1 = rows.find((r) => r.date === '01/01');
+    expect(jan1?.epoch).toBe(Date.parse('2026-01-01T00:00:00+09:00'));
+  });
+});
+
+describe('toEventsFactory', () => {
+  it('keeps an event exactly at `since` and drops an event exactly at `until`', () => {
+    const since = new Date('2026-01-01T00:00:00+09:00');
+    const until = new Date('2026-01-02T00:00:00+09:00');
+    const toEvents = toEventsFactory([since, until] as const);
+    const atSince: calendar_v3.Schema$Event = {
+      end: { dateTime: new Date(since.getTime() + 1_800_000).toISOString() },
+      id: 'at-since',
+      start: { dateTime: since.toISOString() },
+      summary: 'At since',
+    };
+    const atUntil: calendar_v3.Schema$Event = {
+      end: { dateTime: new Date(until.getTime() + 1_800_000).toISOString() },
+      id: 'at-until',
+      start: { dateTime: until.toISOString() },
+      summary: 'At until',
+    };
+    const source = new Map<EventType, readonly calendar_v3.Schema$Event[]>([
+      ['others', [atSince, atUntil]],
+    ]);
+    const result = toEvents(source);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.title).toBe('At since');
+  });
+
+  it('truncates to MAX_EVENTS after chronological sort, not before', () => {
+    const since = new Date('2026-01-01T00:00:00+09:00');
+    const until = new Date('2026-01-02T00:00:00+09:00');
+    const toEvents = toEventsFactory([since, until] as const);
+    const count = MAX_EVENTS + 1;
+    // Fixed 10-minute-apart timestamps, all inside the one-day window.
+    const raw: calendar_v3.Schema$Event[] = Array.from(
+      { length: count },
+      (_, i) => ({
+        end: {
+          dateTime: new Date(
+            since.getTime() + i * 600_000 + 300_000,
+          ).toISOString(),
+        },
+        id: `event-${i}`,
+        start: {
+          dateTime: new Date(since.getTime() + i * 600_000).toISOString(),
+        },
+        summary: `Event ${i}`,
+      }),
+      // Insert in reverse-chronological order, so a hypothetical
+      // slice-before-sort implementation would keep the wrong 12.
+    ).toReversed();
+    const source = new Map<EventType, readonly calendar_v3.Schema$Event[]>([
+      ['others', raw],
+    ]);
+    const result = toEvents(source);
+    expect(result).toHaveLength(MAX_EVENTS);
+    // The earliest event (index 0) must survive; the latest (index
+    // `count - 1`, the 13th) must be truncated away.
+    expect(result.some((e) => e.title === 'Event 0')).toBe(true);
+    expect(result.some((e) => e.title === `Event ${count - 1}`)).toBe(false);
+    expect([...result]).toEqual(
+      [...result].toSorted((a, b) => a.epoch - b.epoch),
+    );
+  });
+
+  it('merges synthesized vacation rows for in-window dates with no events', () => {
+    const since = new Date('2026-01-01T00:00:00+09:00');
+    const until = new Date('2026-01-03T00:00:00+09:00');
+    const toEvents = toEventsFactory([since, until] as const);
+    const dayOne: calendar_v3.Schema$Event = {
+      end: { dateTime: new Date(since.getTime() + 1_800_000).toISOString() },
+      id: 'day-one',
+      start: { dateTime: since.toISOString() },
+      summary: 'Day one event',
+    };
+    const source = new Map<EventType, readonly calendar_v3.Schema$Event[]>([
+      ['others', [dayOne]],
+    ]);
+    const result = toEvents(source);
+    expect(result.map((e) => e.date)).toEqual(['01/01', '01/02']);
+    expect(result[1]?.title).toBe('(💤おやすみ)');
   });
 });

--- a/packages/fetcher/src/toRow.test.mts
+++ b/packages/fetcher/src/toRow.test.mts
@@ -64,4 +64,26 @@ describe('toRowMapper', () => {
     expect(rowA.holiday).toBe(true);
     expect(rowB.holiday).toBeUndefined();
   });
+
+  it('computes dateSpan and a single dated row for same-date events that are not adjacent in the array', () => {
+    // `array.filter`/`findIndex` scan the whole array, so a different
+    // date sitting between the two same-date events must not change
+    // the dateSpan or which row renders the date cell.
+    const a = event({ date: '01/01' });
+    const middle = event({
+      date: '01/02',
+      epoch: Date.parse('2026-01-02T12:00:00+09:00'),
+    });
+    const b = event({ date: '01/01' });
+    const array = [a, middle, b];
+    const rowA = toRowMapper(a, 0, array);
+    const rowMiddle = toRowMapper(middle, 1, array);
+    const rowB = toRowMapper(b, 2, array);
+    expect(rowA.date).toBe('01/01');
+    expect(rowA.dateSpan).toBe(2);
+    expect(rowMiddle.date).toBe('01/02');
+    expect(rowMiddle.dateSpan).toBeUndefined();
+    expect(rowB.date).toBeUndefined();
+    expect(rowB.dateSpan).toBeUndefined();
+  });
 });

--- a/packages/fetcher/src/toRow.test.mts
+++ b/packages/fetcher/src/toRow.test.mts
@@ -65,10 +65,20 @@ describe('toRowMapper', () => {
     expect(rowB.holiday).toBeUndefined();
   });
 
-  it('computes dateSpan and a single dated row for same-date events that are not adjacent in the array', () => {
-    // `array.filter`/`findIndex` scan the whole array, so a different
-    // date sitting between the two same-date events must not change
-    // the dateSpan or which row renders the date cell.
+  it('pins toRowMapper’s actual whole-array-scan behavior for same-date events that are not adjacent', () => {
+    // `array.filter`/`findIndex` scan the whole array by `date`, not by
+    // position, so this is `toRowMapper`'s real, already-shipped
+    // behavior for this input shape -- this test pins that pure-function
+    // contract per issue #163's acceptance criteria (a non-adjacent
+    // same-date case), it does not assert that the input shape itself is
+    // expected or that rendering `dateSpan: 2` here would be valid HTML.
+    // `Row.tsx` applies `dateSpan` as `rowSpan`, which requires
+    // contiguous rows, so this input never reaches rendering in
+    // production: `toEventsFactory` sorts events chronologically before
+    // `.map(toRowMapper)`, which guarantees same-date events are always
+    // adjacent by the time they reach this function. Enforcing that
+    // invariant belongs to the sorting step, not to this pure mapper, so
+    // no production source change is made here.
     const a = event({ date: '01/01' });
     const middle = event({
       date: '01/02',


### PR DESCRIPTION
## Summary

Adds unit test coverage for `packages/fetcher`'s three previously
untested (or only partially tested) event-shaping and row-shaping
modules: `parseEvent.mts`, `toRow.mts`, and `fetchRaw.mts`.

`packages/fetcher/src/parseEvent.test.mts` and `toRow.test.mts` already
existed, added incidentally by unrelated fixes (#187's malformed-start
guard, #134/#161's holiday and timezone work). This PR extends both
files with the genuinely-remaining cases and adds the missing
`fetchRaw.test.mts` from scratch:

- `isAvailableRaw` — cancelled-event filtering
- `createVacationEventsFactory` — one `(💤おやすみ)` row per in-window
  date with no matching event; none for a date that already has one
- `toEventFactory` — the `翌` (next-day) marker for a midnight-crossing
  timed event
- `toEventsFactory` — `>= since && < until` boundary
  inclusion/exclusion, `MAX_EVENTS` truncation happening after
  chronological sort (not before — verified during self-review with a
  temporary mutation that confirmed a slice-before-sort implementation
  fails the new assertion), and vacation-row merging
- `toRowMapper` — `dateSpan`/date-cell correctness when two same-date
  events are not adjacent in the source array
- `fetchRawEventsFactory` / `fetchAllRawEventsFactory` — stub
  `calendar_v3.Calendar` client injected through the existing factory
  parameters (no network I/O, no mocking framework beyond `vi.fn`);
  covers `singleEvents`/`timeZone`/`orderBy` always being sent, empty
  `items` handling, and the three-calendar-type fan-out with calendar
  IDs derived from the `ID_<TYPE>` env vars

No production source file is modified. `packages/fetcher` test count:
30 → 47 (monorepo total: 96).

Closes #163

## Notes

- Missing/unparsable event `end` handling is intentionally left
  untested here — it's #187's open scope, and pinning it now would
  force #187 to rewrite these tests.
- Full plan and a critique-pass writeup are on the issue thread.
