### PR TITLE
test(web): replace the placeholder test with real module and component tests

### DIFF
--- a/packages/web/src/components/atoms/Anchor.test.tsx
+++ b/packages/web/src/components/atoms/Anchor.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import type { Component } from 'solid-js';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AnchorAttrsRequired } from './Anchor.js';
+import { Anchor } from './Anchor.js';
+
+/** A stub component standing in for the default `'a'` element. */
+const Stub: Component<AnchorAttrsRequired> = (props) => (
+  <button {...props} type="button" />
+);
+
+afterEach(() => cleanup());
+
+describe('Anchor', () => {
+  it('opens an external https URL in a new tab', () => {
+    const { container } = render(() => (
+      <Anchor href="https://example.test/">External</Anchor>
+    ));
+    const anchor = container.querySelector('a');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not add target or rel to a relative href', () => {
+    const { container } = render(() => <Anchor href="/foo">Internal</Anchor>);
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toHaveAttribute('target');
+    expect(anchor).not.toHaveAttribute('rel');
+  });
+
+  it('renders the component given via the as prop instead of a', () => {
+    const { container } = render(() => (
+      <Anchor as={Stub} href="/foo">
+        Internal
+      </Anchor>
+    ));
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.querySelector('button')).not.toBeNull();
+  });
+});

--- a/packages/web/src/components/atoms/calendar/Row.test.tsx
+++ b/packages/web/src/components/atoms/calendar/Row.test.tsx
@@ -43,4 +43,31 @@ describe('Row', () => {
     expect(cell).toHaveClass('sat');
     expect(cell).not.toHaveClass('holiday');
   });
+
+  it('renders the rowSpan on the date cell when dateSpan is given', () => {
+    const cell = renderDateCell({ date: '01/01', dateSpan: 2, week: 'thu' });
+    expect(cell).toHaveAttribute('rowspan', '2');
+  });
+
+  it('renders no date cell at all when date is omitted', () => {
+    const { container } = render(() => <Row time="10:00">Content</Row>);
+    expect(container.querySelector('.date')).toBeNull();
+  });
+
+  it('spans two columns when time is omitted', () => {
+    const { container } = render(() => <Row date="01/01">Content</Row>);
+    const cell = container.querySelector('td:last-child');
+    expect(cell).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td.time')).toHaveLength(0);
+  });
+
+  it('renders a separate time cell when time is given', () => {
+    const { container } = render(() => (
+      <Row date="01/01" time="10:00">
+        Content
+      </Row>
+    ));
+    expect(container.querySelector('td.time')).not.toBeNull();
+    expect(container.querySelectorAll('td[colspan]')).toHaveLength(0);
+  });
 });

--- a/packages/web/src/i18n/dictionaries.test.ts
+++ b/packages/web/src/i18n/dictionaries.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import en from './en.js';
+import ja from './ja.js';
+
+describe('i18n dictionaries', () => {
+  it('define exactly the same key set for ja and en', () => {
+    // A runtime check, independent of TypeScript's excess-property
+    // check on each dictionary's own object-literal assignment: that
+    // check only runs inside a full `tsc`/build pass, not `pnpm run
+    // lint` or `pnpm run test`, so this is the only check in the fast
+    // loop that catches a key added to one locale and not the other.
+    expect(Object.keys(ja).sort()).toStrictEqual(Object.keys(en).sort());
+  });
+});

--- a/packages/web/src/modules/createDarkMode.test.ts
+++ b/packages/web/src/modules/createDarkMode.test.ts
@@ -1,0 +1,74 @@
+import { createRoot } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDarkMode } from './createDarkMode.js';
+
+/** The storage key {@link createDarkMode} persists the theme under. */
+const storageKey = 'theme';
+
+/** The options shared by every test in this file. */
+const options = { dark: 'dark', light: 'light' };
+
+/**
+ * Stubs `window.matchMedia` so `(prefers-color-scheme: dark)` reports a
+ * fixed, controllable state. jsdom has no native `matchMedia`
+ * implementation.
+ * @param matches Whether the dark-mode media query should report a match.
+ */
+const stubMatchMedia = (matches: boolean): void => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    })),
+  );
+};
+
+beforeEach(() => localStorage.removeItem(storageKey));
+
+afterEach(() => {
+  localStorage.removeItem(storageKey);
+  vi.unstubAllGlobals();
+});
+
+describe('createDarkMode', () => {
+  it('follows a dark media preference when nothing is stored', () =>
+    createRoot((dispose) => {
+      stubMatchMedia(true);
+      const isDark = createDarkMode(options);
+      expect(isDark()).toBe(true);
+      dispose();
+    }));
+
+  it('follows a light media preference when nothing is stored', () =>
+    createRoot((dispose) => {
+      stubMatchMedia(false);
+      const isDark = createDarkMode(options);
+      expect(isDark()).toBe(false);
+      dispose();
+    }));
+
+  it('lets a stored dark value win over a light media preference', () =>
+    createRoot((dispose) => {
+      localStorage.setItem(storageKey, options.dark);
+      stubMatchMedia(false);
+      const isDark = createDarkMode(options);
+      expect(isDark()).toBe(true);
+      dispose();
+    }));
+
+  it('lets a stored light value win over a dark media preference', () =>
+    createRoot((dispose) => {
+      localStorage.setItem(storageKey, options.light);
+      stubMatchMedia(true);
+      const isDark = createDarkMode(options);
+      expect(isDark()).toBe(false);
+      dispose();
+    }));
+});

--- a/packages/web/src/modules/createI18N.test.tsx
+++ b/packages/web/src/modules/createI18N.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router';
+import type { Component } from 'solid-js';
+import { createRoot } from 'solid-js';
+import { afterEach, describe, expect, it } from 'vitest';
+import en from '../i18n/en.js';
+import ja from '../i18n/ja.js';
+import { createI18N, useLanguage } from './createI18N.js';
+
+afterEach(() => cleanup());
+
+/** A probe component that renders {@link useLanguage}'s current value. */
+const LanguageProbe: Component = () => {
+  const language = useLanguage();
+  return <>{language()}</>;
+};
+
+/**
+ * Renders {@link LanguageProbe} under a `MemoryRouter` initialized at the
+ * given path, matched against an optional `language` route param.
+ * @param path The initial memory-history location.
+ * @returns The `render` result.
+ */
+const renderLanguageProbe = (path: string) => {
+  const history = createMemoryHistory();
+  history.set({ value: path, replace: true });
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route component={LanguageProbe} path="/:language?" />
+    </MemoryRouter>
+  ));
+};
+
+describe('useLanguage', () => {
+  it('falls back to ja when the route language param is absent', () => {
+    const { container } = renderLanguageProbe('/');
+    expect(container.textContent).toBe('ja');
+  });
+
+  it('uses the route language param when present', () => {
+    const { container } = renderLanguageProbe('/en');
+    expect(container.textContent).toBe('en');
+  });
+});
+
+describe('createI18N', () => {
+  it('resolves a key from the ja dictionary', () =>
+    createRoot((dispose) => {
+      const t = createI18N(() => 'ja');
+      expect(t('calendar')).toBe(ja.calendar);
+      dispose();
+    }));
+
+  it('resolves a key from the en dictionary', () =>
+    createRoot((dispose) => {
+      const t = createI18N(() => 'en');
+      expect(t('calendar')).toBe(en.calendar);
+      dispose();
+    }));
+
+  it('interpolates the released template for ja', () =>
+    createRoot((dispose) => {
+      const t = createI18N(() => 'ja');
+      expect(t('released', { year: 2026 })).toBe('2026 年リリース');
+      dispose();
+    }));
+
+  it('interpolates the released template for en', () =>
+    createRoot((dispose) => {
+      const t = createI18N(() => 'en');
+      expect(t('released', { year: 2026 })).toBe('Released in 2026');
+      dispose();
+    }));
+});

--- a/packages/web/src/modules/useLanguageHref.test.tsx
+++ b/packages/web/src/modules/useLanguageHref.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router';
+import type { Component } from 'solid-js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useLanguageHref } from './useLanguageHref.js';
+
+afterEach(() => cleanup());
+
+/**
+ * A probe component that renders {@link useLanguageHref}'s current value
+ * for the given target language.
+ * @param props The properties.
+ * @param props.target The target language to swap to.
+ * @returns The component.
+ */
+const HrefProbe: Component<{ readonly target: 'en' | 'ja' }> = (props) => {
+  const href = useLanguageHref(props.target);
+  return <>{href()}</>;
+};
+
+/**
+ * Renders {@link HrefProbe} under a `MemoryRouter` initialized at the
+ * given path.
+ * @param path The initial memory-history location.
+ * @param target The target language to swap to.
+ * @returns The `render` result.
+ */
+const renderHrefProbe = (path: string, target: 'en' | 'ja') => {
+  const history = createMemoryHistory();
+  history.set({ value: path, replace: true });
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route component={() => <HrefProbe target={target} />} path="*" />
+    </MemoryRouter>
+  ));
+};
+
+describe('useLanguageHref', () => {
+  it('targets the language root when swapping from the unprefixed root', () => {
+    const { container } = renderHrefProbe('/', 'ja');
+    expect(container.textContent).toBe('/ja/');
+  });
+
+  it('swaps ja to en while preserving the rest of the path', () => {
+    const { container } = renderHrefProbe('/ja/', 'en');
+    expect(container.textContent).toBe('/en/');
+  });
+
+  it('swaps en to ja while preserving the rest of the path', () => {
+    const { container } = renderHrefProbe('/en/', 'ja');
+    expect(container.textContent).toBe('/ja/');
+  });
+});

--- a/packages/web/src/test.test.mts
+++ b/packages/web/src/test.test.mts
@@ -1,3 +1,0 @@
-import { expect, it } from 'vitest';
-
-it('should work the vitest', () => expect(true).toBeTruthy());


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/kit.black/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/kit.black/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/kit.black/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

`packages/web`'s test suite grew organically to 16 tests across 4
files without ever removing the original placeholder assertion
(`src/test.test.mts`), which proved nothing about the application.
Deletes that placeholder and adds real coverage for the five units the
issue names, bringing the package to 36 tests across 8 files:

- `modules/createI18N.ts` — `useLanguage()`'s route-param fallback to
  `ja` (and using the param when present), the plain `createI18N`
  translator resolving a key from each dictionary, and the `released`
  template's `{{ year }}` interpolation for both locales.
- `modules/useLanguageHref.ts` — locale swapping on `/`, `/ja/`, and
  `/en/`, rendered under a `MemoryRouter` (no real browser history
  needed).
- `modules/createDarkMode.ts` — following a stubbed
  `window.matchMedia` preference (jsdom has no native implementation)
  when nothing is in `localStorage`, and a stored value winning over a
  contradicting preference.
- `components/atoms/Anchor.tsx` — an `https?:` href gets
  `target="_blank"`/`rel="noopener noreferrer"`, a relative href gets
  neither, and the `as` prop swaps the rendered element.
- `components/atoms/calendar/Row.tsx` — extends the existing
  `Row.test.tsx` (holiday/week-class coverage from #134) rather than
  duplicating it: `rowSpan` on the date cell, no date cell at all when
  `date` is omitted, and the two-column fallback cell when `time` is
  omitted.
- `i18n/{ja,en}.ts` — a runtime parity check that both dictionaries
  define exactly the same key set. TypeScript's excess-property check
  on each dictionary's own object-literal assignment does catch an
  added key today, but only inside a full `tsc`/build pass — neither
  `pnpm run lint` nor `pnpm run test` invokes `tsc`, so this is the
  only check inside the fast loop that catches a key added to one
  locale and not the other.

No production source file is modified; `pnpm run test` and
`pnpm run lint` both pass locally.

### Deliberately left uncovered

Per the issue's own guidance, presentational atoms/molecules/organisms
whose entire body is JSX/Tailwind classes are left untested — a
snapshot test would add maintenance cost without catching bugs, and
they're already exercised by their Storybook stories. Of the 50
`packages/web` components not touched by this PR:

- **39** have a `.stories.ts(x)` sibling and are pure presentation with
  no branching logic worth pinning (for example
  `atoms/cards/{Activity,Event}.tsx`, `atoms/icons/*.tsx`,
  `molecules/{Kito,KitoWithLogo,WorkCard,Carousel,LinkItem}.tsx`,
  `organisms/{Hero,Footer,Links,LinksRandom,Activities,Events,Calendar,Works}.tsx`).
- **11** have no story, for two distinct reasons rather than one blanket
  exemption:
  - 7 render non-visual document metadata into `<head>`
    (`atoms/meta/{LinkList,MetaList,Ogp,Title,XCard}.tsx`,
    `molecules/Head.tsx`, `organisms/Head.tsx`) — not suited to
    Storybook's visual canvas.
  - 4 are thin organism-level composition wrappers
    (`organisms/{LanguageChanger,ToggleTheme,Navbar,Splash}.tsx`) whose
    only real logic is now exercised indirectly: they call this PR's
    newly-tested `useLanguageHref`/`createDarkMode`/`createI18N`
    modules and render an already-storied atom/molecule
    (`molecules/LanguageChanger`, `atoms/ToggleTheme`,
    `molecules/Splash` all have stories); the wrapper itself is only
    prop-plumbing and router/DOM-ref wiring.

Closes #164
