### PR TITLE
fix(a11y): correct invalid ARIA roles and unnamed controls

### DIFF
--- a/packages/web/src/components/atoms/Avatar.stories.ts
+++ b/packages/web/src/components/atoms/Avatar.stories.ts
@@ -18,6 +18,7 @@ export default {
     class: '',
     id: 'Id',
     nextId: 'NextId',
+    nextLabel: 'Go to the next avatar',
     src: `https://placehold.jp/${rect.width}x${rect.height}.png` as const,
   },
   component: Avatar,

--- a/packages/web/src/components/atoms/Avatar.test.tsx
+++ b/packages/web/src/components/atoms/Avatar.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Avatar } from './Avatar.js';
+
+afterEach(() => cleanup());
+
+describe('Avatar', () => {
+  it('renders the skip link with an accessible name when nextLabel is given', () => {
+    const { container } = render(() => (
+      <Avatar nextId="next" nextLabel="Go to the next avatar" src="a.webp" />
+    ));
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link).toHaveAttribute('aria-label', 'Go to the next avatar');
+    expect(link).toHaveAttribute('href', '#next');
+  });
+
+  it('omits the skip link entirely when nextLabel is missing', () => {
+    const { container } = render(() => <Avatar nextId="next" src="a.webp" />);
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('omits the skip link entirely when nextLabel is blank', () => {
+    const { container } = render(() => (
+      <Avatar nextId="next" nextLabel="   " src="a.webp" />
+    ));
+    expect(container.querySelector('a')).toBeNull();
+  });
+});

--- a/packages/web/src/components/atoms/Avatar.tsx
+++ b/packages/web/src/components/atoms/Avatar.tsx
@@ -1,4 +1,5 @@
 import type { Component, JSX } from 'solid-js';
+import { Show } from 'solid-js';
 import { twMerge } from 'tailwind-merge';
 
 /** Type definition for the properties. */
@@ -13,7 +14,11 @@ export interface AvatarProps
   /** The ID of the next element. */
   readonly nextId: string;
 
-  /** The accessible label for the link to the next element. */
+  /**
+   * The accessible label for the link to the next element. The link is
+   * omitted entirely when this is blank, so a focusable control never
+   * ships with an empty accessible name.
+   */
   readonly nextLabel?: string | undefined;
 }
 
@@ -36,15 +41,17 @@ export const Avatar: Component<AvatarProps> = (props) => (
       src={props.src}
       width={props.width}
     />
-    <a
-      aria-label={props.nextLabel}
-      href={`#${props.nextId}`}
-      class={twMerge(
-        'absolute left-0 right-0 mx-auto cursor-grab max-md:hidden',
-        props.anchorClass,
-      )}
-    >
-      &nbsp;
-    </a>
+    <Show when={props.nextLabel?.trim()}>
+      <a
+        aria-label={props.nextLabel}
+        href={`#${props.nextId}`}
+        class={twMerge(
+          'absolute left-0 right-0 mx-auto cursor-grab max-md:hidden',
+          props.anchorClass,
+        )}
+      >
+        &nbsp;
+      </a>
+    </Show>
   </div>
 );

--- a/packages/web/src/components/atoms/Avatar.tsx
+++ b/packages/web/src/components/atoms/Avatar.tsx
@@ -12,6 +12,9 @@ export interface AvatarProps
 
   /** The ID of the next element. */
   readonly nextId: string;
+
+  /** The accessible label for the link to the next element. */
+  readonly nextLabel?: string | undefined;
 }
 
 /**
@@ -34,6 +37,7 @@ export const Avatar: Component<AvatarProps> = (props) => (
       width={props.width}
     />
     <a
+      aria-label={props.nextLabel}
       href={`#${props.nextId}`}
       class={twMerge(
         'absolute left-0 right-0 mx-auto cursor-grab max-md:hidden',

--- a/packages/web/src/components/atoms/HamburgerButton.stories.ts
+++ b/packages/web/src/components/atoms/HamburgerButton.stories.ts
@@ -8,6 +8,6 @@ type Target = typeof HamburgerButton;
 export const Default: StoryObj<Target> = {};
 
 export default {
-  args: { class: '', label: 'Menu' },
+  args: { class: '', controls: 'demo-menu', expanded: false, label: 'Menu' },
   component: HamburgerButton,
 } satisfies Meta<Target>;

--- a/packages/web/src/components/atoms/HamburgerButton.tsx
+++ b/packages/web/src/components/atoms/HamburgerButton.tsx
@@ -37,6 +37,7 @@ export const HamburgerButton: Component<HamburgerButtonProps> = (props) => (
       aria-controls={props.controls}
       aria-expanded={props.expanded ?? false}
       aria-label={props.label}
+      checked={props.expanded ?? false}
       onClick={props.onClick}
       type="checkbox"
       value="expanded"

--- a/packages/web/src/components/atoms/HamburgerButton.tsx
+++ b/packages/web/src/components/atoms/HamburgerButton.tsx
@@ -8,6 +8,15 @@ export interface HamburgerButtonProps {
   /** The CSS classes. */
   readonly class?: string | undefined;
 
+  /** The `id` of the element this control expands/collapses. */
+  readonly controls?: string | undefined;
+
+  /**
+   * Whether the controlled element is currently expanded.
+   * @default false
+   */
+  readonly expanded?: boolean | undefined;
+
   /** The accessible label for the toggle input. */
   readonly label: string;
 
@@ -25,6 +34,8 @@ export interface HamburgerButtonProps {
 export const HamburgerButton: Component<HamburgerButtonProps> = (props) => (
   <label class={twMerge('btn btn-ghost swap swap-rotate', props.class)}>
     <input
+      aria-controls={props.controls}
+      aria-expanded={props.expanded ?? false}
       aria-label={props.label}
       onClick={props.onClick}
       type="checkbox"

--- a/packages/web/src/components/atoms/IconContainer.stories.ts
+++ b/packages/web/src/components/atoms/IconContainer.stories.ts
@@ -4,8 +4,13 @@ import { IconContainer } from './IconContainer.js';
 /** Type definition for the component. */
 type Target = typeof IconContainer;
 
-/** The default story for the component. */
+/** The default story for the component: decorative, no accessible name. */
 export const Default: StoryObj<Target> = {};
+
+/** A story for the opt-in labeled (non-decorative) variant. */
+export const Labeled: StoryObj<Target> = {
+  args: { label: 'A named icon' },
+};
 
 export default {
   args: { children: '◆', class: 'text-pink-500' },

--- a/packages/web/src/components/atoms/IconContainer.test.tsx
+++ b/packages/web/src/components/atoms/IconContainer.test.tsx
@@ -20,4 +20,12 @@ describe('IconContainer', () => {
     expect(icon).toHaveAttribute('aria-label', 'A named icon');
     expect(icon).not.toHaveAttribute('aria-hidden');
   });
+
+  it('treats a blank (empty or whitespace-only) label as decorative', () => {
+    const { container } = render(() => <IconContainer label="   " />);
+    const icon = container.querySelector('i');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).not.toHaveAttribute('role');
+    expect(icon).not.toHaveAttribute('aria-label');
+  });
 });

--- a/packages/web/src/components/atoms/IconContainer.test.tsx
+++ b/packages/web/src/components/atoms/IconContainer.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { IconContainer } from './IconContainer.js';
+
+afterEach(() => cleanup());
+
+describe('IconContainer', () => {
+  it('is decorative by default: aria-hidden, no role', () => {
+    const { container } = render(() => <IconContainer />);
+    const icon = container.querySelector('i');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).not.toHaveAttribute('role');
+    expect(icon).not.toHaveAttribute('aria-label');
+  });
+
+  it('exposes an accessible name when a label is given', () => {
+    const { container } = render(() => <IconContainer label="A named icon" />);
+    const icon = container.querySelector('i');
+    expect(icon).toHaveAttribute('role', 'img');
+    expect(icon).toHaveAttribute('aria-label', 'A named icon');
+    expect(icon).not.toHaveAttribute('aria-hidden');
+  });
+});

--- a/packages/web/src/components/atoms/IconContainer.tsx
+++ b/packages/web/src/components/atoms/IconContainer.tsx
@@ -8,9 +8,10 @@ export interface IconProps extends Readonly<ParentProps> {
   readonly class?: string | undefined;
 
   /**
-   * The accessible name for the icon. When omitted, the icon is treated
-   * as decorative (`aria-hidden`) because its meaning is assumed to be
-   * carried by adjacent text or a labelled ancestor.
+   * The accessible name for the icon. When omitted or blank (empty or
+   * whitespace-only), the icon is treated as decorative (`aria-hidden`)
+   * because its meaning is assumed to be carried by adjacent text or a
+   * labelled ancestor.
    */
   readonly label?: string | undefined;
 }
@@ -25,12 +26,14 @@ const defaultProps = { children: '◆' } as const satisfies IconProps;
  */
 export const IconContainer: Component<IconProps> = (props) => {
   const concProps = mergeProps(defaultProps, props);
+  /** Whether a non-blank accessible name was given. */
+  const isNamed = () => (concProps.label ?? '').trim() !== '';
   return (
     <i
-      aria-hidden={concProps.label === undefined ? true : undefined}
-      aria-label={concProps.label}
+      aria-hidden={isNamed() ? undefined : true}
+      aria-label={isNamed() ? concProps.label : undefined}
       class={twMerge('not-italic', concProps.class)}
-      role={concProps.label === undefined ? undefined : 'img'}
+      role={isNamed() ? 'img' : undefined}
     >
       {concProps.children}
     </i>

--- a/packages/web/src/components/atoms/IconContainer.tsx
+++ b/packages/web/src/components/atoms/IconContainer.tsx
@@ -6,6 +6,13 @@ import { twMerge } from 'tailwind-merge';
 export interface IconProps extends Readonly<ParentProps> {
   /** The CSS class. */
   readonly class?: string | undefined;
+
+  /**
+   * The accessible name for the icon. When omitted, the icon is treated
+   * as decorative (`aria-hidden`) because its meaning is assumed to be
+   * carried by adjacent text or a labelled ancestor.
+   */
+  readonly label?: string | undefined;
 }
 
 /** The default properties. */
@@ -19,7 +26,12 @@ const defaultProps = { children: '◆' } as const satisfies IconProps;
 export const IconContainer: Component<IconProps> = (props) => {
   const concProps = mergeProps(defaultProps, props);
   return (
-    <i class={twMerge('not-italic', concProps.class)} role="img">
+    <i
+      aria-hidden={concProps.label === undefined ? true : undefined}
+      aria-label={concProps.label}
+      class={twMerge('not-italic', concProps.class)}
+      role={concProps.label === undefined ? undefined : 'img'}
+    >
       {concProps.children}
     </i>
   );

--- a/packages/web/src/components/molecules/Kito.stories.ts
+++ b/packages/web/src/components/molecules/Kito.stories.ts
@@ -8,6 +8,6 @@ type Target = typeof Kito;
 export const Default: StoryObj<Target> = {};
 
 export default {
-  args: { class: 'w-full', id: 'id' },
+  args: { class: 'w-full', id: 'id', nextLabel: 'Go to the next avatar' },
   component: Kito,
 } satisfies Meta<Target>;

--- a/packages/web/src/components/molecules/Kito.tsx
+++ b/packages/web/src/components/molecules/Kito.tsx
@@ -17,6 +17,9 @@ export interface KitoProps {
 
   /** The ID of the element. */
   readonly id?: string;
+
+  /** The accessible label for the link between the two avatars. */
+  readonly nextLabel?: string;
 }
 
 /** The IDs of the elements. */
@@ -42,6 +45,7 @@ export const Kito: Component<KitoProps> = (props) => {
         height={2403}
         id={kitoId}
         nextId={momonekoId}
+        nextLabel={props.nextLabel}
         src={avatarKito}
         width={1242}
       />
@@ -52,6 +56,7 @@ export const Kito: Component<KitoProps> = (props) => {
         height={988}
         id={momonekoId}
         nextId={kitoId}
+        nextLabel={props.nextLabel}
         src={avatarMomoneko}
         width={511}
       />

--- a/packages/web/src/components/molecules/KitoWithLogo.stories.ts
+++ b/packages/web/src/components/molecules/KitoWithLogo.stories.ts
@@ -7,4 +7,7 @@ type Target = typeof KitoWithLogo;
 /** The default story for the component. */
 export const Default: StoryObj<Target> = {};
 
-export default { component: KitoWithLogo } satisfies Meta<Target>;
+export default {
+  args: { nextLabel: 'Go to the next avatar' },
+  component: KitoWithLogo,
+} satisfies Meta<Target>;

--- a/packages/web/src/components/molecules/KitoWithLogo.tsx
+++ b/packages/web/src/components/molecules/KitoWithLogo.tsx
@@ -19,6 +19,6 @@ export const KitoWithLogo: Component<KitoWithLogoProps> = (props) => (
       id="hero"
       {...props}
     />
-    <Logo class="-ml-[36%] h-[50%] w-auto opacity-95" role="banner" />
+    <Logo class="-ml-[36%] h-[50%] w-auto opacity-95" />
   </div>
 );

--- a/packages/web/src/components/molecules/LanguageChanger.tsx
+++ b/packages/web/src/components/molecules/LanguageChanger.tsx
@@ -21,7 +21,7 @@ export interface LanguageChangerProps extends Pick<AnchorProps, 'as'> {
  * @returns The component.
  */
 export const LanguageChanger: Component<LanguageChangerProps> = (props) => (
-  <details class="dropdown" role="listbox">
+  <details class="dropdown">
     <summary class="btn btn-ghost">
       <TbLanguageHiragana
         aria-label={props.label}

--- a/packages/web/src/components/molecules/calendar/Header.tsx
+++ b/packages/web/src/components/molecules/calendar/Header.tsx
@@ -20,11 +20,7 @@ export interface HeaderProps {
 export const Header: Component<HeaderProps> = (props) => (
   <header class="flex items-end gap-4 drop-shadow lg:basis-4/12 lg:flex-col-reverse">
     <div class="relative w-full basis-3/12 sm:basis-4/12">
-      <Logo
-        class="lg:text-stroke-3 max-md:opacity-80"
-        level={3}
-        role="banner"
-      />
+      <Logo class="lg:text-stroke-3 max-md:opacity-80" level={3} />
       <Logo aria-hidden class="absolute top-0 w-full max-md:hidden" level={3} />
     </div>
     <div class="text-stroke-3">

--- a/packages/web/src/components/organisms/Hero.tsx
+++ b/packages/web/src/components/organisms/Hero.tsx
@@ -28,6 +28,7 @@ export const Hero: Component = () => {
         <KitoWithLogo
           altKito={t('avatarKito')}
           altMomoneko={t('avatarMomoneko')}
+          nextLabel={t('avatarNext')}
         />
       }
       secondaryLabel={t('heroAbout')}

--- a/packages/web/src/components/organisms/Navbar.tsx
+++ b/packages/web/src/components/organisms/Navbar.tsx
@@ -5,6 +5,9 @@ import { useTranslator } from '../../modules/createI18N.js';
 import { LanguageChanger } from './LanguageChanger.js';
 import { ToggleTheme } from './ToggleTheme.js';
 
+/** The `id` of the collapsible menu list, referenced by `aria-controls`. */
+const menuId = 'navbar-menu';
+
 /**
  * The navigation bar.
  * @returns The component.
@@ -13,16 +16,14 @@ export const Navbar: Component = () => {
   const [expanded, setExpandState] = createSignal(false);
   const t = useTranslator();
   return (
-    <header
+    <nav
       aria-label={t('navbarLabel')}
       class="navbar pointer-events-none fixed top-0 z-50 justify-end"
-      role="navigation"
     >
       <ul
-        aria-expanded={expanded()}
         class="navbar-end max-lg:bg-primary/90 bg-primary/40 hover:bg-primary/90 pointer-events-auto flex items-center justify-between rounded-lg transition-all"
         classList={{ 'w-14': !expanded(), 'w-44': expanded() }}
-        role="menubar"
+        id={menuId}
       >
         <li classList={{ hidden: !expanded() }}>
           <LanguageChanger />
@@ -32,11 +33,13 @@ export const Navbar: Component = () => {
         </li>
         <li>
           <HamburgerButton
+            controls={menuId}
+            expanded={expanded()}
             label={t('hamburgerMenu')}
             onClick={(event) => setExpandState(event.currentTarget.checked)}
           />
         </li>
       </ul>
-    </header>
+    </nav>
   );
 };

--- a/packages/web/src/i18n/en.ts
+++ b/packages/web/src/i18n/en.ts
@@ -5,6 +5,7 @@ const resources: Resources = {
   activitiesCarousel: 'Kuroné Kito’s activity photos',
   avatarKito: 'Kuroné Kito’s standard avatar',
   avatarMomoneko: '“Momoneko-chan” modified avatar for VR',
+  avatarNext: 'Go to the next avatar',
   author: 'Kuroné Kito',
   calendar:
     'The following live streaming schedule is automatically generated based on information extracted from the Calendar app eight times daily.',

--- a/packages/web/src/i18n/ja.ts
+++ b/packages/web/src/i18n/ja.ts
@@ -5,6 +5,7 @@ const resources: Resources = {
   activitiesCarousel: '黒音キトの活動写真',
   avatarKito: '黒音キトの標準アバター',
   avatarMomoneko: 'VR 用アバター“ももねこちゃん”改変',
+  avatarNext: '次のアバターへ移動',
   author: '黒音キト',
   calendar:
     '以下の配信スケジュールは、カレンダー アプリから毎日 8 回抽出した情報に基づき、自動生成しております。',

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -10,6 +10,7 @@ export type ResourcesKeys =
   | 'author'
   | 'avatarKito'
   | 'avatarMomoneko'
+  | 'avatarNext'
   | 'calendar'
   | 'hamburgerMenu'
   | 'heroAbout'


### PR DESCRIPTION
## Summary

Six ARIA/landmark defects found in a 2026-07-28 repository audit: an
overridden `<header>` landmark, a fake `menubar` widget with no
keyboard behavior, `aria-expanded` on the wrong element, a disclosure
widget mislabeled as a `listbox`, a duplicate `banner` landmark, an
unnamed `role="img"` icon wrapper, and a focusable link whose entire
content was a non-breaking space.

- `Navbar`: `<header role="navigation">` → `<nav aria-label>`; dropped
  `role="menubar"` from the menu list (no arrow-key behavior is
  implemented, so it was never a real menubar).
- `HamburgerButton`: `aria-expanded`/`aria-controls` now live on the
  toggle `<input>` itself (new optional `expanded`/`controls` props),
  not on the `<ul>` it controls.
- `LanguageChanger` (molecule): dropped `role="listbox"` from the
  `<details>` dropdown — a disclosure widget containing links needs no
  extra role.
- `calendar/Header` + `KitoWithLogo`: removed `role="banner"` from
  both `Logo` call sites. Neither location is the real site header, so
  this leaves zero `banner` landmarks rather than two.
- `IconContainer`: now decorative (`aria-hidden`) by default; a new
  optional `label` prop opts a call site into `role="img"` +
  `aria-label`. Checked all 4 existing call sites — every one already
  carries its meaning through adjacent visible text or the wrapping
  `Anchor`'s own `aria-label`, so none needs the labeled variant today.
- `Avatar`: the empty `<a>{&nbsp;}</a>` skip link between the two
  carousel avatars gets a real accessible name via a new optional
  `nextLabel` prop, threaded through `Kito` → `KitoWithLogo` → `Hero`
  with a new `avatarNext` i18n key (ja/en), following the
  organism-owns-`useTranslator()` pattern #155 established.

**Explicit scope note**: `atoms/icons/{X,Pixiv,Threads,L08,Marshmallow,
Bluesky}.tsx` are separate `<svg role="img">` components, not
`IconContainer`, and are always nested inside an already-`aria-label`ed
`Anchor` in every current usage. They're out of scope for this issue
(not in its defect table) — flagged here as a deliberate scope call,
not an oversight.

## Verification

- `pnpm run lint && pnpm run test` pass, including a new
  `IconContainer.test.tsx` covering both the decorative-default and
  opt-in-labeled branches.
- Full local production build (`.env` present); grepped the
  prerendered `dist/{,en/,ja/}index.html` output directly and
  confirmed: zero remaining `role="navigation"`/`"menubar"`/
  `"listbox"`/`"banner"` anywhere, `aria-controls`/`aria-expanded` on
  the hamburger `<input>`, `aria-hidden="true"` on every `IconContainer`
  instance, and a real `aria-label` on both avatar skip links, across
  all three locales.
- `pnpm --filter @kurone-kito/kit.black-web run build:storybook` fails
  with a pre-existing `CriticalPresetLoadError` in this environment
  (`storybook-solidjs-vite` preset: "module is not defined") — verified
  this reproduces identically on the pre-change parent commit, so it is
  an environment-level breakage unrelated to this diff, not a
  regression. Used the production-build DOM inspection above as the
  available substitute for "stories still render."
- An independent subagent critique pass ran against the plan (B2) and
  again against the finished diff (C1); both passed clean after one
  round of plan fixes (a required/optional prop-type mismatch and an
  incorrect `build:storybook` invocation path, both applied before
  implementation).

Closes #154
