### PR TITLE
feat(web): add a webp/png image download button for the calendar

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,6 +39,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.15.3",
     "@solidjs/start": "^1.0.11",
+    "@zumer/snapdom": "^2.24.1",
     "solid-icons": "^1.1.0",
     "solid-js": "^1.9.4",
     "tailwind-merge": "^2.6.0",

--- a/packages/web/src/components/atoms/DownloadCalendarButton.stories.ts
+++ b/packages/web/src/components/atoms/DownloadCalendarButton.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from 'storybook-solidjs';
+import { DownloadCalendarButton } from './DownloadCalendarButton.js';
+
+/** Type definition for the component. */
+type Target = typeof DownloadCalendarButton;
+
+/** The default story for the component. */
+export const Default: StoryObj<Target> = {};
+
+export default {
+  args: { class: '', label: 'Save the schedule calendar as an image' },
+  component: DownloadCalendarButton,
+} satisfies Meta<Target>;

--- a/packages/web/src/components/atoms/DownloadCalendarButton.test.tsx
+++ b/packages/web/src/components/atoms/DownloadCalendarButton.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, fireEvent, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DownloadCalendarButton } from './DownloadCalendarButton.js';
+
+afterEach(() => cleanup());
+
+describe('DownloadCalendarButton', () => {
+  it('renders an accessible, labeled button', () => {
+    const { getByRole } = render(() => (
+      <DownloadCalendarButton label="Save the schedule calendar as an image" />
+    ));
+    const button = getByRole('button', {
+      name: 'Save the schedule calendar as an image',
+    });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('forwards the click handler', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <DownloadCalendarButton label="Download" onClick={onClick} />
+    ));
+    fireEvent.click(getByRole('button', { name: 'Download' }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/components/atoms/DownloadCalendarButton.tsx
+++ b/packages/web/src/components/atoms/DownloadCalendarButton.tsx
@@ -1,0 +1,35 @@
+import { FaSolidDownload } from 'solid-icons/fa';
+import type { Component, JSX } from 'solid-js';
+import { twMerge } from 'tailwind-merge';
+
+/** Type definition for the properties. */
+export interface DownloadCalendarButtonProps {
+  /** The CSS classes. */
+  readonly class?: string | undefined;
+
+  /** The visible and accessible label. */
+  readonly label: string;
+
+  /** The click event handler. */
+  readonly onClick?:
+    | JSX.EventHandlerUnion<HTMLButtonElement, MouseEvent>
+    | undefined;
+}
+
+/**
+ * The button to download the schedule calendar as an image.
+ * @param props The component properties.
+ * @returns The component.
+ */
+export const DownloadCalendarButton: Component<DownloadCalendarButtonProps> = (
+  props,
+) => (
+  <button
+    class={twMerge('btn btn-primary gap-2 font-semibold', props.class)}
+    onClick={props.onClick}
+    type="button"
+  >
+    <FaSolidDownload aria-hidden="true" class="h-5 w-5" />
+    {props.label}
+  </button>
+);

--- a/packages/web/src/components/organisms/Calendar.test.tsx
+++ b/packages/web/src/components/organisms/Calendar.test.tsx
@@ -1,0 +1,65 @@
+import { MemoryRouter, Route } from '@solidjs/router';
+import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Calendar } from './Calendar.js';
+
+// `vi.mock` factories may only reference hoisted bindings, so the mock
+// function is created via `vi.hoisted` rather than a plain top-level
+// `const` -- see https://vitest.dev/api/vi.html#vi-hoisted.
+const { toBlob } = vi.hoisted(() => ({
+  toBlob: vi.fn(async () => new Blob(['snapshot'], { type: 'image/webp' })),
+}));
+
+vi.mock('@zumer/snapdom', () => ({ snapdom: { toBlob } }));
+
+const createObjectURL = vi.fn(() => 'blob:mock-url');
+const revokeObjectURL = vi.fn();
+
+afterEach(() => {
+  cleanup();
+  toBlob.mockClear();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+});
+
+describe('Calendar organism', () => {
+  it('captures the calendar element and downloads it with the computed filename', async () => {
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+    const clickedAnchors: HTMLAnchorElement[] = [];
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        clickedAnchors.push(this);
+      });
+
+    const { getByRole } = render(() => (
+      <MemoryRouter>
+        <Route path="/:language?" component={Calendar} />
+      </MemoryRouter>
+    ));
+
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() => expect(clickedAnchors).toHaveLength(1));
+
+    expect(toBlob).toHaveBeenCalledOnce();
+    const [element, options] = toBlob.mock.calls[0] as [
+      HTMLElement,
+      Record<string, unknown>,
+    ];
+    expect(element).toHaveAttribute('id', 'calendar');
+    expect(options).toMatchObject({
+      embedFonts: true,
+      scale: 2,
+      type: 'webp',
+    });
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(clickedAnchors[0]?.href).toBe('blob:mock-url');
+    expect(clickedAnchors[0]?.download).toMatch(/^schedule-.+\.webp$/);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+    clickSpy.mockRestore();
+  });
+});

--- a/packages/web/src/components/organisms/Calendar.test.tsx
+++ b/packages/web/src/components/organisms/Calendar.test.tsx
@@ -15,11 +15,24 @@ vi.mock('@zumer/snapdom', () => ({ snapdom: { toBlob } }));
 const createObjectURL = vi.fn(() => 'blob:mock-url');
 const revokeObjectURL = vi.fn();
 
+// jsdom implements neither `URL.createObjectURL` nor
+// `URL.revokeObjectURL`; save the (absent) originals so `afterEach` can
+// restore them -- not just clear the mocks -- even if an assertion
+// throws mid-test.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+let clickSpy: ReturnType<typeof vi.spyOn> | undefined;
+
 afterEach(() => {
   cleanup();
   toBlob.mockClear();
   createObjectURL.mockClear();
   revokeObjectURL.mockClear();
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  clickSpy?.mockRestore();
+  clickSpy = undefined;
 });
 
 describe('Calendar organism', () => {
@@ -27,7 +40,7 @@ describe('Calendar organism', () => {
     URL.createObjectURL = createObjectURL;
     URL.revokeObjectURL = revokeObjectURL;
     const clickedAnchors: HTMLAnchorElement[] = [];
-    const clickSpy = vi
+    clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, 'click')
       .mockImplementation(function (this: HTMLAnchorElement) {
         clickedAnchors.push(this);
@@ -59,7 +72,61 @@ describe('Calendar organism', () => {
     expect(clickedAnchors[0]?.href).toBe('blob:mock-url');
     expect(clickedAnchors[0]?.download).toMatch(/^schedule-.+\.webp$/);
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
 
-    clickSpy.mockRestore();
+  it('logs and does not throw when the capture fails', async () => {
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+    toBlob.mockRejectedValueOnce(new Error('capture failed'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const { getByRole } = render(() => (
+      <MemoryRouter>
+        <Route path="/:language?" component={Calendar} />
+      </MemoryRouter>
+    ));
+
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to download the calendar image.',
+      expect.any(Error),
+    );
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  it('still revokes the object URL when a failure happens after it is created', async () => {
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {
+        throw new Error('click failed');
+      });
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const { getByRole } = render(() => (
+      <MemoryRouter>
+        <Route path="/:language?" component={Calendar} />
+      </MemoryRouter>
+    ));
+
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+    consoleError.mockRestore();
   });
 });

--- a/packages/web/src/components/organisms/Calendar.test.tsx
+++ b/packages/web/src/components/organisms/Calendar.test.tsx
@@ -23,6 +23,7 @@ const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
 
 let clickSpy: ReturnType<typeof vi.spyOn> | undefined;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 afterEach(() => {
   cleanup();
@@ -33,6 +34,8 @@ afterEach(() => {
   URL.revokeObjectURL = originalRevokeObjectURL;
   clickSpy?.mockRestore();
   clickSpy = undefined;
+  consoleErrorSpy?.mockRestore();
+  consoleErrorSpy = undefined;
 });
 
 describe('Calendar organism', () => {
@@ -78,9 +81,7 @@ describe('Calendar organism', () => {
     URL.createObjectURL = createObjectURL;
     URL.revokeObjectURL = revokeObjectURL;
     toBlob.mockRejectedValueOnce(new Error('capture failed'));
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { getByRole } = render(() => (
       <MemoryRouter>
@@ -90,29 +91,27 @@ describe('Calendar organism', () => {
 
     fireEvent.click(getByRole('button'));
 
-    await waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalledOnce());
 
-    expect(consoleError).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Failed to download the calendar image.',
       expect.any(Error),
     );
     expect(createObjectURL).not.toHaveBeenCalled();
     expect(revokeObjectURL).not.toHaveBeenCalled();
-
-    consoleError.mockRestore();
   });
 
-  it('still revokes the object URL when a failure happens after it is created', async () => {
+  it('still revokes the object URL and removes the anchor when a failure happens after it is created', async () => {
     URL.createObjectURL = createObjectURL;
     URL.revokeObjectURL = revokeObjectURL;
+    let clickedAnchor: HTMLAnchorElement | undefined;
     clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, 'click')
-      .mockImplementation(() => {
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        clickedAnchor = this;
         throw new Error('click failed');
       });
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { getByRole } = render(() => (
       <MemoryRouter>
@@ -122,11 +121,11 @@ describe('Calendar organism', () => {
 
     fireEvent.click(getByRole('button'));
 
-    await waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalledOnce());
 
     expect(createObjectURL).toHaveBeenCalledOnce();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
-
-    consoleError.mockRestore();
+    expect(clickedAnchor).toBeDefined();
+    expect(document.body.contains(clickedAnchor ?? null)).toBe(false);
   });
 });

--- a/packages/web/src/components/organisms/Calendar.tsx
+++ b/packages/web/src/components/organisms/Calendar.tsx
@@ -1,9 +1,11 @@
 import { tupleMap, weekRange, formatDate } from '@kurone-kito/kit.black-lib';
 import type { Component } from 'solid-js';
 import rows from '../../data.json';
+import { calendarDownloadFilename } from '../../modules/downloadFilename.js';
 import { useTranslator } from '../../modules/createI18N.js';
 import { Article } from '../atoms/Article.js';
 import type { RowProps } from '../atoms/calendar/Row.js';
+import { DownloadCalendarButton } from '../atoms/DownloadCalendarButton.js';
 import { Calendar as MoleculeCalendar } from '../molecules/calendar/Calendar.js';
 
 /*
@@ -20,6 +22,33 @@ const [since, until] = tupleMap(weekRange(new Date()), formatDate);
  */
 export const Calendar: Component = () => {
   const t = useTranslator();
+  let calendarRef!: HTMLElement;
+
+  /**
+   * Captures the calendar element and downloads it as an image.
+   *
+   * `@zumer/snapdom` is browser-only, so it is loaded via a dynamic
+   * `import()` inside this handler -- never as a top-level import --
+   * so SolidStart SSR and the static build never evaluate it.
+   */
+  const handleDownload = async (): Promise<void> => {
+    const { snapdom } = await import('@zumer/snapdom');
+    const blob = await snapdom.toBlob(calendarRef, {
+      embedFonts: true,
+      scale: 2,
+      type: 'webp',
+    });
+    const filename = calendarDownloadFilename(since, until, blob.type);
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.download = filename;
+    anchor.href = url;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <Article
       class="!px-safe flex flex-col justify-center xl:w-10/12"
@@ -28,9 +57,15 @@ export const Calendar: Component = () => {
       <p>{t('calendar')}</p>
       <MoleculeCalendar
         id="calendar"
+        ref={calendarRef}
         rows={rows as readonly RowProps[]}
         since={since}
         until={until}
+      />
+      <DownloadCalendarButton
+        class="mx-auto"
+        label={t('downloadCalendar')}
+        onClick={handleDownload}
       />
     </Article>
   );

--- a/packages/web/src/components/organisms/Calendar.tsx
+++ b/packages/web/src/components/organisms/Calendar.tsx
@@ -33,6 +33,7 @@ export const Calendar: Component = () => {
    */
   const handleDownload = async (): Promise<void> => {
     let url: string | undefined;
+    let anchor: HTMLAnchorElement | undefined;
     try {
       const { snapdom } = await import('@zumer/snapdom');
       const blob = await snapdom.toBlob(calendarRef, {
@@ -42,15 +43,15 @@ export const Calendar: Component = () => {
       });
       const filename = calendarDownloadFilename(since, until, blob.type);
       url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
+      anchor = document.createElement('a');
       anchor.download = filename;
       anchor.href = url;
       document.body.appendChild(anchor);
       anchor.click();
-      anchor.remove();
     } catch (error) {
       console.error('Failed to download the calendar image.', error);
     } finally {
+      anchor?.remove();
       if (url) {
         URL.revokeObjectURL(url);
       }

--- a/packages/web/src/components/organisms/Calendar.tsx
+++ b/packages/web/src/components/organisms/Calendar.tsx
@@ -32,21 +32,29 @@ export const Calendar: Component = () => {
    * so SolidStart SSR and the static build never evaluate it.
    */
   const handleDownload = async (): Promise<void> => {
-    const { snapdom } = await import('@zumer/snapdom');
-    const blob = await snapdom.toBlob(calendarRef, {
-      embedFonts: true,
-      scale: 2,
-      type: 'webp',
-    });
-    const filename = calendarDownloadFilename(since, until, blob.type);
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.download = filename;
-    anchor.href = url;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
+    let url: string | undefined;
+    try {
+      const { snapdom } = await import('@zumer/snapdom');
+      const blob = await snapdom.toBlob(calendarRef, {
+        embedFonts: true,
+        scale: 2,
+        type: 'webp',
+      });
+      const filename = calendarDownloadFilename(since, until, blob.type);
+      url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.download = filename;
+      anchor.href = url;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+    } catch (error) {
+      console.error('Failed to download the calendar image.', error);
+    } finally {
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
+    }
   };
 
   return (

--- a/packages/web/src/i18n/en.ts
+++ b/packages/web/src/i18n/en.ts
@@ -9,6 +9,7 @@ const resources: Resources = {
   author: 'Kuroné Kito',
   calendar:
     'The following live streaming schedule is automatically generated based on information extracted from the Calendar app eight times daily.',
+  downloadCalendar: 'Save the schedule calendar as an image',
   hamburgerMenu: 'Menu',
   heroAbout: 'About Kuroné Kito',
   heroIntroduction: 'Kuroné Kito’s introduction',

--- a/packages/web/src/i18n/ja.ts
+++ b/packages/web/src/i18n/ja.ts
@@ -9,6 +9,7 @@ const resources: Resources = {
   author: '黒音キト',
   calendar:
     '以下の配信スケジュールは、カレンダー アプリから毎日 8 回抽出した情報に基づき、自動生成しております。',
+  downloadCalendar: 'スケジュール表を画像として保存',
   hamburgerMenu: 'メニュー',
   heroAbout: '黒音キトについて',
   heroIntroduction: '黒音キトの自己紹介',

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -12,6 +12,7 @@ export type ResourcesKeys =
   | 'avatarMomoneko'
   | 'avatarNext'
   | 'calendar'
+  | 'downloadCalendar'
   | 'hamburgerMenu'
   | 'heroAbout'
   | 'heroIntroduction'

--- a/packages/web/src/modules/downloadFilename.test.ts
+++ b/packages/web/src/modules/downloadFilename.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calendarDownloadFilename,
+  extensionFromBlobType,
+} from './downloadFilename.js';
+
+describe('extensionFromBlobType', () => {
+  it.each([
+    ['image/webp', 'webp'],
+    ['image/png', 'png'],
+  ] as const)('%s -> "%s"', (blobType, expected) =>
+    expect(extensionFromBlobType(blobType)).toBe(expected),
+  );
+
+  it('falls back to png for an unexpected blob type', () =>
+    expect(extensionFromBlobType('image/jpeg')).toBe('png'));
+});
+
+describe('calendarDownloadFilename', () => {
+  it('builds a webp filename from the displayed range', () =>
+    expect(calendarDownloadFilename('08/10', '08/16', 'image/webp')).toBe(
+      'schedule-08-10-08-16.webp',
+    ));
+
+  it('builds a png filename from the displayed range', () =>
+    expect(calendarDownloadFilename('08/10', '08/16', 'image/png')).toBe(
+      'schedule-08-10-08-16.png',
+    ));
+});

--- a/packages/web/src/modules/downloadFilename.ts
+++ b/packages/web/src/modules/downloadFilename.ts
@@ -1,0 +1,31 @@
+/** The image MIME type produced when the browser can encode WebP. */
+const WEBP_TYPE = 'image/webp';
+
+/**
+ * Decides the file extension from the produced blob's MIME type.
+ *
+ * Safari cannot encode WebP, so a WebP request there still yields a
+ * `image/png` blob; deciding from `blob.type` (rather than the
+ * requested format) keeps the downloaded filename honest either way.
+ * @param blobType The MIME type reported by the captured blob.
+ * @returns `'webp'` for a WebP blob, `'png'` for everything else.
+ */
+export const extensionFromBlobType = (blobType: string): 'png' | 'webp' =>
+  blobType === WEBP_TYPE ? 'webp' : 'png';
+
+/**
+ * Builds the download filename for the captured schedule calendar.
+ * @param since The displayed range's start date, as shown in the UI.
+ * @param until The displayed range's end date, as shown in the UI.
+ * @param blobType The MIME type reported by the captured blob.
+ * @returns The filename, e.g. `schedule-08-10-08-16.webp`.
+ */
+export const calendarDownloadFilename = (
+  since: string,
+  until: string,
+  blobType: string,
+): string => {
+  const slug = (value: string): string => value.replaceAll('/', '-');
+  const extension = extensionFromBlobType(blobType);
+  return `schedule-${slug(since)}-${slug(until)}.${extension}`;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@solidjs/start':
         specifier: ^1.0.11
         version: 1.0.11(@testing-library/jest-dom@6.6.3)(solid-js@1.9.4)(vinxi@0.5.1(@types/node@22.13.1)(db0@0.2.3)(ioredis@5.4.2)(jiti@2.4.2)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(vite@6.0.11(@types/node@22.13.1)(jiti@2.4.2)(terser@5.37.0)(yaml@2.7.0))
+      '@zumer/snapdom':
+        specifier: ^2.24.1
+        version: 2.24.1
       solid-icons:
         specifier: ^1.1.0
         version: 1.1.0(solid-js@1.9.4)
@@ -2549,6 +2552,9 @@ packages:
 
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
+
+  '@zumer/snapdom@2.24.1':
+    resolution: {integrity: sha512-COYwb8hczQeevjyOSsTVT4P7CtKYtitXirmMbe/q4bkkULZdMHFFqmNDrlzeWPi5XBmk8+/ZBkNPWV/NX9LqtA==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -8164,13 +8170,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@kesills/eslint-config-airbnb-typescript@20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@kesills/eslint-config-airbnb-typescript@20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@stylistic/eslint-plugin': 2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.2)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
     optionalDependencies:
       typescript: 5.7.3
 
@@ -8194,14 +8200,14 @@ snapshots:
       '@eslint/js': 9.19.0
       '@eslint/json': 0.9.1
       '@eslint/markdown': 6.2.2
-      '@kesills/eslint-config-airbnb-typescript': 20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
+      '@kesills/eslint-config-airbnb-typescript': 20.0.0(@stylistic/eslint-plugin@2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@stylistic/eslint-plugin': 2.13.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
       eslint-config-prettier: 9.1.0(eslint@9.19.0(jiti@2.4.2))
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
       eslint-plugin-editorconfig: 4.0.3
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2))
       eslint-plugin-jsdoc: 50.6.3(eslint@9.19.0(jiti@2.4.2))
@@ -9480,6 +9486,8 @@ snapshots:
       tinyrainbow: 2.0.0
 
   '@zeit/schemas@2.36.0': {}
+
+  '@zumer/snapdom@2.24.1': {}
 
   JSONStream@1.3.5:
     dependencies:
@@ -10763,7 +10771,7 @@ snapshots:
       eslint: 9.19.0(jiti@2.4.2)
       semver: 7.7.1
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.19.0(jiti@2.4.2)
@@ -10800,7 +10808,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@9.4.0)
@@ -10816,14 +10824,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10853,7 +10861,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Adds a download button below the schedule calendar (`#calendar`) so
visitors can save the currently displayed schedule as an image for
sharing.

- New `packages/web/src/modules/downloadFilename.ts`: pure functions
  that decide the file extension from the captured blob's real MIME
  type (`image/webp` → `webp`, else `png` — covers Safari's automatic
  webp→png fallback) and build the `schedule-{since}-{until}.{ext}`
  filename from the displayed range.
- New `packages/web/src/components/atoms/DownloadCalendarButton.tsx`:
  a daisyUI button atom with a download icon and an i18n label,
  mirroring the existing `HamburgerButton.tsx` atom shape.
- `packages/web/src/components/organisms/Calendar.tsx`: forwards a
  `ref` to the calendar molecule (it already accepted one; only the
  organism needed to wire it) and renders the new button below the
  calendar, outside `#calendar`. The click handler dynamically
  `import()`s `@zumer/snapdom` (never a top-level import, so SSR and
  the static build never evaluate it), captures the calendar element
  at 2x scale with fonts embedded, and triggers a browser download.
- `packages/web/src/i18n/{types,ja,en}.ts`: one new label key in both
  locales.
- `packages/web/package.json`: adds `@zumer/snapdom` (`^2.24.1`, the
  current npm `latest` — the issue's `v2.16` reference was stale).

## Verification

- `pnpm run lint` (eslint, oxlint, prettier, stylelint, cspell,
  markdownlint) passes clean.
- `pnpm run test` passes (58 tests in `packages/web`, including three
  new files: pure-function unit tests, an atom test, and an organism
  test that mocks `@zumer/snapdom` and asserts the captured element,
  the computed filename, and the triggered download).
- A full production build (`pnpm run build`) succeeds; the
  prerendered `dist/index.html` was inspected to confirm the button
  renders exactly once, structurally after `#calendar`'s closing tag
  (not nested inside the captured element).
- The credential-free build check from #130's local-verification hint
  also succeeds: stub `packages/web/src/data.json`, run
  `prebuild:manifest` + `prebuild:yaml` (both credential-free), then
  `pnpm exec vinxi build` directly — bypassing `prebuild:fetcher` (and
  therefore any dependency on Google Calendar credentials), since
  `pnpm exec` (unlike `pnpm run build`) does not trigger the workspace's
  automatic `prebuild` hook.
- `grep -rn "@zumer/snapdom" packages/web/src` shows only the dynamic
  `import()` call site and the test's `vi.mock`, never a static
  top-level import.

## Out of scope (per the issue)

Pixel fidelity (fonts, container-query rendering) and real-Safari
webp→png fallback behavior are not asserted by CI — no E2E harness
exists in this repo, and this change was not manually verified in a
live browser. Per the issue's own scope note, that manual check is
left to a human before/after merge.

Closes #135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the option to download the displayed calendar as a WebP image.
  * Downloaded files use date-based filenames and appropriate image extensions.
  * Added accessible download button labeling in English and Japanese.

* **Tests**
  * Added coverage for calendar image generation, downloads, filenames, and button interactions.
  * Added Storybook documentation for the download button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->