### PR TITLE
fix(web): stop the splash overlay from covering content without javascript

### DIFF
--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -77,11 +77,12 @@
 /*
  * The splash overlay fails closed: it stays hidden unless the
  * `splash-visible` animation is actively running, so a visitor gets
- * page content whenever the animation cannot run at all (stripped
- * CSS, an unsupported browser, or a `prefers-reduced-motion: reduce`
- * request below) rather than a permanently stuck overlay -- with or
- * without JavaScript. The 3s duration matches `DURATION` in
- * `organisms/Splash.tsx`; keep both in sync if either changes.
+ * page content whenever the animation cannot run at all (an
+ * unsupported browser, CSS animations disabled, or a
+ * `prefers-reduced-motion: reduce` request below) rather than a
+ * permanently stuck overlay -- with or without JavaScript. Unlike the
+ * former JS-timed version, this CSS owns the full 3s window itself;
+ * there is no separate JS constant to keep in sync anymore.
  */
 .splash-overlay {
   visibility: hidden;

--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -73,3 +73,30 @@
     --splash-logo-scale: 5vmax;
   }
 }
+
+/*
+ * The splash overlay fails closed: it stays hidden unless the
+ * `splash-visible` animation is actively running, so a visitor gets
+ * page content whenever the animation cannot run at all (stripped
+ * CSS, an unsupported browser, or a `prefers-reduced-motion: reduce`
+ * request below) rather than a permanently stuck overlay -- with or
+ * without JavaScript. The 3s duration matches `DURATION` in
+ * `organisms/Splash.tsx`; keep both in sync if either changes.
+ */
+.splash-overlay {
+  visibility: hidden;
+  animation: splash-visible 3s;
+}
+
+@keyframes splash-visible {
+  from,
+  to {
+    visibility: visible;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splash-overlay {
+    animation: none;
+  }
+}

--- a/packages/web/src/components/molecules/Splash.test.tsx
+++ b/packages/web/src/components/molecules/Splash.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Splash } from './Splash.js';
+
+afterEach(() => cleanup());
+
+describe('Splash molecule', () => {
+  it('renders the splash-overlay class that owns visibility and timing in CSS', () => {
+    const { container } = render(() => <Splash label="Loading" />);
+    const section = container.querySelector('section');
+    expect(section).toHaveClass('splash-overlay');
+  });
+
+  it('announces itself as a status region with the given label', () => {
+    const { container } = render(() => <Splash label="Loading the website" />);
+    const section = container.querySelector('section');
+    expect(section).toHaveAttribute('role', 'status');
+    expect(section).toHaveAttribute('aria-label', 'Loading the website');
+  });
+
+  it('pauses the logo animation until the animation prop is enabled', () => {
+    const { container } = render(() => <Splash label="Loading" />);
+    const logo = container.querySelector(
+      '.animate-\\[splash-logo-scale_1\\.5s_ease-in_1\\.5s\\]',
+    );
+    expect(logo).toHaveClass('[animation-play-state:paused]');
+    expect(logo).not.toHaveClass('[animation-play-state:running]');
+  });
+
+  it('runs the logo animation once the animation prop is enabled', () => {
+    const { container } = render(() => <Splash animation label="Loading" />);
+    const logo = container.querySelector(
+      '.animate-\\[splash-logo-scale_1\\.5s_ease-in_1\\.5s\\]',
+    );
+    expect(logo).toHaveClass('[animation-play-state:running]');
+    expect(logo).not.toHaveClass('[animation-play-state:paused]');
+  });
+});

--- a/packages/web/src/components/molecules/Splash.test.tsx
+++ b/packages/web/src/components/molecules/Splash.test.tsx
@@ -8,12 +8,14 @@ describe('Splash molecule', () => {
   it('renders the splash-overlay class that owns visibility and timing in CSS', () => {
     const { container } = render(() => <Splash label="Loading" />);
     const section = container.querySelector('section');
+    expect(section).not.toBeNull();
     expect(section).toHaveClass('splash-overlay');
   });
 
   it('announces itself as a status region with the given label', () => {
     const { container } = render(() => <Splash label="Loading the website" />);
     const section = container.querySelector('section');
+    expect(section).not.toBeNull();
     expect(section).toHaveAttribute('role', 'status');
     expect(section).toHaveAttribute('aria-label', 'Loading the website');
   });
@@ -23,6 +25,7 @@ describe('Splash molecule', () => {
     const logo = container.querySelector(
       '.animate-\\[splash-logo-scale_1\\.5s_ease-in_1\\.5s\\]',
     );
+    expect(logo).not.toBeNull();
     expect(logo).toHaveClass('[animation-play-state:paused]');
     expect(logo).not.toHaveClass('[animation-play-state:running]');
   });
@@ -32,6 +35,7 @@ describe('Splash molecule', () => {
     const logo = container.querySelector(
       '.animate-\\[splash-logo-scale_1\\.5s_ease-in_1\\.5s\\]',
     );
+    expect(logo).not.toBeNull();
     expect(logo).toHaveClass('[animation-play-state:running]');
     expect(logo).not.toHaveClass('[animation-play-state:paused]');
   });

--- a/packages/web/src/components/molecules/Splash.tsx
+++ b/packages/web/src/components/molecules/Splash.tsx
@@ -17,7 +17,7 @@ export interface SplashProps {
 export const Splash: Component<SplashProps> = (props) => (
   <section
     aria-label={props.label}
-    class="absolute h-[100lvh] w-[100lvw]"
+    class="splash-overlay absolute h-[100lvh] w-[100lvw]"
     role="status"
   >
     <div class="bg-base-300 relative z-50 flex h-[100lvh] items-center justify-center overflow-hidden">

--- a/packages/web/src/components/molecules/Splash.tsx
+++ b/packages/web/src/components/molecules/Splash.tsx
@@ -11,6 +11,13 @@ export interface SplashProps {
 
 /**
  * The splash component.
+ *
+ * `role="status"` is intentional, not decorative: the `splash-overlay`
+ * class in `app.css` only ever shows this section for a genuine
+ * ~3 s transient (or never at all, e.g. under
+ * `prefers-reduced-motion: reduce`), so a screen reader user who does
+ * encounter it is hearing an accurate, short-lived loading
+ * announcement rather than a misused live region over static content.
  * @param props The properties.
  * @returns The component.
  */

--- a/packages/web/src/components/organisms/Splash.tsx
+++ b/packages/web/src/components/organisms/Splash.tsx
@@ -3,7 +3,13 @@ import { createSignal, onMount } from 'solid-js';
 import { Splash as MoleculesSplash } from '../molecules/Splash.js';
 import { useTranslator } from '../../modules/createI18N.js';
 
-/** The duration of the splash animation. */
+/**
+ * The duration of the splash overlay, in milliseconds.
+ *
+ * Documents the value only -- the overlay's actual visible window is
+ * driven by the `splash-visible` CSS animation on `.splash-overlay` in
+ * `app.css`. Keep both in sync if either changes.
+ */
 export const DURATION = 3_000;
 
 /**

--- a/packages/web/src/components/organisms/Splash.tsx
+++ b/packages/web/src/components/organisms/Splash.tsx
@@ -4,15 +4,6 @@ import { Splash as MoleculesSplash } from '../molecules/Splash.js';
 import { useTranslator } from '../../modules/createI18N.js';
 
 /**
- * The duration of the splash overlay, in milliseconds.
- *
- * Documents the value only -- the overlay's actual visible window is
- * driven by the `splash-visible` CSS animation on `.splash-overlay` in
- * `app.css`. Keep both in sync if either changes.
- */
-export const DURATION = 3_000;
-
-/**
  * The splash component.
  * @returns The component.
  */

--- a/packages/web/src/components/template/RootTemplate.tsx
+++ b/packages/web/src/components/template/RootTemplate.tsx
@@ -1,33 +1,30 @@
-import { createMediaQuery } from '@solid-primitives/media';
 import { MetaProvider } from '@solidjs/meta';
 import type { RouteSectionProps } from '@solidjs/router';
 import type { Component } from 'solid-js';
-import { createSignal, onMount, Show, Suspense } from 'solid-js';
+import { onMount, Suspense } from 'solid-js';
 import { themeChange } from 'theme-change';
 import { Footer } from '../organisms/Footer.js';
 import { Head } from '../organisms/Head.js';
 import { Navbar } from '../organisms/Navbar.js';
-import { DURATION, Splash } from '../organisms/Splash.js';
+import { Splash } from '../organisms/Splash.js';
 
 /**
  * The root template component.
+ *
+ * The splash overlay always renders here; `app.css`'s `splash-overlay`
+ * class owns its visibility and 3s timing (including the
+ * `prefers-reduced-motion` fallback) so the behavior is identical with
+ * or without JavaScript -- see #159.
  * @param props The properties.
  * @returns The component.
  */
 export const RootTemplate: Component<RouteSectionProps> = (props) => {
-  const reduceMotion = createMediaQuery('(prefers-reduced-motion: reduce)');
-  const [isSplash, setSplash] = createSignal<boolean>(!reduceMotion());
-  onMount(() => {
-    themeChange(false);
-    setTimeout(() => setSplash(false), DURATION);
-  });
+  onMount(() => themeChange(false));
   return (
     <MetaProvider>
       <Head />
       <Navbar />
-      <Show when={isSplash()}>
-        <Splash />
-      </Show>
+      <Splash />
       <Suspense>
         <main>
           {props.children}

--- a/packages/web/src/components/template/RootTemplate.tsx
+++ b/packages/web/src/components/template/RootTemplate.tsx
@@ -13,8 +13,11 @@ import { Splash } from '../organisms/Splash.js';
  *
  * The splash overlay always renders here; `app.css`'s `splash-overlay`
  * class owns its visibility and 3s timing (including the
- * `prefers-reduced-motion` fallback) so the behavior is identical with
- * or without JavaScript -- see #159.
+ * `prefers-reduced-motion` fallback), so that timing is identical with
+ * or without JavaScript -- see #159. The logo's own entrance animation
+ * (`organisms/Splash.tsx`) still gates on client mount and stays paused
+ * without JavaScript; only the overlay's visibility/timing is unified
+ * here.
  * @param props The properties.
  * @returns The component.
  */


### PR DESCRIPTION
## Summary

The splash overlay used to depend on `createMediaQuery('(prefers-reduced-motion: reduce)')`, which has no `window` server-side and always resolves to `false` there. That made `isSplash` default to `true` on the server, so the full-viewport overlay was baked visible into the prerendered HTML for `/`, `/ja/`, and `/en/`. The only thing that ever cleared it was a client-side `setTimeout`, so it stayed on screen **permanently** for visitors without JavaScript, and `prefers-reduced-motion` only took effect after hydration — too late for the already-painted artifact.

This PR moves the overlay's visibility and timing entirely into CSS:

- `packages/web/src/components/template/RootTemplate.tsx` now renders `<Splash />` unconditionally — no signal, no `Show`, no `createMediaQuery` read.
- `packages/web/src/app.css` adds a `.splash-overlay` rule that defaults to `visibility: hidden` and is shown only while the `splash-visible` animation runs (`from`/`to` both `visible`, 3s duration — matching the prior JS `DURATION`). Because the base rule is `hidden` and the animation is what reveals it, this **fails closed**: if the animation can't run for any reason (unsupported browser, animations disabled, or a `prefers-reduced-motion: reduce` request, handled below via `animation: none`), the visitor gets content, never a stuck overlay.
- `packages/web/src/components/molecules/Splash.tsx` gets a stable `splash-overlay` class hook, and a doc comment justifying why `role="status"`/`aria-label` stay unchanged: the region now only ever mounts for a genuine ~3s transient (or never, under reduced motion), so it's an accurate loading announcement rather than a decorative region misusing a live-region role.
- `packages/web/src/components/organisms/Splash.tsx` drops the now-dead `DURATION` export (CSS is the sole timing source now).
- New test: `packages/web/src/components/molecules/Splash.test.tsx` covers the JS-verifiable static surface (the `splash-overlay` class, `role`/`aria-label`, and the existing mount-gated logo `animation-play-state` toggle).

One deliberate behavioral note: under this design, a no-JS visitor now sees the splash for the same ~3s window as a JS visitor, then content — rather than the old (broken) behavior of no-JS visitors never losing the overlay. This is the strongest reading of "keep the splash's appearance and timing unchanged": JS and no-JS visitors behave identically instead of diverging, and the background's stated bug ("permanently covered") is what's fixed.

An earlier draft of this fix tried the opposite approach (JS signal starting `false`, content-first, splash introduced by `onMount`) but a self-review caught that it would make the splash pop in *over* already-painted content for ordinary JS visitors, and that the client-only timing it depended on isn't exercisable under `@solid-primitives/media`'s hydration code path in `vitest`/`jsdom`. The CSS-first design in this PR avoids both problems and is explicitly one of the two mechanisms the issue itself proposed.

## Verification

- `pnpm run lint` and `pnpm run test` pass.
- Full production build (`pnpm run build`), then inspected the built output directly:
  - All three prerendered pages (`dist/index.html`, `dist/ja/index.html`, `dist/en/index.html`) contain `<section ... class="splash-overlay absolute h-[100lvh] w-[100lvw]" role="status" aria-label="...">` with the correct per-locale label (`ウェブサイトを読み込み中` / `ウェブサイトを読み込み中` / `Loading the website`).
  - The built CSS (`dist/_server/assets/app-*.css`) contains exactly:
    ```css
    .splash-overlay{animation:splash-visible 3s;visibility:hidden}
    @keyframes splash-visible{0%,to{visibility:visible}}
    @media (prefers-reduced-motion:reduce){.splash-overlay{animation:none}}
    ```
- Live browser check (headless Chromium via Playwright, served the built `dist/`), sampling `getComputedStyle('.splash-overlay').visibility` over time, with forced compositor frames since headless mode otherwise doesn't tick the animation timeline:
  - **Normal** (JS enabled, no reduced-motion): `visible` at t=0 and t=1.5s, flips to `hidden` between t=1.5s and t=2.9s (i.e. at the 3s mark), stays `hidden` through t=3.5s. Confirmed via `element.getAnimations()` in a separate run: `currentTime` progresses from ~83ms to ~2533ms then the animation list becomes empty (completed) right around 3000ms of document-timeline time, at which point `visibility` reads `hidden`.
  - **Reduced motion** (`prefers-reduced-motion: reduce` emulated): `hidden` at t=0, t=0.5s, t=1.5s, and t=3.5s — no splash frame at any point, matching the issue's acceptance criterion.
  - **No JavaScript** (`javaScriptEnabled: false`): confirmed the page renders real content (body text length 2784, i.e. not a blank/broken page) and the splash is `visible` at t=0, matching the same CSS rule set proven above under JS. The harness could not force compositor frames to observe the later transition in this specific no-JS browser context (a Playwright/headless limitation, not a behavioral difference — CSS animations execute identically regardless of `javaScriptEnabled`, which only gates script execution), so the later-timing part of this state is verified by construction (same `.splash-overlay` CSS rule, proven to transition to `hidden` at 3s under the JS-enabled run above) rather than directly observed in this specific browser context.

Closes #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the splash screen to display through CSS-controlled timing.
  - Added fail-closed visibility behavior so the splash remains hidden outside its active display period.
  - Improved reduced-motion support by disabling splash animations when preferred.
  - Ensured the splash status region and logo animation behavior remain accessible and consistent.

- **Tests**
  - Added coverage for splash visibility, timing, accessibility attributes, and animation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->