### PR TITLE
fix(seo): give each prerendered locale its own language, canonical, and alternates

### DIFF
--- a/packages/web/src/components/atoms/meta/LinkList.test.tsx
+++ b/packages/web/src/components/atoms/meta/LinkList.test.tsx
@@ -79,4 +79,52 @@ describe('LinkList', () => {
       '/site.webmanifest',
     );
   });
+
+  it('renders no canonical or alternate links when unset', () => {
+    render(() => (
+      <MetaProvider>
+        <LinkList />
+      </MetaProvider>
+    ));
+    expect(document.head.querySelector('link[rel="canonical"]')).toBeNull();
+    expect(document.head.querySelector('link[rel="alternate"]')).toBeNull();
+  });
+
+  it('renders the canonical link when provided', () => {
+    render(() => (
+      <MetaProvider>
+        <LinkList canonicalUrl="https://kit.black/en/" />
+      </MetaProvider>
+    ));
+    expect(
+      document.head.querySelector('link[rel="canonical"]'),
+    ).toHaveAttribute('href', 'https://kit.black/en/');
+  });
+
+  it('renders one alternate link per entry, each with its own hreflang', () => {
+    render(() => (
+      <MetaProvider>
+        <LinkList
+          alternates={[
+            { hreflang: 'ja', href: 'https://kit.black/ja/' },
+            { hreflang: 'en', href: 'https://kit.black/en/' },
+            { hreflang: 'x-default', href: 'https://kit.black/' },
+          ]}
+        />
+      </MetaProvider>
+    ));
+    const alternates = document.head.querySelectorAll('link[rel="alternate"]');
+    expect(alternates).toHaveLength(3);
+    expect(document.head.querySelector('link[hreflang="ja"]')).toHaveAttribute(
+      'href',
+      'https://kit.black/ja/',
+    );
+    expect(document.head.querySelector('link[hreflang="en"]')).toHaveAttribute(
+      'href',
+      'https://kit.black/en/',
+    );
+    expect(
+      document.head.querySelector('link[hreflang="x-default"]'),
+    ).toHaveAttribute('href', 'https://kit.black/');
+  });
 });

--- a/packages/web/src/components/atoms/meta/LinkList.tsx
+++ b/packages/web/src/components/atoms/meta/LinkList.tsx
@@ -2,13 +2,28 @@ import { Link } from '@solidjs/meta';
 import type { Component } from 'solid-js';
 import { Index, Show } from 'solid-js';
 
+/** A single `hreflang` alternate-language link. */
+export interface AlternateLink {
+  /** The `hreflang` value, e.g. `"ja"`, `"en"`, or `"x-default"`. */
+  readonly hreflang: string;
+
+  /** The absolute URL of the alternate-language page. */
+  readonly href: string;
+}
+
 /** Type definition for the properties. */
 export interface LinkListProps {
   /** The apple-touch-icon URL. */
   readonly appleTouchIconUrl?: string | undefined;
 
+  /** The `hreflang` alternate-language links. */
+  readonly alternates?: readonly AlternateLink[] | undefined;
+
   /** The author URL. */
   readonly authorUrl?: string | undefined;
+
+  /** The canonical URL of the page. */
+  readonly canonicalUrl?: string | undefined;
 
   /** The 16x16 PNG favicon URL. */
   readonly icon16Url?: string | undefined;
@@ -45,6 +60,9 @@ export const LinkList: Component<LinkListProps> = (props) => (
     <Show when={props.authorUrl}>
       {(href) => <Link href={href()} rel="author" />}
     </Show>
+    <Show when={props.canonicalUrl}>
+      {(href) => <Link href={href()} rel="canonical" />}
+    </Show>
     <Show when={props.iconIcoUrl}>
       {(href) => <Link href={href()} rel="icon" sizes="16x16 32x32 48x48" />}
     </Show>
@@ -68,6 +86,15 @@ export const LinkList: Component<LinkListProps> = (props) => (
       {(href) => <Link href={href()} hreflang="en" rel="license" />}
     </Show>
     <Show when={props.next}>{(href) => <Link href={href()} rel="next" />}</Show>
+    <Index each={props.alternates}>
+      {(alternate) => (
+        <Link
+          href={alternate().href}
+          hreflang={alternate().hreflang}
+          rel="alternate"
+        />
+      )}
+    </Index>
     <Index each={props.preloadImages}>
       {(image) => <Link as="image" href={image()} rel="preload" />}
     </Index>

--- a/packages/web/src/components/atoms/meta/MetaList.test.tsx
+++ b/packages/web/src/components/atoms/meta/MetaList.test.tsx
@@ -1,0 +1,31 @@
+import { MetaProvider } from '@solidjs/meta';
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MetaList } from './MetaList.js';
+
+afterEach(() => {
+  cleanup();
+  document.head.innerHTML = '';
+});
+
+describe('MetaList', () => {
+  it('emits a correctly-spelled referrer meta tag', () => {
+    render(() => (
+      <MetaProvider>
+        <MetaList />
+      </MetaProvider>
+    ));
+    expect(
+      document.head.querySelector('meta[name="referrer"]'),
+    ).toHaveAttribute('content', 'strict-origin-when-cross-origin');
+  });
+
+  it('never emits the misspelled referer meta tag', () => {
+    render(() => (
+      <MetaProvider>
+        <MetaList />
+      </MetaProvider>
+    ));
+    expect(document.head.querySelector('meta[name="referer"]')).toBeNull();
+  });
+});

--- a/packages/web/src/components/atoms/meta/MetaList.tsx
+++ b/packages/web/src/components/atoms/meta/MetaList.tsx
@@ -48,7 +48,7 @@ export const MetaList: Component<MetaListProps> = (props) => (
     <Show when={props.keywords}>
       <Meta name="keywords" content={props.keywords} />
     </Show>
-    <Meta name="referer" content="strict-origin-when-cross-origin" />
+    <Meta name="referrer" content="strict-origin-when-cross-origin" />
     <Show when={props.colorLight}>
       <Meta
         name="theme-color"

--- a/packages/web/src/components/atoms/meta/XCard.test.tsx
+++ b/packages/web/src/components/atoms/meta/XCard.test.tsx
@@ -56,4 +56,18 @@ describe('XCard', () => {
       document.head.querySelector('meta[name="twitter:image:alt"]'),
     ).toBeNull();
   });
+
+  it('never emits twitter:author, even when author is set', () => {
+    render(() => (
+      <MetaProvider>
+        <XCard author="Example Author" siteName="Example" />
+      </MetaProvider>
+    ));
+    expect(
+      document.head.querySelector('meta[name="twitter:author"]'),
+    ).toBeNull();
+    expect(
+      document.head.querySelector('meta[name="twitter:creator"]'),
+    ).toHaveAttribute('content', 'Example Author');
+  });
 });

--- a/packages/web/src/components/atoms/meta/XCard.test.tsx
+++ b/packages/web/src/components/atoms/meta/XCard.test.tsx
@@ -70,4 +70,15 @@ describe('XCard', () => {
       document.head.querySelector('meta[name="twitter:creator"]'),
     ).toHaveAttribute('content', 'Example Author');
   });
+
+  it('does not emit twitter:creator when author is unset', () => {
+    render(() => (
+      <MetaProvider>
+        <XCard siteName="Example" />
+      </MetaProvider>
+    ));
+    expect(
+      document.head.querySelector('meta[name="twitter:creator"]'),
+    ).toBeNull();
+  });
 });

--- a/packages/web/src/components/atoms/meta/XCard.tsx
+++ b/packages/web/src/components/atoms/meta/XCard.tsx
@@ -46,9 +46,6 @@ export const XCard: Component<XCardProps> = (props) => (
     <Show when={props.image && props.imageAlt}>
       <Meta name="twitter:image:alt" content={props.imageAlt} />
     </Show>
-    <Show when={props.author}>
-      <Meta name="twitter:author" content={props.author} />
-    </Show>
     <Show
       fallback={<Meta name="twitter:title" content={props.siteName} />}
       when={props.title}

--- a/packages/web/src/components/organisms/Head.test.tsx
+++ b/packages/web/src/components/organisms/Head.test.tsx
@@ -1,0 +1,107 @@
+import { MetaProvider } from '@solidjs/meta';
+import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router';
+import { cleanup, render } from '@solidjs/testing-library';
+import { Suspense } from 'solid-js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Head } from './Head.js';
+
+afterEach(() => {
+  cleanup();
+  document.head.innerHTML = '';
+});
+
+/**
+ * Renders {@link Head} under a `MemoryRouter` initialized at the given
+ * path, matched against the same `:language?` route param the app's
+ * real `[[language]]` route uses. The `Suspense` boundary mirrors
+ * `RootTemplate`'s real tree.
+ *
+ * This still logs a harmless `computations created outside a
+ * \`createRoot\` or \`render\` will never be disposed` warning to
+ * stderr: `@solidjs/router`'s route-matching schedules a computation
+ * via a microtask that resolves after `render`'s synchronous owner
+ * scope has already exited. It does not affect any assertion below --
+ * confirmed by isolating every other piece of this component tree
+ * (bare `useLocation`, `useTranslator`, `<Title>`, and `LinkList`
+ * alone) under the same `MemoryRouter`/`MetaProvider`/`Suspense`
+ * wrapping without reproducing it, so it is specific to `@solidjs/router`
+ * internals rather than this test's structure or `Head`'s own logic.
+ * @param path The initial memory-history location.
+ * @returns The `render` result.
+ */
+const renderHead = (path: string) => {
+  const history = createMemoryHistory();
+  history.set({ value: path, replace: true });
+  return render(() => (
+    <MetaProvider>
+      <MemoryRouter history={history}>
+        <Suspense>
+          <Route path="/:language?" component={Head} />
+        </Suspense>
+      </MemoryRouter>
+    </MetaProvider>
+  ));
+};
+
+describe('organisms/Head', () => {
+  it('declares the ja OGP locale on the /ja/ page', () => {
+    renderHead('/ja/');
+    expect(
+      document.head.querySelector('meta[property="og:locale"]'),
+    ).toHaveAttribute('content', 'ja_JP');
+  });
+
+  it('declares the en OGP locale on the /en/ page', () => {
+    renderHead('/en/');
+    expect(
+      document.head.querySelector('meta[property="og:locale"]'),
+    ).toHaveAttribute('content', 'en_US');
+  });
+
+  it('falls back to the ja OGP locale on the unprefixed root', () => {
+    renderHead('/');
+    expect(
+      document.head.querySelector('meta[property="og:locale"]'),
+    ).toHaveAttribute('content', 'ja_JP');
+  });
+
+  it('declares a canonical link and og:url matching the current page', () => {
+    renderHead('/en/');
+    expect(
+      document.head.querySelector('link[rel="canonical"]'),
+    ).toHaveAttribute('href', 'https://kit.black/en/');
+    expect(
+      document.head.querySelector('meta[property="og:url"]'),
+    ).toHaveAttribute('content', 'https://kit.black/en/');
+  });
+
+  it('declares a distinct canonical link and og:url per page', () => {
+    renderHead('/ja/');
+    expect(
+      document.head.querySelector('link[rel="canonical"]'),
+    ).toHaveAttribute('href', 'https://kit.black/ja/');
+    expect(
+      document.head.querySelector('meta[property="og:url"]'),
+    ).toHaveAttribute('content', 'https://kit.black/ja/');
+  });
+
+  it('emits ja, en, and x-default hreflang alternates on every page', () => {
+    renderHead('/en/');
+    // `link[hreflang="en"]` alone would also match the unrelated
+    // `rel="license"` link (see `LinkList.tsx`), so scope every selector
+    // to `rel="alternate"` as well.
+    const alternates = document.head.querySelectorAll('link[rel="alternate"]');
+    expect(alternates).toHaveLength(3);
+    expect(
+      document.head.querySelector('link[rel="alternate"][hreflang="ja"]'),
+    ).toHaveAttribute('href', 'https://kit.black/ja/');
+    expect(
+      document.head.querySelector('link[rel="alternate"][hreflang="en"]'),
+    ).toHaveAttribute('href', 'https://kit.black/en/');
+    expect(
+      document.head.querySelector(
+        'link[rel="alternate"][hreflang="x-default"]',
+      ),
+    ).toHaveAttribute('href', 'https://kit.black/');
+  });
+});

--- a/packages/web/src/components/organisms/Head.tsx
+++ b/packages/web/src/components/organisms/Head.tsx
@@ -1,10 +1,16 @@
+import { useLocation } from '@solidjs/router';
 import type { Component } from 'solid-js';
+import { createMemo } from 'solid-js';
 import constants from '../../constants.json';
-import { useTranslator } from '../../modules/createI18N.js';
+import { useLanguage, useTranslator } from '../../modules/createI18N.js';
+import { useLanguageHref } from '../../modules/useLanguageHref.js';
 import { Head as InternalHead } from '../molecules/Head.js';
 
 /** The images for the Open Graph protocol. */
 const images = [constants.favicon.url] as const;
+
+/** The OGP `og:locale` value (`language_TERRITORY`) for each language. */
+const ogLocales = { en: 'en_US', ja: 'ja_JP' } as const;
 
 /**
  * The head metadata component.
@@ -12,11 +18,28 @@ const images = [constants.favicon.url] as const;
  */
 export const Head: Component = () => {
   const t = useTranslator();
+  const language = useLanguage();
+  const location = useLocation();
+  const jaHref = useLanguageHref('ja');
+  const enHref = useLanguageHref('en');
+
+  /** The absolute URL of the current page. */
+  const pageUrl = createMemo(() => `${constants.site.url}${location.pathname}`);
+
+  /** The `hreflang` alternate-language links for the current page. */
+  const alternates = createMemo(() => [
+    { hreflang: 'ja', href: `${constants.site.url}${jaHref()}` },
+    { hreflang: 'en', href: `${constants.site.url}${enHref()}` },
+    { hreflang: 'x-default', href: `${constants.site.url}/` },
+  ]);
+
   return (
     <InternalHead
+      alternates={alternates()}
       appleTouchIconUrl={constants.icons.appleTouchIcon}
       author={t('author')}
       authorUrl={constants.author.url}
+      canonicalUrl={pageUrl()}
       colorDark={constants.color.dark}
       colorLight={constants.color.light}
       description={t('siteDescription')}
@@ -29,13 +52,13 @@ export const Head: Component = () => {
       images={images}
       imageType={constants.favicon.type}
       imageWidth={constants.favicon.size}
-      language="ja"
+      language={ogLocales[language()]}
       licenseUrl={constants.licenseUrl}
       manifestUrl={constants.icons.manifest}
       next={undefined}
       prev={undefined}
       siteName={constants.site.name}
-      url={constants.site.url}
+      url={pageUrl()}
     />
   );
 };

--- a/packages/web/src/entry-server.tsx
+++ b/packages/web/src/entry-server.tsx
@@ -1,11 +1,33 @@
 // @refresh reload
 import { createHandler, StartServer } from '@solidjs/start/server';
+import { getRequestEvent } from 'solid-js/web';
+
+/** The fallback document language, matching the app's i18n fallback. */
+const FALLBACK_LANGUAGE = 'ja';
+
+/** Matches a leading `en`/`ja` locale path segment. */
+const localeSegment = /^\/?(en|ja)(?:\/|$)/;
+
+/**
+ * Resolves the document language from the current request path.
+ *
+ * The document shell renders outside the router, so `useLanguage()`
+ * isn't reachable here. `getRequestEvent()` is populated by the same
+ * synchronous SSR pass `StartServer` itself reads it in, so it is safe
+ * to read again here.
+ * @returns The resolved language code.
+ */
+const resolveLanguage = () => {
+  const event = getRequestEvent();
+  const pathname = event ? new URL(event.request.url).pathname : '';
+  return localeSegment.exec(pathname)?.[1] ?? FALLBACK_LANGUAGE;
+};
 
 /** The server handler. */
 export default createHandler(() => (
   <StartServer
     document={({ assets, children, scripts }) => (
-      <html>
+      <html lang={resolveLanguage()}>
         <head prefix="og: http://ogp.me/ns#">
           <meta charset="utf-8" />
           {assets}


### PR DESCRIPTION
## Summary

The site prerenders `/`, `/ja/`, and `/en/` but shipped one shared
document identity for all three. This PR gives each page its own:

- **Document language.** `entry-server.tsx` resolves `<html lang>`
  from the request path (`getRequestEvent()`, since the document shell
  renders outside the router), falling back to `ja` — the app's
  existing i18n default — for the unprefixed root.
- **OGP locale.** `organisms/Head.tsx` now derives `og:locale` from
  `useLanguage()` instead of the hardcoded `"ja"`, using OGP's own
  `language_TERRITORY` format (`ja_JP` / `en_US`) rather than the bare
  code the app previously emitted (which was already non-conformant on
  `/ja/`, not only wrong on `/en/`).
- **Canonical + `og:url`.** Both are now built from the current path
  (`useLocation()`) instead of the constant site root, so each
  prerendered page claims its own URL.
- **`hreflang` alternates.** Every page links to the `ja`/`en` variants
  plus `x-default`, reusing `modules/useLanguageHref.ts`. `LinkList.tsx`
  gained `canonicalUrl` and `alternates` props/rendering for this.
- **`referer` → `referrer`.** `MetaList.tsx`'s meta name was a typo
  (`referer` is the HTTP-header misspelling, not a valid meta name), so
  the referrer policy was inert.
- **Dropped `twitter:author`.** Not part of the Twitter Card
  vocabulary; `twitter:creator` (already emitted from the same prop)
  is the correct field.

## Evidence — built `/ja/` and `/en/` `<head>` (via `pnpm run build`)

`/ja/`:

```html
<html lang="ja">
...
<link href="https://kit.black/ja/" rel="canonical"/>
<meta property="og:url" content="https://kit.black/ja/"/>
<meta property="og:locale" content="ja_JP"/>
<link href="https://kit.black/ja/" hreflang="ja" rel="alternate"/>
<link href="https://kit.black/en/" hreflang="en" rel="alternate"/>
<link href="https://kit.black/" hreflang="x-default" rel="alternate"/>
<meta name="referrer" content="strict-origin-when-cross-origin"/>
```

`/en/`:

```html
<html lang="en">
...
<link href="https://kit.black/en/" rel="canonical"/>
<meta property="og:url" content="https://kit.black/en/"/>
<meta property="og:locale" content="en_US"/>
<link href="https://kit.black/ja/" hreflang="ja" rel="alternate"/>
<link href="https://kit.black/en/" hreflang="en" rel="alternate"/>
<link href="https://kit.black/" hreflang="x-default" rel="alternate"/>
<meta name="referrer" content="strict-origin-when-cross-origin"/>
```

No `name="referer"` or `twitter:author` tag remains anywhere in the
built output (verified by grep across all three built pages).

## Scope

Touches only `packages/web/src/entry-server.tsx`,
`components/organisms/Head.tsx`, and `components/atoms/meta/{LinkList,
MetaList, XCard}.tsx` plus their tests — matching roadmap #153's note
that "the metadata track owns `atoms/meta/*` exclusively." The
calendar's deliberate `lang="ja"`, `robots.txt`/`sitemap.xml`, and the
flag-emoji language switcher are all out of scope per the issue and
roadmap.

Closes #158

## Test plan

- [x] `pnpm run build`, then inspected the built `/`, `/ja/`, `/en/`
      `<head>` sections directly for every acceptance criterion (see
      evidence above).
- [x] `pnpm run lint`
- [x] `pnpm run test` (78 tests in `packages/web`, including new/updated
      coverage in `LinkList.test.tsx`, `XCard.test.tsx`, new
      `MetaList.test.tsx`, and new `organisms/Head.test.tsx`)

**Known test-harness caveat (not a defect):** `Head.test.tsx` logs a
harmless `computations created outside a createRoot or render will
never be disposed` warning to stderr on every test run. Traced to
`@solidjs/router`'s internal route-matching scheduling a computation
via microtask after the synchronous render owner scope exits (not to
this diff's own logic — isolated probes of the other pieces of this
component tree under the same test wrapping did not reproduce it). All
assertions pass; documented inline in the test file.
