### PR TITLE
fix(fetcher): guard toEventFactory against a missing/unparsable event end

### DIFF
--- a/packages/fetcher/src/parseEvent.mts
+++ b/packages/fetcher/src/parseEvent.mts
@@ -42,6 +42,15 @@ export const createVacationEventsFactory = (since: DateParsable) => {
 };
 
 /**
+ * Get the label used to identify an event in a skip warning.
+ * @param raw The raw event.
+ * @returns The event's trimmed summary, falling back to its id, or
+ * `'(unknown)'` if neither is available.
+ */
+const labelOf = (raw: calendar_v3.Schema$Event): string =>
+  raw.summary?.trim() || raw.id || '(unknown)';
+
+/**
  * create thee function that converts the raw event to the event.
  * @param type The type of the event.
  * @returns The function that converts the raw event to the event.
@@ -52,28 +61,38 @@ export const toEventFactory =
    * Convert the raw event to the event.
    *
    * `calendar_v3.Schema$Event.start` may have neither `dateTime` nor
-   * `date` set. Rather than throwing and failing the entire batch on
-   * one malformed event, this skips the event: it logs a warning to
-   * `stderr` naming the event so the drop is visible in the build log,
-   * and returns `undefined` so the caller can filter it out. A skipped
+   * `date` set, and a timed event's `end` is just as optional. Rather
+   * than throwing and failing the entire batch on one malformed event,
+   * this skips the event in either case: it logs a warning to `stderr`
+   * naming the event so the drop is visible in the build log, and
+   * returns `undefined` so the caller can filter it out. A skipped
    * event's date is no longer represented, so
    * {@link createVacationEventsFactory} may synthesize a vacation-day
    * placeholder for that date instead -- an accepted side effect of
    * skipping rather than a separate bug.
    * @param raw The raw event.
    * @returns The event, or `undefined` if the event has no resolvable
-   * start time.
+   * start time, or is a timed event with no resolvable end time.
    */
   (raw: calendar_v3.Schema$Event): EventDetail | undefined => {
     const { end, start, summary } = raw;
     const { dateTime, date } = start ?? {};
     const epoch = new Date((dateTime || date) ?? '').getTime();
     if (Number.isNaN(epoch)) {
-      const label = summary?.trim() || raw.id || '(unknown)';
-      console.warn(`Skipping event with no resolvable start time: ${label}`);
+      console.warn(
+        `Skipping event with no resolvable start time: ${labelOf(raw)}`,
+      );
       return undefined;
     }
-    const time = date ? undefined : formatTimeRange(epoch, end?.dateTime ?? '');
+    const endEpoch = date ? undefined : new Date(end?.dateTime ?? '').getTime();
+    if (endEpoch !== undefined && Number.isNaN(endEpoch)) {
+      console.warn(
+        `Skipping event with no resolvable end time: ${labelOf(raw)}`,
+      );
+      return undefined;
+    }
+    const time =
+      endEpoch === undefined ? undefined : formatTimeRange(epoch, endEpoch);
     return { date: formatDate(epoch), epoch, time, title: summary ?? '', type };
   };
 

--- a/packages/fetcher/src/parseEvent.test.mts
+++ b/packages/fetcher/src/parseEvent.test.mts
@@ -85,6 +85,57 @@ describe('toEventFactory', () => {
     );
   });
 
+  it('skips a timed event with no end object at all, without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      id: 'no-end-event',
+      start: { dateTime: '2026-01-01T12:00:00+09:00' },
+      summary: 'No End',
+    };
+    expect(() => toEventFactory('others')(raw)).not.toThrow();
+    expect(toEventFactory('others')(raw)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No End'));
+  });
+
+  it('skips a timed event whose end has no dateTime, without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      end: {},
+      id: 'empty-end-event',
+      start: { dateTime: '2026-01-01T12:00:00+09:00' },
+      summary: 'Empty End',
+    };
+    expect(() => toEventFactory('others')(raw)).not.toThrow();
+    expect(toEventFactory('others')(raw)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Empty End'));
+  });
+
+  it('skips a timed event whose end.dateTime is an empty string, without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      end: { dateTime: '' },
+      id: 'blank-end-event',
+      start: { dateTime: '2026-01-01T12:00:00+09:00' },
+      summary: 'Blank End',
+    };
+    expect(() => toEventFactory('others')(raw)).not.toThrow();
+    expect(toEventFactory('others')(raw)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Blank End'));
+  });
+
+  it('skips a timed event whose end.dateTime does not parse, without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw: calendar_v3.Schema$Event = {
+      end: { dateTime: 'not-a-date' },
+      id: 'garbled-end-event',
+      start: { dateTime: '2026-01-01T12:00:00+09:00' },
+      summary: 'Garbled End',
+    };
+    expect(() => toEventFactory('others')(raw)).not.toThrow();
+    expect(toEventFactory('others')(raw)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Garbled End'));
+  });
+
   it('renders the 翌 (next-day) marker when the event crosses a JST midnight', () => {
     const raw: calendar_v3.Schema$Event = {
       end: { dateTime: '2026-01-02T00:30:00+09:00' },


### PR DESCRIPTION
## Summary

`toEventFactory` (`packages/fetcher/src/parseEvent.mts`) already skips a
raw calendar event whose `start` has neither `dateTime` nor `date`
(#162), but the parallel gap on `end` was left unguarded: for a timed
event (`date` falsy), `end?.dateTime ?? ''` can resolve to `''` when
`end`/`end.dateTime` is missing or unparsable. `formatTimeRange` builds
`new Date('')` from that, and `Intl.DateTimeFormat.prototype.format`
throws `RangeError: Invalid time value` inside `dayKeyOf` — the same
crash class #162 fixed, just on `end` instead of `start`, taking down
the whole fetcher run over one malformed event.

**Chosen resolution** (per the issue's own suggested options): treat a
timed event with a missing/unparsable `end`/`end.dateTime` the same way
as an unresolvable `start` — skip the event, warn to stderr naming it,
and return `undefined`. This mirrors the existing `start` precedent
exactly and needed no new dependency or product decision.

- `toEventFactory` now computes an `endEpoch` for timed events only
  (`date` falsy) and, if it's `NaN` (covers a missing `end` object, a
  missing `end.dateTime`, an empty string, and any unparsable string),
  warns `Skipping event with no resolvable end time: <label>` and
  returns `undefined` before `formatTimeRange` is ever called. The
  all-day path (`date` truthy) is untouched.
- Reused the guard's already-computed `endEpoch` as `formatTimeRange`'s
  second argument instead of re-parsing `end?.dateTime` a second time.
- Extracted the warn-label computation (`summary?.trim() || raw.id ||
  '(unknown)'`), previously inlined once for the start guard, into a
  small `labelOf` helper, since the end guard now needs the identical
  logic — avoids a third inline copy.
- Updated `toEventFactory`'s JSDoc to document the new end-time skip
  path.
- Added four tests covering a timed event with: no `end` object at all,
  an `end` object with no `dateTime`, an `end.dateTime` of `''`, and an
  unparsable `end.dateTime` string — each asserting no throw, an
  `undefined` return, and a `console.warn` naming the event. Confirmed
  the existing all-day-event test and the valid-timed-event/midnight-
  crossing tests still pass unchanged.

Closes #187

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run test` (`packages/fetcher/src/parseEvent.test.mts`: 20/20,
      full monorepo: 162/162)
- [x] Independent critique passes on both the plan and the diff (no
      blocking findings)
