### PR TITLE
ci: harden push-main.yml deploy safety, permissions, and pinning

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}
+  queue: max
 permissions:
   contents: read
 jobs:
@@ -113,6 +114,9 @@ jobs:
         # cspell:disable-next-line
         uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0
         with:
+          enable-commit-comment: false
+          enable-commit-status: false
+          enable-github-deployment: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           production-deploy: true
           production-branch: main

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -7,9 +7,10 @@ on:
   schedule:
     - cron: '0 */3 * * *'
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
 permissions:
   contents: read
-  pull-requests: write
 jobs:
   detect-changes:
     if: github.event_name == 'schedule'
@@ -35,8 +36,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
-      - name: Install the latest corepack explicitly
-        run: npm install --force -g corepack@latest
       - name: Enable the corepack because of the pnpm
         run: corepack enable
       - name: Post-prepare the Node.js environment
@@ -81,8 +80,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
-      - name: Install the latest corepack explicitly
-        run: npm install --force -g corepack@latest
       - name: Enable the corepack because of the pnpm
         run: corepack enable
       - name: Post-prepare the Node.js environment
@@ -114,7 +111,7 @@ jobs:
           NODE_ENV: production
         name: Deploy to Netlify
         # cspell:disable-next-line
-        uses: nwtgck/actions-netlify@v4.0
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           production-deploy: true


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/push-main.yml` (the production Netlify
deploy workflow) against three of the four defects the issue reported:

- Added a `concurrency` group keyed on the workflow, so a scheduled run
  can no longer race a merge-triggered run for the same production
  deploy (deliberately no `cancel-in-progress`, so a newer run queues
  behind an in-flight deploy instead of cancelling it).
- Dropped the unused top-level `pull-requests: write` permission,
  keeping only `contents: read`. Nothing in this push/schedule/dispatch
  workflow writes to pull requests, and `nwtgck/actions-netlify`'s
  PR-comment behavior only activates under a `pull_request` event,
  which this workflow never runs under.
- Pinned `nwtgck/actions-netlify` from the mutable `@v4.0` tag to its
  resolved commit SHA
  `d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0`.
- Dropped the `npm install --force -g corepack@latest` step in both
  jobs. `package.json` already declares a hash-pinned `packageManager`
  field (`pnpm@10.2.0+sha512...`), and the repository's Node 24 floor
  (`.node-version`) bundles corepack, so the existing `corepack enable`
  step alone activates the pinned pnpm version without an extra
  unpinned global install.

**Cron cadence direction chosen**: no code change. The workflow's
schedule was already `0 */3 * * *` (8 runs/day), matching the site's
published "eight times daily" copy — this was fixed as an unrelated
side effect of commit `1837a52` ("ci: skip the scheduled deploy when
calendar data is unchanged") before this issue was claimed. Verified
against `packages/web/src/i18n/{ja,en}.ts`, which still say eight times
daily.

`.github/workflows/push.yml` is untouched — out of scope per the issue
body (its own branch-filter defect was tracked separately in #117,
already closed).

## Verification

- `pnpm run lint` and `pnpm run test` pass locally.
- The YAML still parses correctly (`yaml.safe_load` and this repo's own
  prettier/markdown/cspell checks all pass on the file).
- Not verified by a manual `workflow_dispatch` from this branch: that
  would trigger a real Netlify **production** deploy of unmerged code.
  Instead, the acceptance criterion "a workflow run reaches the deploy
  step successfully" will be evidenced by the merge-triggered `push`
  run of `push-main.yml` on `main` after this PR merges, which
  exercises the same `deploy` job end-to-end (including the corepack
  removal and the pinned action).

## Follow-up

None needed — all remaining defects the issue reported are covered by
this change scope.

Closes #145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release and deployment process for greater reliability and consistency.
  * Prevented overlapping deployment runs from interfering with one another.
  * Strengthened workflow security by applying more limited permissions.
  * Updated deployment tooling to use a stable, verified version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->