### PR TITLE
feat(security): serve security response headers from the Netlify deploy

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,7 @@
     "prebuild:yaml": "js-yaml src/constants.yaml > src/constants.json",
     "build": "vinxi build",
     "build:storybook": "storybook build",
-    "postbuild": "cp src/data.json dist/data.json && rimraf -g \"dist/**/*.map\"",
+    "postbuild": "cp src/data.json dist/data.json && rimraf -g \"dist/**/*.map\" && node scripts/generate-csp-headers.mjs",
     "clean": "rimraf -g \"*.tgz\" \"*.tsbuildinfo\" .output .vinxi dist node_modules/.cache \"src/*.json\" \"public/site.webmanifest\" storybook-static",
     "serve": "serve dist",
     "prestart": "pnpm run prebuild",

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -1,0 +1,6 @@
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), midi=(), fullscreen=(), picture-in-picture=(), display-capture=()
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'

--- a/packages/web/scripts/generate-csp-headers.build.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.build.test.mjs
@@ -30,6 +30,18 @@ const hasDist = existsSync(distDir);
 const resourceLoadPattern =
   /<(script|img|source|audio|video|iframe)\b[^>]*\ssrc=["'](https?:\/\/[^"']+)["']|<link\b[^>]*\srel=["'](?:stylesheet|preload|modulepreload|icon|manifest)["'][^>]*\shref=["'](https?:\/\/[^"']+)["']/gi;
 
+/**
+ * `srcset` candidates are a comma-separated `url descriptor, …` list, so
+ * an external origin need not start the attribute value the way a bare
+ * `src` does — this checks every whitespace-delimited token in each
+ * `srcset` value, not just an anchored prefix. Not part of
+ * {@link resourceLoadPattern} itself so a `srcset` hit records every
+ * offending token rather than only the first. Kept as its own check
+ * (rather than folded into the CSP source list today) so this stays a
+ * regression guard once #151 adds responsive image variants.
+ */
+const srcsetPattern = /<(?:img|source)\b[^>]*\ssrcset=["']([^"']+)["']/gi;
+
 describe.skipIf(!hasDist)(
   'production build output matches the shipped CSP',
   () => {
@@ -59,6 +71,12 @@ describe.skipIf(!hasDist)(
         const html = await readFile(file, 'utf8');
         for (const match of html.matchAll(resourceLoadPattern)) {
           violations.push({ file, url: match[2] ?? match[3] });
+        }
+        for (const [, srcset] of html.matchAll(srcsetPattern)) {
+          for (const candidate of srcset.split(',')) {
+            const url = candidate.trim().split(/\s+/)[0];
+            if (/^https?:\/\//i.test(url)) violations.push({ file, url });
+          }
         }
       }
       expect(violations).toStrictEqual([]);

--- a/packages/web/scripts/generate-csp-headers.build.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.build.test.mjs
@@ -1,0 +1,67 @@
+// Integration coverage against the *actual* production build output,
+// as opposed to generate-csp-headers.test.mjs's fixture-based unit
+// tests. `dist/` only exists after `pnpm run build` (CI always builds
+// before it lints/tests — see .github/workflows/push.yml — but a local
+// `pnpm test` run without a prior build should not fail here), so every
+// test below is skipped when it is absent.
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  collectHtmlFiles,
+  extractInlineScriptHashes,
+} from './generate-csp-headers.mjs';
+
+// `join(process.cwd(), 'dist')` rather than an `import.meta.url`-derived
+// path: vitest's module loader for this file does not always expose a
+// plain `file:` URL, and every `test` script in this monorepo (`pnpm
+// run -r test`) already runs with the package root as its cwd.
+const distDir = join(process.cwd(), 'dist');
+const hasDist = existsSync(distDir);
+
+/**
+ * Resource-loading tag/attribute combinations the CSP's fetch
+ * directives actually govern. `<a href>` and metadata `<link
+ * rel="alternate|author|canonical|license">` are navigation targets,
+ * not subresource loads, so they are deliberately excluded — CSP does
+ * not gate them.
+ */
+const resourceLoadPattern =
+  /<(script|img|source|audio|video|iframe)\b[^>]*\ssrc=["'](https?:\/\/[^"']+)["']|<link\b[^>]*\srel=["'](?:stylesheet|preload|modulepreload|icon|manifest)["'][^>]*\shref=["'](https?:\/\/[^"']+)["']/gi;
+
+describe.skipIf(!hasDist)(
+  'production build output matches the shipped CSP',
+  () => {
+    it('every inline <script> hash in the built HTML is present in dist/_headers', async () => {
+      const htmlFiles = await collectHtmlFiles(distDir);
+      expect(htmlFiles.length).toBeGreaterThan(0);
+      const headers = await readFile(`${distDir}/_headers`, 'utf8');
+      const cspLine = headers
+        .split('\n')
+        .find((line) => line.includes('Content-Security-Policy'));
+      expect(cspLine).toBeDefined();
+
+      const missing = [];
+      for (const file of htmlFiles) {
+        const html = await readFile(file, 'utf8');
+        for (const hash of extractInlineScriptHashes(html)) {
+          if (!cspLine.includes(`'${hash}'`)) missing.push({ file, hash });
+        }
+      }
+      expect(missing).toStrictEqual([]);
+    });
+
+    it('no built page loads a third-party script, stylesheet, image, or media resource', async () => {
+      const htmlFiles = await collectHtmlFiles(distDir);
+      const violations = [];
+      for (const file of htmlFiles) {
+        const html = await readFile(file, 'utf8');
+        for (const match of html.matchAll(resourceLoadPattern)) {
+          violations.push({ file, url: match[2] ?? match[3] });
+        }
+      }
+      expect(violations).toStrictEqual([]);
+    });
+  },
+);

--- a/packages/web/scripts/generate-csp-headers.build.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.build.test.mjs
@@ -20,27 +20,168 @@ import {
 const distDir = join(process.cwd(), 'dist');
 const hasDist = existsSync(distDir);
 
+/** Tag names whose `src=` attribute is a resource load CSP governs. */
+const srcTagNames = /** @type {const} */ ([
+  'script',
+  'img',
+  'source',
+  'audio',
+  'video',
+  'iframe',
+]);
+
+/** `<link rel=…>` values that load a subresource, as opposed to
+ * metadata/navigation values (`alternate`, `author`, `canonical`,
+ * `license`) that CSP does not gate. */
+const resourceLinkRels = /** @type {const} */ ([
+  'stylesheet',
+  'preload',
+  'modulepreload',
+  'icon',
+  'manifest',
+]);
+
 /**
- * Resource-loading tag/attribute combinations the CSP's fetch
- * directives actually govern. `<a href>` and metadata `<link
+ * Read one attribute's value from a captured attribute string,
+ * tolerating single, double, or no quotes — real HTML permits all
+ * three, and this file's own attribute order (`rel` before `href`, or
+ * the reverse) must not matter either. Two-pass by design (tag first,
+ * then attributes independently) rather than one attribute-order-locked
+ * regex, per the review finding that flagged the single-regex version
+ * as matching zero real `<link>` tags in this codebase's own build
+ * (which always emits `href` before `rel`).
+ * @param {string} attrs The tag's attribute string (between the tag
+ * name and the closing `>`).
+ * @param {string} name The attribute name to read.
+ * @returns {string | undefined} The attribute's value, or `undefined`
+ * when the attribute is absent.
+ */
+const readAttr = (attrs, name) =>
+  attrs.match(new RegExp(`\\s${name}=["']?([^"'\\s>]+)`, 'i'))?.[1];
+
+/**
+ * Same as {@link readAttr}, but for a value that may itself contain
+ * internal whitespace (only `srcset` today: a comma-separated `url
+ * descriptor, …` list). {@link readAttr}'s `[^"'\s>]+` would truncate
+ * at the value's first internal space, so this instead requires a
+ * matching quote pair and captures everything up to it. An unquoted
+ * `srcset` cannot legally contain a space or comma at all, so this
+ * intentionally does not attempt the unquoted case.
+ * @param {string} attrs See {@link readAttr}.
+ * @param {string} name See {@link readAttr}.
+ * @returns {string | undefined} See {@link readAttr}.
+ */
+const readQuotedAttr = (attrs, name) =>
+  attrs.match(new RegExp(`\\s${name}=["']([^"']+)["']`, 'i'))?.[1];
+
+/**
+ * Find every resource-loading reference to a third-party (`http(s)://`)
+ * origin in one HTML document: `src=` on a script/img/source/audio/
+ * video/iframe tag, `href=` on a resource-loading `<link>`, and every
+ * `srcset` candidate URL. `<a href>` and metadata `<link
  * rel="alternate|author|canonical|license">` are navigation targets,
  * not subresource loads, so they are deliberately excluded — CSP does
  * not gate them.
+ * @param {string} html The HTML document text.
+ * @returns {string[]} Every offending third-party URL found.
  */
-const resourceLoadPattern =
-  /<(script|img|source|audio|video|iframe)\b[^>]*\ssrc=["'](https?:\/\/[^"']+)["']|<link\b[^>]*\srel=["'](?:stylesheet|preload|modulepreload|icon|manifest)["'][^>]*\shref=["'](https?:\/\/[^"']+)["']/gi;
+const findThirdPartyResourceLoads = (html) => {
+  const urls = [];
 
-/**
- * `srcset` candidates are a comma-separated `url descriptor, …` list, so
- * an external origin need not start the attribute value the way a bare
- * `src` does — this checks every whitespace-delimited token in each
- * `srcset` value, not just an anchored prefix. Not part of
- * {@link resourceLoadPattern} itself so a `srcset` hit records every
- * offending token rather than only the first. Kept as its own check
- * (rather than folded into the CSP source list today) so this stays a
- * regression guard once #151 adds responsive image variants.
- */
-const srcsetPattern = /<(?:img|source)\b[^>]*\ssrcset=["']([^"']+)["']/gi;
+  for (const tagName of srcTagNames) {
+    for (const [, attrs] of html.matchAll(
+      new RegExp(`<${tagName}\\b([^>]*)>`, 'gi'),
+    )) {
+      const src = readAttr(attrs, 'src');
+      if (src && /^https?:\/\//i.test(src)) urls.push(src);
+    }
+  }
+
+  for (const [, attrs] of html.matchAll(/<link\b([^>]*)>/gi)) {
+    const rel = readAttr(attrs, 'rel');
+    const href = readAttr(attrs, 'href');
+    if (
+      rel &&
+      href &&
+      /^https?:\/\//i.test(href) &&
+      resourceLinkRels.includes(/** @type {never} */ (rel.toLowerCase()))
+    ) {
+      urls.push(href);
+    }
+  }
+
+  // `srcset` candidates are a comma-separated `url descriptor, …` list,
+  // so an external origin need not start the attribute value the way a
+  // bare `src` does — check every whitespace-delimited token in each
+  // `srcset` value, not just the raw attribute string. Kept as a
+  // separate check (rather than folded into the CSP source list today)
+  // so this stays a regression guard once #151 adds responsive image
+  // variants.
+  for (const [, attrs] of html.matchAll(/<(?:img|source)\b([^>]*)>/gi)) {
+    const srcset = readQuotedAttr(attrs, 'srcset');
+    if (!srcset) continue;
+    for (const candidate of srcset.split(',')) {
+      const url = candidate.trim().split(/\s+/)[0];
+      if (url && /^https?:\/\//i.test(url)) urls.push(url);
+    }
+  }
+
+  return urls;
+};
+
+// Fixture-based coverage for findThirdPartyResourceLoads itself (always
+// runs, unlike the dist/-gated suite below): this repo's own build
+// output happens to emit href-before-rel on every real <link> tag, so
+// the dist/-based suite alone would never actually exercise the
+// order-independence this function exists to provide.
+describe('findThirdPartyResourceLoads', () => {
+  it('detects a <link> resource load regardless of rel/href attribute order', () => {
+    const relFirst = '<link rel="stylesheet" href="https://evil.test/x.css">';
+    const hrefFirst = '<link href="https://evil.test/x.css" rel="stylesheet">';
+    expect(findThirdPartyResourceLoads(relFirst)).toStrictEqual([
+      'https://evil.test/x.css',
+    ]);
+    expect(findThirdPartyResourceLoads(hrefFirst)).toStrictEqual([
+      'https://evil.test/x.css',
+    ]);
+  });
+
+  it('ignores navigation-only <link> rel values', () => {
+    const html =
+      '<link href="https://kit.black/ja/" rel="alternate" hreflang="ja">';
+    expect(findThirdPartyResourceLoads(html)).toStrictEqual([]);
+  });
+
+  it('ignores <a href> navigation links entirely', () => {
+    expect(
+      findThirdPartyResourceLoads('<a href="https://github.com/x">link</a>'),
+    ).toStrictEqual([]);
+  });
+
+  it('detects a third-party <script src> and <img src>, quoted or not', () => {
+    expect(
+      findThirdPartyResourceLoads(
+        '<script src="https://evil.test/a.js"></script>',
+      ),
+    ).toStrictEqual(['https://evil.test/a.js']);
+    expect(
+      findThirdPartyResourceLoads('<img src=https://evil.test/a.webp>'),
+    ).toStrictEqual(['https://evil.test/a.webp']);
+  });
+
+  it('detects a third-party origin anywhere in a srcset candidate list', () => {
+    const html = '<img srcset="/local.webp 1x, https://evil.test/a.webp 2x">';
+    expect(findThirdPartyResourceLoads(html)).toStrictEqual([
+      'https://evil.test/a.webp',
+    ]);
+  });
+
+  it('finds nothing in same-origin-only markup', () => {
+    const html =
+      '<script src="/app.js"></script><link href="/site.css" rel="stylesheet"><img src="/a.webp" srcset="/a.webp 1x, /a-2x.webp 2x">';
+    expect(findThirdPartyResourceLoads(html)).toStrictEqual([]);
+  });
+});
 
 describe.skipIf(!hasDist)(
   'production build output matches the shipped CSP',
@@ -69,14 +210,8 @@ describe.skipIf(!hasDist)(
       const violations = [];
       for (const file of htmlFiles) {
         const html = await readFile(file, 'utf8');
-        for (const match of html.matchAll(resourceLoadPattern)) {
-          violations.push({ file, url: match[2] ?? match[3] });
-        }
-        for (const [, srcset] of html.matchAll(srcsetPattern)) {
-          for (const candidate of srcset.split(',')) {
-            const url = candidate.trim().split(/\s+/)[0];
-            if (/^https?:\/\//i.test(url)) violations.push({ file, url });
-          }
+        for (const url of findThirdPartyResourceLoads(html)) {
+          violations.push({ file, url });
         }
       }
       expect(violations).toStrictEqual([]);

--- a/packages/web/scripts/generate-csp-headers.mjs
+++ b/packages/web/scripts/generate-csp-headers.mjs
@@ -65,10 +65,14 @@ export const collectHtmlFiles = async (dir) => {
  */
 export const extractInlineScriptHashes = (html) => {
   const hashes = new Set();
-  for (const [tag, body] of html.matchAll(
-    /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g,
+  for (const [, attrs, body] of html.matchAll(
+    /<script((?:\s[^>]*)?)>([\s\S]*?)<\/script>/g,
   )) {
-    if (/<script[^>]*\ssrc=/.test(tag) || !body.trim()) continue;
+    // Only the opening tag's own attributes may carry `src=`; matching
+    // against the whole tag (attrs + body) would false-positive on a
+    // script body that happens to contain the literal text `<script
+    // src=`, e.g. an embedded HTML string in the asset manifest.
+    if (/\ssrc=/.test(attrs) || !body.trim()) continue;
     hashes.add(`sha256-${createHash('sha256').update(body).digest('base64')}`);
   }
   return [...hashes];
@@ -121,6 +125,33 @@ export const sentryConnectOrigin = (dsn) => {
 };
 
 /**
+ * The warning `sentryConnectOriginOrWarn` emits when `VITE_SENTRY_DSN`
+ * is set but not a parsable URL. Exported so tests can assert on it
+ * without duplicating the exact wording.
+ * @type {string}
+ */
+export const malformedDsnWarning =
+  'generate-csp-headers: VITE_SENTRY_DSN is set but not a parsable URL — ' +
+  "shipping this build with connect-src/worker-src still pinned to 'self' " +
+  '(and blob: omitted) would silently block Sentry telemetry once ' +
+  'initSentry() runs with this same value. Fix or unset VITE_SENTRY_DSN.';
+
+/**
+ * {@link sentryConnectOrigin}, but logs {@link malformedDsnWarning} to
+ * stderr on the failure case instead of failing silently — a DSN that
+ * is present-but-unparsable would otherwise ship a CSP that blocks
+ * Sentry's own beacons and Replay worker with no build-time signal, and
+ * Sentry cannot report its own CSP-blocked traffic to itself.
+ * @param {string | undefined} dsn See {@link sentryConnectOrigin}.
+ * @returns {string | undefined} See {@link sentryConnectOrigin}.
+ */
+export const sentryConnectOriginOrWarn = (dsn) => {
+  const origin = sentryConnectOrigin(dsn);
+  if (dsn && !origin) console.warn(malformedDsnWarning);
+  return origin;
+};
+
+/**
  * Whether this module was invoked directly (`node scripts/…mjs`), rather
  * than imported. Deliberately avoids `import.meta.main` (Node >=24.2
  * only) for the same fail-open-no-op reason documented in
@@ -141,7 +172,9 @@ if (isMain) {
     .sort()
     .map((hash) => `'${hash}'`);
 
-  const connectOrigin = sentryConnectOrigin(process.env['VITE_SENTRY_DSN']);
+  const connectOrigin = sentryConnectOriginOrWarn(
+    process.env['VITE_SENTRY_DSN'],
+  );
 
   const headersPath = `${distDir}/_headers`;
   const original = await readFile(headersPath, 'utf8');

--- a/packages/web/scripts/generate-csp-headers.mjs
+++ b/packages/web/scripts/generate-csp-headers.mjs
@@ -65,14 +65,19 @@ export const collectHtmlFiles = async (dir) => {
  */
 export const extractInlineScriptHashes = (html) => {
   const hashes = new Set();
+  // HTML tag names and attribute names are case-insensitive per spec
+  // (`<SCRIPT SRC=…>` is as valid as `<script src=…>`), so both this
+  // tag matcher and the `src=` attribute check below use the `i` flag —
+  // a case-sensitive version would silently miss an uppercase/mixed-case
+  // script tag, dropping a real inline script's hash from the CSP.
   for (const [, attrs, body] of html.matchAll(
-    /<script((?:\s[^>]*)?)>([\s\S]*?)<\/script>/g,
+    /<script((?:\s[^>]*)?)>([\s\S]*?)<\/script>/gi,
   )) {
     // Only the opening tag's own attributes may carry `src=`; matching
     // against the whole tag (attrs + body) would false-positive on a
     // script body that happens to contain the literal text `<script
     // src=`, e.g. an embedded HTML string in the asset manifest.
-    if (/\ssrc=/.test(attrs) || !body.trim()) continue;
+    if (/\ssrc=/i.test(attrs) || !body.trim()) continue;
     hashes.add(`sha256-${createHash('sha256').update(body).digest('base64')}`);
   }
   return [...hashes];

--- a/packages/web/scripts/generate-csp-headers.mjs
+++ b/packages/web/scripts/generate-csp-headers.mjs
@@ -1,0 +1,164 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/**
+ * A `_headers` file's Content-Security-Policy `script-src` value before
+ * this script patches in the build's actual inline-script hashes. Kept
+ * as a bare `'self'` (not a real hash list) so that a `vinxi build` run
+ * without this postbuild step fails inline scripts closed instead of
+ * silently shipping an unpatched, overly-permissive header.
+ * @type {string}
+ */
+export const scriptSrcPlaceholder = "script-src 'self';";
+
+/**
+ * The `connect-src` placeholder this script extends with the Sentry
+ * ingest origin, only when a build-time DSN is present.
+ * @type {string}
+ */
+export const connectSrcPlaceholder = "connect-src 'self';";
+
+/**
+ * The `worker-src` placeholder this script extends with `blob:`, only
+ * when a build-time Sentry DSN is present. Sentry Session Replay's
+ * compression worker is always bundled (it ships regardless of whether
+ * a DSN is configured — only the runtime `init()` call is DSN-gated),
+ * and empirically creates its worker from a same-origin-restricted
+ * `Blob` + `URL.createObjectURL()` (a `blob:` URL), which `'self'`
+ * alone does not permit. See the PR body for how this was verified.
+ * @type {string}
+ */
+export const workerSrcPlaceholder = "worker-src 'self';";
+
+/**
+ * Recursively collect every `.html` file under a directory.
+ * @param {string} dir The directory to walk.
+ * @returns {Promise<string[]>} The absolute paths of every `.html` file
+ * found, in no particular order.
+ */
+export const collectHtmlFiles = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const found = await Promise.all(
+    entries.map(async (entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectHtmlFiles(full);
+      return entry.isFile() && entry.name.endsWith('.html') ? [full] : [];
+    }),
+  );
+  return found.flat();
+};
+
+/**
+ * Extract a CSP `script-src` hash source for every distinct, non-empty
+ * inline `<script>` block in an HTML document.
+ *
+ * A prerendered SolidStart page inlines its hydration bootstrap and
+ * asset manifest directly in `<script>` tags, and the manifest embeds
+ * content-hashed asset filenames — so these hashes change on every
+ * build and must be computed from the actual output, never hand-copied.
+ * A `<script src="…">` tag referencing a same-origin file is already
+ * covered by `'self'` and is skipped.
+ * @param {string} html The HTML document text.
+ * @returns {string[]} Deduped `sha256-<base64>` source list entries.
+ */
+export const extractInlineScriptHashes = (html) => {
+  const hashes = new Set();
+  for (const [tag, body] of html.matchAll(
+    /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g,
+  )) {
+    if (/<script[^>]*\ssrc=/.test(tag) || !body.trim()) continue;
+    hashes.add(`sha256-${createHash('sha256').update(body).digest('base64')}`);
+  }
+  return [...hashes];
+};
+
+/**
+ * Replace a literal CSP directive placeholder (e.g.
+ * {@link scriptSrcPlaceholder}) with the same directive extended by
+ * additional source values.
+ * @param {string} headersContent The `_headers` file content.
+ * @param {string} placeholder The exact placeholder substring to find,
+ * including its trailing `;`.
+ * @param {readonly string[]} extraSources Additional source values
+ * (already `'`-quoted or bare, e.g. `'sha256-…'` or
+ * `https://example.test`) to append before the `;`.
+ * @returns {string} The updated `_headers` content, unchanged when
+ * `extraSources` is empty.
+ * @throws {Error} If `placeholder` does not appear in `headersContent`.
+ */
+export const injectCspSources = (headersContent, placeholder, extraSources) => {
+  if (!headersContent.includes(placeholder)) {
+    throw new Error(
+      `generate-csp-headers: expected the literal "${placeholder}" placeholder in _headers, but it was not found. Did the CSP line in public/_headers change?`,
+    );
+  }
+  if (extraSources.length === 0) return headersContent;
+  const directive = placeholder.slice(0, -1);
+  const replacement = `${directive}${extraSources.map((s) => ` ${s}`).join('')};`;
+  return headersContent.replace(placeholder, replacement);
+};
+
+/**
+ * Derive the CSP `connect-src` origin Sentry's client SDK will call once
+ * a DSN is configured, from that same DSN — never hand-guessed. A
+ * Sentry DSN has the shape `https://<key>@<host>/<projectId>`; the
+ * origin the SDK actually calls is `https://<host>`.
+ * @param {string | undefined} dsn The `VITE_SENTRY_DSN` build-time
+ * value, or `undefined`/empty when Sentry is not configured for this
+ * build (the SDK itself no-ops in that case — see `initSentry.ts`).
+ * @returns {string | undefined} The Sentry ingest origin, or
+ * `undefined` when `dsn` is empty, undefined, or unparsable as a URL.
+ */
+export const sentryConnectOrigin = (dsn) => {
+  if (!dsn) return undefined;
+  try {
+    return new URL(dsn).origin;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Whether this module was invoked directly (`node scripts/…mjs`), rather
+ * than imported. Deliberately avoids `import.meta.main` (Node >=24.2
+ * only) for the same fail-open-no-op reason documented in
+ * `generate-manifest.mjs`.
+ */
+const isMain = import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
+
+if (isMain) {
+  const root = fileURLToPath(new URL('..', import.meta.url));
+  const distDir = `${root}/dist`;
+  const htmlFiles = await collectHtmlFiles(distDir);
+  const perFile = await Promise.all(
+    htmlFiles.map(async (file) =>
+      extractInlineScriptHashes(await readFile(file, 'utf8')),
+    ),
+  );
+  const scriptHashes = [...new Set(perFile.flat())]
+    .sort()
+    .map((hash) => `'${hash}'`);
+
+  const connectOrigin = sentryConnectOrigin(process.env['VITE_SENTRY_DSN']);
+
+  const headersPath = `${distDir}/_headers`;
+  const original = await readFile(headersPath, 'utf8');
+  const withScriptSrc = injectCspSources(
+    original,
+    scriptSrcPlaceholder,
+    scriptHashes,
+  );
+  const withConnectSrc = injectCspSources(
+    withScriptSrc,
+    connectSrcPlaceholder,
+    connectOrigin ? [connectOrigin] : [],
+  );
+  const withWorkerSrc = injectCspSources(
+    withConnectSrc,
+    workerSrcPlaceholder,
+    connectOrigin ? ['blob:'] : [],
+  );
+  await writeFile(headersPath, withWorkerSrc);
+}

--- a/packages/web/scripts/generate-csp-headers.mjs
+++ b/packages/web/scripts/generate-csp-headers.mjs
@@ -70,16 +70,20 @@ export const extractInlineScriptHashes = (html) => {
   // tag matcher and the `src=` attribute check below use the `i` flag —
   // a case-sensitive version would silently miss an uppercase/mixed-case
   // script tag, dropping a real inline script's hash from the CSP.
-  // `\b` (not a literal `>`) ends the tag name on both the opening and
-  // closing tag, then `[^>]*` absorbs everything up to the real `>` —
-  // this matches how a browser's HTML parser actually closes `<script>`
-  // raw-text mode: on `</script` followed by *any* non-letter
-  // (whitespace, `/`, bogus attributes), not only a bare `</script>`. A
-  // stricter literal (even `<\/script\s*>`) misses real end-tag forms a
-  // browser still honors, silently dropping a real inline script's hash
-  // from the CSP.
+  //
+  // The closing tag uses a lookahead for the exact delimiter set a
+  // browser's HTML parser recognizes after `</script` — tab, newline,
+  // form feed, space, `/`, or `>` — then `[^>]*` absorbs everything up
+  // to the real `>`. This matters in both directions: a stricter literal
+  // (even `<\/script\s*>`) misses real end-tag forms a browser still
+  // honors (bogus attributes, `/`), silently dropping a real inline
+  // script's hash; a looser `\b` word-boundary check is *too*
+  // permissive — `-`, `:`, and other non-word, non-delimiter characters
+  // satisfy `\b` but a browser does not treat `</script-anything` as a
+  // close at all, so a `\b`-based match could truncate a script body
+  // early and hash the wrong (partial) content.
   for (const [, attrs, body] of html.matchAll(
-    /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi,
+    /<script\b([^>]*)>([\s\S]*?)<\/script(?=[\t\n\f />])[^>]*>/gi,
   )) {
     // Only the opening tag's own attributes may carry `src=`; matching
     // against the whole tag (attrs + body) would false-positive on a

--- a/packages/web/scripts/generate-csp-headers.mjs
+++ b/packages/web/scripts/generate-csp-headers.mjs
@@ -69,11 +69,17 @@ export const extractInlineScriptHashes = (html) => {
   // (`<SCRIPT SRC=…>` is as valid as `<script src=…>`), so both this
   // tag matcher and the `src=` attribute check below use the `i` flag —
   // a case-sensitive version would silently miss an uppercase/mixed-case
-  // script tag, dropping a real inline script's hash from the CSP. The
-  // end tag also allows trailing whitespace before `>` (`</script >` is
-  // valid HTML), which a bare `<\/script>` literal would not match.
+  // script tag, dropping a real inline script's hash from the CSP.
+  // `\b` (not a literal `>`) ends the tag name on both the opening and
+  // closing tag, then `[^>]*` absorbs everything up to the real `>` —
+  // this matches how a browser's HTML parser actually closes `<script>`
+  // raw-text mode: on `</script` followed by *any* non-letter
+  // (whitespace, `/`, bogus attributes), not only a bare `</script>`. A
+  // stricter literal (even `<\/script\s*>`) misses real end-tag forms a
+  // browser still honors, silently dropping a real inline script's hash
+  // from the CSP.
   for (const [, attrs, body] of html.matchAll(
-    /<script((?:\s[^>]*)?)>([\s\S]*?)<\/script\s*>/gi,
+    /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi,
   )) {
     // Only the opening tag's own attributes may carry `src=`; matching
     // against the whole tag (attrs + body) would false-positive on a

--- a/packages/web/scripts/generate-csp-headers.mjs
+++ b/packages/web/scripts/generate-csp-headers.mjs
@@ -69,9 +69,11 @@ export const extractInlineScriptHashes = (html) => {
   // (`<SCRIPT SRC=…>` is as valid as `<script src=…>`), so both this
   // tag matcher and the `src=` attribute check below use the `i` flag —
   // a case-sensitive version would silently miss an uppercase/mixed-case
-  // script tag, dropping a real inline script's hash from the CSP.
+  // script tag, dropping a real inline script's hash from the CSP. The
+  // end tag also allows trailing whitespace before `>` (`</script >` is
+  // valid HTML), which a bare `<\/script>` literal would not match.
   for (const [, attrs, body] of html.matchAll(
-    /<script((?:\s[^>]*)?)>([\s\S]*?)<\/script>/gi,
+    /<script((?:\s[^>]*)?)>([\s\S]*?)<\/script\s*>/gi,
   )) {
     // Only the opening tag's own attributes may carry `src=`; matching
     // against the whole tag (attrs + body) would false-positive on a

--- a/packages/web/scripts/generate-csp-headers.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.test.mjs
@@ -45,6 +45,21 @@ describe('extractInlineScriptHashes', () => {
     expect(extractInlineScriptHashes(html)).toStrictEqual([]);
   });
 
+  it('matches real-world end-tag forms browsers still honor', () => {
+    // A browser's HTML tokenizer closes script raw-text mode on
+    // `</script` followed by *any* non-letter — whitespace, `/`, or
+    // bogus attributes — not only a bare `</script>`.
+    const forms = [
+      '<script>const a = 1;</script >',
+      '<script>const a = 1;</script\t\n>',
+      '<script>const a = 1;</script foo="bar">',
+      '<script>const a = 1;</script/>',
+    ];
+    for (const html of forms) {
+      expect(extractInlineScriptHashes(html)).toHaveLength(1);
+    }
+  });
+
   it('produces a hash matching an independently-computed sha256', async () => {
     const { createHash } = await import('node:crypto');
     const body = 'window.manifest = { a: 1 };';

--- a/packages/web/scripts/generate-csp-headers.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.test.mjs
@@ -31,6 +31,15 @@ describe('extractInlineScriptHashes', () => {
     expect(extractInlineScriptHashes(html)).toStrictEqual([]);
   });
 
+  it('matches upper- and mixed-case <SCRIPT> tags (HTML tag names are case-insensitive)', () => {
+    const hashed = extractInlineScriptHashes('<SCRIPT>const a = 1;</SCRIPT>');
+    expect(hashed).toHaveLength(1);
+    const skipped = extractInlineScriptHashes(
+      '<ScRiPt SRC="/app.js"></ScRiPt>',
+    );
+    expect(skipped).toStrictEqual([]);
+  });
+
   it('skips empty inline scripts', () => {
     const html = '<script></script><script>   </script>';
     expect(extractInlineScriptHashes(html)).toStrictEqual([]);

--- a/packages/web/scripts/generate-csp-headers.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.test.mjs
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  connectSrcPlaceholder,
+  extractInlineScriptHashes,
+  injectCspSources,
+  scriptSrcPlaceholder,
+  sentryConnectOrigin,
+  workerSrcPlaceholder,
+} from './generate-csp-headers.mjs';
+
+describe('extractInlineScriptHashes', () => {
+  it('hashes each distinct non-empty inline script body', () => {
+    const html = `<html><body>
+      <script>const a = 1;</script>
+      <script>const b = 2;</script>
+    </body></html>`;
+    const hashes = extractInlineScriptHashes(html);
+    expect(hashes).toHaveLength(2);
+    expect(hashes.every((h) => h.startsWith('sha256-'))).toBe(true);
+  });
+
+  it('deduplicates identical inline script bodies', () => {
+    const html = '<script>const a = 1;</script><script>const a = 1;</script>';
+    expect(extractInlineScriptHashes(html)).toHaveLength(1);
+  });
+
+  it('skips scripts with a src attribute', () => {
+    const html = '<script type="module" async src="/app.js"></script>';
+    expect(extractInlineScriptHashes(html)).toStrictEqual([]);
+  });
+
+  it('skips empty inline scripts', () => {
+    const html = '<script></script><script>   </script>';
+    expect(extractInlineScriptHashes(html)).toStrictEqual([]);
+  });
+
+  it('produces a hash matching an independently-computed sha256', async () => {
+    const { createHash } = await import('node:crypto');
+    const body = 'window.manifest = { a: 1 };';
+    const html = `<script>${body}</script>`;
+    const expected = `sha256-${createHash('sha256').update(body).digest('base64')}`;
+    expect(extractInlineScriptHashes(html)).toStrictEqual([expected]);
+  });
+});
+
+describe('injectCspSources', () => {
+  it('replaces the placeholder with the directive plus extra sources', () => {
+    const headers = `/*\n  Content-Security-Policy: default-src 'self'; ${scriptSrcPlaceholder} style-src 'self'\n`;
+    const result = injectCspSources(headers, scriptSrcPlaceholder, [
+      "'sha256-AAA='",
+      "'sha256-BBB='",
+    ]);
+    expect(result).toContain("script-src 'self' 'sha256-AAA=' 'sha256-BBB=';");
+    expect(result).not.toContain(scriptSrcPlaceholder);
+  });
+
+  it('returns the content unchanged when there are no extra sources', () => {
+    const headers = `Content-Security-Policy: ${scriptSrcPlaceholder}`;
+    expect(injectCspSources(headers, scriptSrcPlaceholder, [])).toBe(headers);
+  });
+
+  it('throws when the placeholder is missing', () => {
+    expect(() =>
+      injectCspSources(
+        "Content-Security-Policy: default-src 'self'",
+        scriptSrcPlaceholder,
+        ["'sha256-AAA='"],
+      ),
+    ).toThrow(/placeholder/);
+  });
+
+  it('works for the connect-src placeholder too', () => {
+    const headers = `Content-Security-Policy: default-src 'self'; ${connectSrcPlaceholder}`;
+    const result = injectCspSources(headers, connectSrcPlaceholder, [
+      'https://o123.ingest.us.sentry.io',
+    ]);
+    expect(result).toContain(
+      "connect-src 'self' https://o123.ingest.us.sentry.io;",
+    );
+  });
+
+  it('works for the worker-src placeholder too', () => {
+    const headers = `Content-Security-Policy: default-src 'self'; ${workerSrcPlaceholder}`;
+    const result = injectCspSources(headers, workerSrcPlaceholder, ['blob:']);
+    expect(result).toContain("worker-src 'self' blob:;");
+  });
+});
+
+describe('sentryConnectOrigin', () => {
+  it('returns undefined when the DSN is undefined', () => {
+    expect(sentryConnectOrigin(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the DSN is empty', () => {
+    expect(sentryConnectOrigin('')).toBeUndefined();
+  });
+
+  it('derives the ingest origin from a realistic Sentry DSN', () => {
+    expect(
+      sentryConnectOrigin('https://examplekey@o123456.ingest.us.sentry.io/789'),
+    ).toBe('https://o123456.ingest.us.sentry.io');
+  });
+
+  it('returns undefined for an unparsable DSN', () => {
+    expect(sentryConnectOrigin('not-a-url')).toBeUndefined();
+  });
+});

--- a/packages/web/scripts/generate-csp-headers.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.test.mjs
@@ -26,8 +26,11 @@ describe('extractInlineScriptHashes', () => {
     expect(extractInlineScriptHashes(html)).toHaveLength(1);
   });
 
-  it('skips scripts with a src attribute', () => {
-    const html = '<script type="module" async src="/app.js"></script>';
+  it('skips scripts with a src attribute, even when the body is non-empty', () => {
+    // A non-empty body means this can only pass via the `src=` check
+    // itself, not the separate empty-body skip below.
+    const html =
+      '<script type="module" async src="/app.js">not real content</script>';
     expect(extractInlineScriptHashes(html)).toStrictEqual([]);
   });
 
@@ -35,7 +38,7 @@ describe('extractInlineScriptHashes', () => {
     const hashed = extractInlineScriptHashes('<SCRIPT>const a = 1;</SCRIPT>');
     expect(hashed).toHaveLength(1);
     const skipped = extractInlineScriptHashes(
-      '<ScRiPt SRC="/app.js"></ScRiPt>',
+      '<ScRiPt SRC="/app.js">not real content</ScRiPt>',
     );
     expect(skipped).toStrictEqual([]);
   });
@@ -47,8 +50,8 @@ describe('extractInlineScriptHashes', () => {
 
   it('matches real-world end-tag forms browsers still honor', () => {
     // A browser's HTML tokenizer closes script raw-text mode on
-    // `</script` followed by *any* non-letter — whitespace, `/`, or
-    // bogus attributes — not only a bare `</script>`.
+    // `</script` followed by tab, newline, form feed, space, `/`, or
+    // `>` — not only a bare `</script>`.
     const forms = [
       '<script>const a = 1;</script >',
       '<script>const a = 1;</script\t\n>',
@@ -58,6 +61,19 @@ describe('extractInlineScriptHashes', () => {
     for (const html of forms) {
       expect(extractInlineScriptHashes(html)).toHaveLength(1);
     }
+  });
+
+  it('does not treat "</script" followed by a non-delimiter character as a close', async () => {
+    // A browser does NOT recognize `</script-anything` as an end tag at
+    // all (only tab/LF/FF/space/`/`/`>` may follow `</script`), so the
+    // raw-text scan continues past it to the *real* closing tag. A
+    // looser `\b`-word-boundary check would incorrectly stop here and
+    // hash only the truncated `const a = 1;` prefix.
+    const html = '<script>const a = 1;</script-fake>const b = 2;</script>';
+    const { createHash } = await import('node:crypto');
+    const body = 'const a = 1;</script-fake>const b = 2;';
+    const expected = `sha256-${createHash('sha256').update(body).digest('base64')}`;
+    expect(extractInlineScriptHashes(html)).toStrictEqual([expected]);
   });
 
   it('produces a hash matching an independently-computed sha256', async () => {

--- a/packages/web/scripts/generate-csp-headers.test.mjs
+++ b/packages/web/scripts/generate-csp-headers.test.mjs
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   connectSrcPlaceholder,
   extractInlineScriptHashes,
   injectCspSources,
+  malformedDsnWarning,
   scriptSrcPlaceholder,
   sentryConnectOrigin,
+  sentryConnectOriginOrWarn,
   workerSrcPlaceholder,
 } from './generate-csp-headers.mjs';
 
@@ -40,6 +42,16 @@ describe('extractInlineScriptHashes', () => {
     const html = `<script>${body}</script>`;
     const expected = `sha256-${createHash('sha256').update(body).digest('base64')}`;
     expect(extractInlineScriptHashes(html)).toStrictEqual([expected]);
+  });
+
+  it('does not false-positive on a script body that contains the text "<script src="', () => {
+    // The manifest script legitimately embeds asset metadata as a
+    // string; if that string happened to contain a script-tag-shaped
+    // substring, only the *opening* tag's own attributes should decide
+    // whether this is a src-referencing script.
+    const body = 'window.manifest = { snippet: "<script src=\\"x.js\\">" };';
+    const html = `<script>${body}</script>`;
+    expect(extractInlineScriptHashes(html)).toHaveLength(1);
   });
 });
 
@@ -103,5 +115,32 @@ describe('sentryConnectOrigin', () => {
 
   it('returns undefined for an unparsable DSN', () => {
     expect(sentryConnectOrigin('not-a-url')).toBeUndefined();
+  });
+});
+
+describe('sentryConnectOriginOrWarn', () => {
+  it('returns the origin and warns nothing when the DSN is valid', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(
+      sentryConnectOriginOrWarn(
+        'https://examplekey@o123456.ingest.us.sentry.io/789',
+      ),
+    ).toBe('https://o123456.ingest.us.sentry.io');
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('warns nothing when the DSN is unset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(sentryConnectOriginOrWarn(undefined)).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('warns when the DSN is set but unparsable, instead of failing silently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(sentryConnectOriginOrWarn('not-a-url')).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(malformedDsnWarning);
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

kit.black shipped no response security headers at all — no `netlify.toml`, no `public/_headers`, no `_redirects` (verified again on this branch: still absent before this change). This adds them.

**Header source: `packages/web/public/_headers`, not `netlify.toml`.** The `netlify-static` vinxi preset already copies `public/_headers` verbatim into `dist/_headers` and *appends* its own `/_build/assets/*` cache-control block to the same file (confirmed empirically with a local build before writing any header content). Reusing that existing mechanism avoids a second, competing Netlify config surface.

Headers added, all under a single `/*` block:

- `Strict-Transport-Security: max-age=63072000; includeSubDomains` (2-year max-age; `preload` deliberately omitted — that's a separate, harder-to-reverse decision requiring submission to the browser preload list)
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), midi=(), fullscreen=(), picture-in-picture=(), display-capture=()` — verified against `packages/web/src`: none of these APIs are used anywhere in the app
- `Content-Security-Policy` — directives derived from inspecting a local production build's actual `dist/**/*.html` and `dist/_build/assets/*.css` output (not guessed):
  - `default-src 'self'`
  - `script-src 'self' <hashes>` — see "Why a postbuild script" below
  - `style-src 'self' 'unsafe-inline'` — SolidStart inlines critical CSS at prerender time (the built output has 3 inline `<style>` blocks and 14 inline `style=` attributes); the issue text pre-authorizes `unsafe-inline` for styles specifically while requiring scripts to stay strict
  - `img-src 'self' data:` — daisyUI/Tailwind form-control background icons are inlined as `data:image/svg+xml` in the built CSS; nothing else uses a `data:` or third-party image URL
  - `font-src 'self'` — Lato is self-hosted since #149 (PR #196); no remaining Google Fonts origin
  - `connect-src 'self' <+ Sentry origin, conditionally>` / `worker-src 'self' <+ blob:, conditionally>` — see below
  - `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'` (no `<form>` exists in the built output, but a safe default), `object-src 'none'`

  Every external `https://…` reference in the built HTML (GitHub, X, YouTube, Booth, etc.) is a plain `<a href>` or `<link rel="alternate|author|license|canonical">` navigation target, never a resource load — CSP's fetch directives don't need to allow any of them.

### Why a postbuild script, not a fully static file

The prerendered pages inline a SolidStart hydration bootstrap and an asset manifest whose content embeds content-hashed filenames — so the inline `<script>` bodies (and their SHA-256 hashes) change on **every build**. A hardcoded hash list would go stale on the very next build and reintroduce the exact problem this issue exists to fix.

`packages/web/scripts/generate-csp-headers.mjs` runs as part of `postbuild` (after the existing `cp src/data.json … && rimraf …` step) and:

1. Walks `dist/**/*.html`, extracts every distinct non-empty inline `<script>` body (skipping any tag with its own `src=`), computes `sha256-<base64>` for each, and patches them into a literal `script-src 'self';` placeholder in `dist/_headers`. Committing a bare `'self'` as the placeholder means a `vinxi build` run *without* this postbuild step fails inline scripts closed instead of silently shipping an unpatched, over-permissive header.
2. Derives a Sentry `connect-src` origin from `VITE_SENTRY_DSN` when it's set at build time — a DSN has the shape `https://<key>@<host>/<projectId>`, and the origin the SDK actually calls is `https://<host>`, read directly from the same env var the app itself uses (`initSentry.ts`), never hand-guessed.
3. Also adds `worker-src 'self' blob:` when a DSN is present. **Verified by inspecting the actual built Sentry bundle**, not assumed: Session Replay's compression worker is created via `new Blob([...], {type:'text/javascript'})` + `URL.createObjectURL()` (a `blob:` URL), which `'self'` alone does not permit. This code ships in the bundle unconditionally (only the runtime `init()` call is DSN-gated — see `initSentry.ts`'s `if (!dsn) return;`), so a strict `worker-src 'self'` with a DSN configured would silently block Session Replay in production with no visible error.
4. Logs a warning (does not throw) if `VITE_SENTRY_DSN` is set but unparsable, since a malformed secret would otherwise silently ship `connect-src`/`worker-src` still pinned to `'self'` — and Sentry can't report its own CSP-blocked traffic to itself.

**Today's production build has no `VITE_SENTRY_DSN`** (roadmap #136's `#137` — creating the Sentry project — is still open and human-gated), so `connect-src`/`worker-src` stay at plain `'self'` for the header shipped by this PR. Once `#137` closes and the secret is registered, the very next production build will automatically pick up the correct Sentry origin and `blob:` allowance with no further code change needed here — this was the main gap flagged by this PR's own self-review (see below).

**No component or application code changes** — matches the issue's explicit acceptance criterion.

## Verification

- Full local production build (`pnpm run build`, Node 24.19.0) confirmed `dist/_headers` contains every header above with real (non-placeholder) hash values, run both with and without a representative `VITE_SENTRY_DSN` to confirm the conditional `connect-src`/`worker-src` and the malformed-DSN warning path.
- **The acceptance criterion "prerendered pages render with no CSP violations in the browser console" could not be interactively verified in this session** — no connected browser extension and no headless-Chromium system libraries were available in this sandbox, and there was no way to install them. As a substitute:
  - Exhaustively inventoried every resource-loading reference (`src=`/`href=` on script/img/link/font/media tags, and CSS `url()`) in the actual built `dist/` output against the shipped CSP directives (see the origin-by-directive breakdown above).
  - Directly inspected the built JS bundle for `new Worker(`/`URL.createObjectURL`/`blob:` usage to ground the `worker-src` decision in real bundled code rather than SDK documentation.
  - Added `packages/web/scripts/generate-csp-headers.build.test.mjs`, an automated integration test (runs whenever `dist/` exists — always true after CI's `pnpm run build` step, which `.github/workflows/push.yml` runs before `lint`/`test`) that fails if any inline-script hash in the built HTML is missing from `dist/_headers`, or if any built page references a third-party script/stylesheet/image/media resource (including `srcset` candidates, ahead of #151).
  - `packages/web/scripts/generate-csp-headers.test.mjs` unit-tests the pure hashing/injection/DSN-parsing functions against fixtures independently of any build.
- A one-time real-browser console check (Chrome DevTools, `pnpm run build && pnpm run serve` or equivalent) is recommended as a follow-up sanity check before or shortly after this merges, given the interactive verification gap above.
- `pnpm run lint` and `pnpm run test` pass (98 tests in `packages/web`, including 24 new).

## Self-review notes

A subagent critique pass on the initial diff flagged that the Sentry client instrumentation merged concurrently with this issue's authoring (#138/#139, both closed 2026-08-13) introduces real network/worker behavior this issue's original text didn't anticipate — addressed by the build-derived `connect-src`/`worker-src` logic above instead of guessing at an origin that doesn't exist yet (Sentry project creation, #137, is still open and human-gated).

A second critique pass on the resulting diff found and fixed, in a follow-up commit:
- The Sentry-DSN-present code path had no CI coverage and failed silently on a malformed DSN — now logs a warning instead.
- The inline-script `src=` detection tested the whole tag+body match instead of just the opening tag's attributes, which could theoretically false-positive on a script body containing the literal text `<script src=`.
- The build-integration test's third-party-resource check now also scans `srcset` candidates, not just `src`, ahead of #151.

Closes #146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added stronger security headers, including HSTS, content-type sniffing protection, referrer controls, permissions restrictions, and Content Security Policy protections.
  * Automatically updates CSP rules for inline scripts and approved monitoring connections during production builds.

* **Bug Fixes**
  * Improved compatibility with generated pages by detecting required script and resource sources in build output.

* **Tests**
  * Added automated checks for CSP generation, inline script hashes, resource detection, and monitoring configuration warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->