### PR TITLE
fix(web): derive x-default hreflang from the current path

### DIFF
--- a/packages/web/src/components/organisms/Head.test.tsx
+++ b/packages/web/src/components/organisms/Head.test.tsx
@@ -36,7 +36,14 @@ const renderHead = (path: string) => {
     <MetaProvider>
       <MemoryRouter history={history}>
         <Suspense>
-          <Route path="/:language?" component={Head} />
+          {/*
+           * The trailing `/*` lets this harness match a synthetic
+           * non-root path (e.g. `/en/about`) that the app itself does
+           * not route yet, while `:language?` still populates for
+           * `useLanguage()` so the OGP-locale assertions stay
+           * meaningful at those paths too.
+           */}
+          <Route path="/:language?/*" component={Head} />
         </Suspense>
       </MemoryRouter>
     </MetaProvider>
@@ -103,5 +110,14 @@ describe('organisms/Head', () => {
         'link[rel="alternate"][hreflang="x-default"]',
       ),
     ).toHaveAttribute('href', 'https://kit.black/');
+  });
+
+  it('derives x-default from the current path instead of the site root', () => {
+    renderHead('/en/about');
+    expect(
+      document.head.querySelector(
+        'link[rel="alternate"][hreflang="x-default"]',
+      ),
+    ).toHaveAttribute('href', 'https://kit.black/about');
   });
 });

--- a/packages/web/src/components/organisms/Head.tsx
+++ b/packages/web/src/components/organisms/Head.tsx
@@ -3,7 +3,10 @@ import type { Component } from 'solid-js';
 import { createMemo } from 'solid-js';
 import constants from '../../constants.json';
 import { useLanguage, useTranslator } from '../../modules/createI18N.js';
-import { useLanguageHref } from '../../modules/useLanguageHref.js';
+import {
+  useLanguageHref,
+  useUnprefixedHref,
+} from '../../modules/useLanguageHref.js';
 import { Head as InternalHead } from '../molecules/Head.js';
 
 /** The images for the Open Graph protocol. */
@@ -22,6 +25,7 @@ export const Head: Component = () => {
   const location = useLocation();
   const jaHref = useLanguageHref('ja');
   const enHref = useLanguageHref('en');
+  const defaultHref = useUnprefixedHref();
 
   /** The absolute URL of the current page. */
   const pageUrl = createMemo(() => `${constants.site.url}${location.pathname}`);
@@ -30,7 +34,7 @@ export const Head: Component = () => {
   const alternates = createMemo(() => [
     { hreflang: 'ja', href: `${constants.site.url}${jaHref()}` },
     { hreflang: 'en', href: `${constants.site.url}${enHref()}` },
-    { hreflang: 'x-default', href: `${constants.site.url}/` },
+    { hreflang: 'x-default', href: `${constants.site.url}${defaultHref()}` },
   ]);
 
   return (

--- a/packages/web/src/modules/useLanguageHref.test.tsx
+++ b/packages/web/src/modules/useLanguageHref.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from '@solidjs/testing-library';
 import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router';
 import type { Component } from 'solid-js';
 import { afterEach, describe, expect, it } from 'vitest';
-import { useLanguageHref } from './useLanguageHref.js';
+import { useLanguageHref, useUnprefixedHref } from './useLanguageHref.js';
 
 afterEach(() => cleanup());
 
@@ -19,21 +19,41 @@ const HrefProbe: Component<{ readonly target: 'en' | 'ja' }> = (props) => {
 };
 
 /**
+ * A probe component that renders {@link useUnprefixedHref}'s current
+ * value.
+ * @returns The component.
+ */
+const UnprefixedHrefProbe: Component = () => {
+  const href = useUnprefixedHref();
+  return <>{href()}</>;
+};
+
+/**
+ * Renders the given probe component under a `MemoryRouter` initialized
+ * at the given path.
+ * @param path The initial memory-history location.
+ * @param Probe The probe component to render.
+ * @returns The `render` result.
+ */
+const renderProbe = (path: string, Probe: Component) => {
+  const history = createMemoryHistory();
+  history.set({ value: path, replace: true });
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route component={Probe} path="*" />
+    </MemoryRouter>
+  ));
+};
+
+/**
  * Renders {@link HrefProbe} under a `MemoryRouter` initialized at the
  * given path.
  * @param path The initial memory-history location.
  * @param target The target language to swap to.
  * @returns The `render` result.
  */
-const renderHrefProbe = (path: string, target: 'en' | 'ja') => {
-  const history = createMemoryHistory();
-  history.set({ value: path, replace: true });
-  return render(() => (
-    <MemoryRouter history={history}>
-      <Route component={() => <HrefProbe target={target} />} path="*" />
-    </MemoryRouter>
-  ));
-};
+const renderHrefProbe = (path: string, target: 'en' | 'ja') =>
+  renderProbe(path, () => <HrefProbe target={target} />);
 
 describe('useLanguageHref', () => {
   it('targets the language root when swapping from the unprefixed root', () => {
@@ -49,5 +69,41 @@ describe('useLanguageHref', () => {
   it('swaps en to ja while preserving the rest of the path', () => {
     const { container } = renderHrefProbe('/en/', 'ja');
     expect(container.textContent).toBe('/ja/');
+  });
+
+  it('swaps the locale segment while preserving a trailing path', () => {
+    // A consuming segment-boundary regex (`(?:\/|$)`) would eat the `/`
+    // before the trailing segment too, mangling the two words together
+    // -- this case only fails under that bug, unlike the bare `/en/`
+    // cases above.
+    const { container } = renderHrefProbe('/en/about', 'ja');
+    expect(container.textContent).toBe('/ja/about');
+  });
+
+  it('does not treat a non-locale path starting with "en" as prefixed', () => {
+    const { container } = renderHrefProbe('/enterprise', 'ja');
+    expect(container.textContent).toBe('/ja/enterprise');
+  });
+});
+
+describe('useUnprefixedHref', () => {
+  it('stays at the root when the path is already unprefixed', () => {
+    const { container } = renderProbe('/', UnprefixedHrefProbe);
+    expect(container.textContent).toBe('/');
+  });
+
+  it('strips a bare locale segment back to the root', () => {
+    const { container } = renderProbe('/ja/', UnprefixedHrefProbe);
+    expect(container.textContent).toBe('/');
+  });
+
+  it('strips the locale segment while preserving a trailing path', () => {
+    const { container } = renderProbe('/en/about', UnprefixedHrefProbe);
+    expect(container.textContent).toBe('/about');
+  });
+
+  it('does not treat a non-locale path starting with "en" as prefixed', () => {
+    const { container } = renderProbe('/enterprise', UnprefixedHrefProbe);
+    expect(container.textContent).toBe('/enterprise');
   });
 });

--- a/packages/web/src/modules/useLanguageHref.ts
+++ b/packages/web/src/modules/useLanguageHref.ts
@@ -2,8 +2,27 @@ import { useLocation } from '@solidjs/router';
 import { createMemo } from 'solid-js';
 import type { Language } from './createI18N.js';
 
-/**The regular expression for the language. */
-const regexp = /^\/?(en|ja)/;
+/**
+ * The regular expression for the language.
+ *
+ * The trailing lookahead asserts a segment boundary without consuming
+ * it -- this function's callers use `.replace()` to remove the matched
+ * locale segment, so a *consuming* boundary (e.g. `(?:\/|$)`) would eat
+ * the following `/` along with it and mangle the remaining path (unlike
+ * `entry-server.tsx`'s own copy of this pattern, which only reads a
+ * capture group via `.exec()` and never reconstructs a path, so
+ * consuming the boundary there is harmless).
+ */
+const regexp = /^\/?(en|ja)(?=\/|$)/;
+
+/**
+ * Strips the request base and any leading locale segment from a
+ * pathname.
+ * @param pathname The raw route pathname.
+ * @returns The path with the locale segment removed.
+ */
+const stripLanguageSegment = (pathname: string): string =>
+  pathname.replace(import.meta.env.SERVER_BASE_URL, '').replace(regexp, '');
 
 /**
  * Uses the href with language from dynamic route.
@@ -12,10 +31,18 @@ const regexp = /^\/?(en|ja)/;
  */
 export const useLanguageHref = (target: Language) => {
   const location = useLocation();
-  return createMemo(() => {
-    const realPath = location.pathname
-      .replace(import.meta.env.SERVER_BASE_URL, '')
-      .replace(regexp, '');
-    return `/${target}${realPath}`;
-  });
+  return createMemo(
+    () => `/${target}${stripLanguageSegment(location.pathname)}`,
+  );
+};
+
+/**
+ * Uses the current path with any leading locale segment stripped, for
+ * locale-independent links such as the `x-default` hreflang alternate.
+ * @returns The unprefixed path (`/` when nothing else follows the
+ * locale segment).
+ */
+export const useUnprefixedHref = () => {
+  const location = useLocation();
+  return createMemo(() => stripLanguageSegment(location.pathname) || '/');
 };


### PR DESCRIPTION
## Summary

The `x-default` hreflang alternate in `organisms/Head.tsx` was hardcoded
to the site root. That's only correct today because the site has
exactly one route; a future non-root page would still advertise `/` as
its `x-default`, misdirecting crawlers.

`useLanguageHref.ts`'s locale-matching regex also had no trailing
segment-boundary assertion, so a future path such as `/enterprise`
would have its leading `en` incorrectly treated as a locale prefix.

- Anchor the regex to a **lookahead** boundary, `/^\/?(en|ja)(?=\/|$)/`
  — not the consuming `(?:\/|$)` form used in `entry-server.tsx`.
  `entry-server.tsx` only reads a capture group via `.exec()`, so
  consuming the boundary there is harmless; `useLanguageHref.ts`
  reconstructs a path via `.replace()`, so a consuming boundary would
  eat the trailing `/` along with the locale segment and mangle the
  remaining path (e.g. `/en/about` → `about` instead of `/about`,
  producing `/jaabout` after a target swap). Verified by hand and with
  `node -e` against `/ja/`, `/en/about`, `/enterprise`, and `/`.
- Extract the shared "strip the request base, then strip the locale
  segment" logic into a private `stripLanguageSegment` helper, reused
  by both `useLanguageHref` (unchanged behavior) and the new exported
  `useUnprefixedHref()`.
- `Head.tsx` now derives the `x-default` href from
  `useUnprefixedHref()` instead of a hardcoded root.

## Tests

- `useLanguageHref.test.tsx`: added cases for the segment-boundary fix
  (`/enterprise` stays untouched; `/en/about` → `/ja/about`, which only
  passes under the lookahead form) and for the new `useUnprefixedHref`
  hook (root stays `/`; `/en/about` → `/about`; `/enterprise` stays
  `/enterprise`).
- `Head.test.tsx`: parameterized `renderHead`'s route to
  `/:language?/*` so a synthetic non-root path can be exercised while
  still populating `:language` for the existing OGP-locale assertions;
  added a case asserting `x-default` at `/en/about` resolves to
  `https://kit.black/about`, alongside the existing root-path case
  (still `https://kit.black/`, unchanged).

Closes #199

## Verification

- `pnpm run lint` — clean (two pre-existing oxlint warnings in
  unrelated files, not touched by this diff).
- `pnpm run test` — 114/114 passing in `packages/web`.
- An independent critique pass on the plan caught a real bug before
  implementation (the issue's own suggestion to copy
  `entry-server.tsx`'s consuming-boundary regex verbatim would have
  broken the existing "swaps ja to en" test and mangled non-root
  paths); a second independent critique pass on the finished diff
  found no correctness issues.
