### PR TITLE
fix(web): sync document.documentElement.lang on client-side locale switch

### DIFF
--- a/packages/web/src/components/organisms/Head.test.tsx
+++ b/packages/web/src/components/organisms/Head.test.tsx
@@ -1,13 +1,15 @@
 import { MetaProvider } from '@solidjs/meta';
 import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router';
-import { cleanup, render } from '@solidjs/testing-library';
-import { Suspense } from 'solid-js';
+import { cleanup, render, waitFor } from '@solidjs/testing-library';
+import type { Component } from 'solid-js';
+import { onMount, Suspense } from 'solid-js';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Head } from './Head.js';
 
 afterEach(() => {
   cleanup();
   document.head.innerHTML = '';
+  document.documentElement.lang = '';
 });
 
 /**
@@ -119,5 +121,48 @@ describe('organisms/Head', () => {
         'link[rel="alternate"][hreflang="x-default"]',
       ),
     ).toHaveAttribute('href', 'https://kit.black/about');
+  });
+
+  it('sets document.documentElement.lang to match the initial en page', async () => {
+    renderHead('/en/');
+    await waitFor(() => expect(document.documentElement.lang).toBe('en'));
+  });
+
+  it('sets document.documentElement.lang to match the initial ja page', async () => {
+    renderHead('/ja/');
+    await waitFor(() => expect(document.documentElement.lang).toBe('ja'));
+  });
+
+  it('keeps document.documentElement.lang synchronized after a client-side navigation, without remounting Head', async () => {
+    // A naive `onMount`-only implementation could pass a lang assertion
+    // alone by coincidentally remounting on this navigation. Wrapping
+    // `Head` with a mount-count probe keeps this test honest: it fails
+    // if the fix ever starts relying on a remount instead of reacting
+    // to `useLanguage()` in place, matching how `Head` is actually
+    // mounted once at the router root (`RootTemplate`) in production.
+    let mountCount = 0;
+    const ProbedHead: Component = () => {
+      onMount(() => {
+        mountCount += 1;
+      });
+      return <Head />;
+    };
+    const history = createMemoryHistory();
+    history.set({ value: '/en/', replace: true });
+    render(() => (
+      <MetaProvider>
+        <MemoryRouter history={history}>
+          <Suspense>
+            <Route path="/:language?/*" component={ProbedHead} />
+          </Suspense>
+        </MemoryRouter>
+      </MetaProvider>
+    ));
+    await waitFor(() => expect(document.documentElement.lang).toBe('en'));
+    expect(mountCount).toBe(1);
+
+    history.set({ value: '/ja/', replace: true });
+    await waitFor(() => expect(document.documentElement.lang).toBe('ja'));
+    expect(mountCount).toBe(1);
   });
 });

--- a/packages/web/src/components/organisms/Head.tsx
+++ b/packages/web/src/components/organisms/Head.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from '@solidjs/router';
 import type { Component } from 'solid-js';
-import { createMemo } from 'solid-js';
+import { createEffect, createMemo } from 'solid-js';
+import { isServer } from 'solid-js/web';
 import constants from '../../constants.json';
 import { useLanguage, useTranslator } from '../../modules/createI18N.js';
 import {
@@ -26,6 +27,19 @@ export const Head: Component = () => {
   const jaHref = useLanguageHref('ja');
   const enHref = useLanguageHref('en');
   const defaultHref = useUnprefixedHref();
+
+  // `entry-server.tsx` sets `<html lang>` once, during the initial SSR
+  // pass; the document shell it renders is outside this component tree.
+  // A client-side locale switch (`LanguageChanger`) is an SPA navigation
+  // that only re-renders inside `#app`, so nothing else keeps
+  // `document.documentElement.lang` in sync afterward. Skip this
+  // entirely during SSR (`document` does not exist there, and the
+  // server-rendered value must stay the first-paint source of truth).
+  if (!isServer) {
+    createEffect(() => {
+      document.documentElement.lang = language();
+    });
+  }
 
   /** The absolute URL of the current page. */
   const pageUrl = createMemo(() => `${constants.site.url}${location.pathname}`);


### PR DESCRIPTION
## Summary

`entry-server.tsx` sets `<html lang>` once, during the initial SSR
pass, since the document shell renders outside the router. Switching
locale via `LanguageChanger` performs a client-side (SPA) navigation
that only re-renders inside `#app`, so `document.documentElement.lang`
kept the page's original request language even after the visible
content switched -- misleading assistive technology and browser
translation tooling.

- Added a client-only `createEffect` in `organisms/Head.tsx`, guarded
  by `isServer` from `solid-js/web`, that keeps
  `document.documentElement.lang` synchronized with the reactive
  `useLanguage()` accessor. `Head` mounts once at the router root
  (`RootTemplate.tsx`), so it survives client-side navigations instead
  of remounting, and the `isServer` guard means the effect never runs
  during SSR/prerendering -- the server-rendered first-paint value
  stays untouched and authoritative.
- `Language` (`'en' | 'ja'`) is already a valid BCP-47 primary subtag,
  so no locale mapping is needed (unlike the `og:locale` mapping a few
  lines below it, which serves a different purpose).

## Tests

- `Head.test.tsx`: added cases asserting
  `document.documentElement.lang` matches the initial route (`en`/`ja`)
  on first render.
- Added a case that renders at `/en/`, then drives a client-side-only
  navigation to `/ja/` on the same `MemoryRouter` history (no
  remount), asserting `document.documentElement.lang` updates to
  `ja`. The test also wraps `Head` with a mount-count probe and
  asserts the count stays `1` across the navigation, so the test
  cannot pass against a naive `onMount`-only implementation that
  happened to remount instead of reacting.
- Reset `document.documentElement.lang` in the existing `afterEach`
  alongside the current `document.head.innerHTML` reset.

Closes #200

## Verification

- `pnpm run lint` -- clean (two pre-existing oxlint warnings in files
  this diff does not touch).
- `pnpm run test` -- 117/117 passing across the workspace, including
  all 10 in `Head.test.tsx`.
- An independent critique pass on the plan (before implementation)
  recommended the mount-count probe above, to make the client-side
  navigation test self-verifying regardless of router internals. A
  second independent critique pass on the finished diff found no
  correctness issues (two low-severity, non-blocking notes: a
  pre-existing type-looseness in `useLanguage()` that this diff does
  not introduce, and minor test-scaffolding duplication).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The document language now updates correctly when switching between English and Japanese pages.
  * Language settings remain synchronized during client-side navigation without requiring a page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->