### PR TITLE
fix(web): derive the calendar's since/until from data.json rows

### DIFF
--- a/packages/web/src/components/organisms/Calendar.test.tsx
+++ b/packages/web/src/components/organisms/Calendar.test.tsx
@@ -1,6 +1,9 @@
 import { MemoryRouter, Route } from '@solidjs/router';
 import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import rows from '../../data.json';
+import { dateRangeOf } from '../../modules/dateRange.js';
+import type { RowProps } from '../atoms/calendar/Row.js';
 import { Calendar } from './Calendar.js';
 
 // `vi.mock` factories may only reference hoisted bindings, so the mock
@@ -39,6 +42,18 @@ afterEach(() => {
 });
 
 describe('Calendar organism', () => {
+  it('renders the date span derived from data.json rows, not the wall clock', () => {
+    const [since, until] = dateRangeOf(rows as readonly RowProps[]);
+
+    const { getByText } = render(() => (
+      <MemoryRouter>
+        <Route path="/:language?" component={Calendar} />
+      </MemoryRouter>
+    ));
+
+    expect(getByText(`${since}〜${until}`)).toBeInTheDocument();
+  });
+
   it('captures the calendar element and downloads it with the computed filename', async () => {
     URL.createObjectURL = createObjectURL;
     URL.revokeObjectURL = revokeObjectURL;

--- a/packages/web/src/components/organisms/Calendar.tsx
+++ b/packages/web/src/components/organisms/Calendar.tsx
@@ -1,6 +1,6 @@
-import { tupleMap, weekRange, formatDate } from '@kurone-kito/kit.black-lib';
 import type { Component } from 'solid-js';
 import rows from '../../data.json';
+import { dateRangeOf } from '../../modules/dateRange.js';
 import { calendarDownloadFilename } from '../../modules/downloadFilename.js';
 import { useTranslator } from '../../modules/createI18N.js';
 import { Article } from '../atoms/Article.js';
@@ -9,12 +9,16 @@ import { DownloadCalendarButton } from '../atoms/DownloadCalendarButton.js';
 import { Calendar as MoleculeCalendar } from '../molecules/calendar/Calendar.js';
 
 /*
- * Captured once, at build time -- this must stay aligned with the
- * `data.json` the same build produced, so it is intentionally not a
- * reactive value. Do not replace this with a live-updating clock; doing
- * so would desynchronize the displayed range from the fetched rows.
+ * Derived once, at build time, from the same `rows` the component
+ * renders below -- so this must stay aligned with the `data.json` the
+ * same build produced, and is intentionally not a reactive value. Do
+ * not replace this with a wall-clock read (`new Date()`); this module
+ * evaluates once server-side during prerender and again client-side on
+ * hydration, and a wall-clock value can disagree between the two once
+ * real time has passed -- see #174.
  */
-const [since, until] = tupleMap(weekRange(new Date()), formatDate);
+const typedRows = rows as readonly RowProps[];
+const [since, until] = dateRangeOf(typedRows);
 
 /**
  * The calendar component.
@@ -67,7 +71,7 @@ export const Calendar: Component = () => {
       <MoleculeCalendar
         id="calendar"
         ref={calendarRef}
-        rows={rows as readonly RowProps[]}
+        rows={typedRows}
         since={since}
         until={until}
       />

--- a/packages/web/src/modules/dateRange.test.ts
+++ b/packages/web/src/modules/dateRange.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { RowProps } from '../components/atoms/calendar/Row.js';
+import { dateRangeOf } from './dateRange.js';
+
+describe('dateRangeOf', () => {
+  it('returns the first and last defined date across multiple days', () =>
+    expect(
+      dateRangeOf([
+        { children: 'A', date: '08/10', type: 'others', week: 'sun' },
+        { children: 'B', date: '08/11', type: 'others', week: 'mon' },
+        { children: 'C', date: '08/16', type: 'others', week: 'sat' },
+      ]),
+    ).toEqual(['08/10', '08/16']));
+
+  it('returns the same date twice for a single row', () =>
+    expect(
+      dateRangeOf([
+        { children: 'A', date: '08/10', type: 'others', week: 'sun' },
+      ]),
+    ).toEqual(['08/10', '08/10']));
+
+  it('falls back to the last row that carries a date, when the last day has multiple events', () =>
+    // The fetcher only sets `date` on the first row of each calendar
+    // day (see `packages/fetcher/src/toRow.mts`), so the array's final
+    // entry can have `date: undefined` even though it belongs to the
+    // last day in range.
+    expect(
+      dateRangeOf([
+        { children: 'A', date: '08/10', type: 'others', week: 'sun' },
+        {
+          children: 'B',
+          date: '08/16',
+          dateSpan: 2,
+          type: 'others',
+          week: 'sat',
+        },
+        { children: 'C', date: undefined, type: 'others', week: 'sat' },
+      ]),
+    ).toEqual(['08/10', '08/16']));
+
+  it('returns empty strings for an empty rows array', () =>
+    expect(dateRangeOf([])).toEqual(['', '']));
+
+  it('returns empty strings when no row carries a date', () =>
+    expect(
+      dateRangeOf([
+        { children: 'A', date: undefined, type: 'others', week: 'sun' },
+      ] satisfies readonly RowProps[]),
+    ).toEqual(['', '']));
+});

--- a/packages/web/src/modules/dateRange.ts
+++ b/packages/web/src/modules/dateRange.ts
@@ -1,0 +1,20 @@
+import type { RowProps } from '../components/atoms/calendar/Row.js';
+
+/**
+ * Derives the displayed schedule's start/end date labels from the
+ * fetched rows, instead of reading the wall clock.
+ *
+ * Pinning this to the same `rows` the build's `data.json` produced
+ * keeps the displayed range in agreement with what is actually
+ * rendered, regardless of when or where (server prerender vs. client
+ * hydration) this is evaluated -- see #174.
+ * @param rows The schedule rows this build's `data.json` produced.
+ * @returns A `[since, until]` tuple; each is `''` when no row carries a
+ *   `date` (for example, an empty `rows`).
+ */
+export const dateRangeOf = (
+  rows: readonly RowProps[],
+): readonly [since: string, until: string] => {
+  const dates = rows.flatMap((row) => (row.date ? [row.date] : []));
+  return [dates.at(0) ?? '', dates.at(-1) ?? ''];
+};

--- a/packages/web/src/modules/dateRange.ts
+++ b/packages/web/src/modules/dateRange.ts
@@ -8,6 +8,10 @@ import type { RowProps } from '../components/atoms/calendar/Row.js';
  * keeps the displayed range in agreement with what is actually
  * rendered, regardless of when or where (server prerender vs. client
  * hydration) this is evaluated -- see #174.
+ *
+ * Assumes `rows` is already in chronological order, which
+ * `packages/fetcher/src/parseEvent.mts` guarantees for the generated
+ * `data.json`; this function does not itself sort.
  * @param rows The schedule rows this build's `data.json` produced.
  * @returns A `[since, until]` tuple; each is `''` when no row carries a
  *   `date` (for example, an empty `rows`).


### PR DESCRIPTION
## Summary

`organisms/Calendar.tsx` computed the displayed schedule's `since`/
`until` labels at module scope via `tupleMap(weekRange(new Date()),
formatDate)`. On this prerendered (SSG) site, that module evaluates
twice -- once server-side during the build's prerender pass, and again
client-side when a visitor's browser hydrates the shipped bundle,
which can happen anywhere from seconds to days later since the deploy
is a static file served from a CDN. Neither `new Date()` call is
pinned to build time, so the two evaluations could disagree once real
time passed since the build (most obviously across a day/week
boundary), producing a hydration mismatch and a displayed range that
no longer agreed with the `rows` the same build's `data.json`
produced -- the exact invariant the removed code comment said must
hold.

- Added `modules/dateRange.ts` (`dateRangeOf`), a pure helper that
  derives `[since, until]` from the fetched `rows` array's own `date`
  fields instead of the wall clock. `RowProps.date` is only set on the
  first row of each calendar day (`packages/fetcher/src/toRow.mts`),
  so the helper collects every defined `date` and takes the first and
  last.
- `Calendar.tsx` now calls `dateRangeOf(typedRows)` and reuses the
  same typed `rows` array for the `MoleculeCalendar` prop, removing a
  duplicate inline cast.
- No wall-clock read (`new Date()`/`Date.now()`) remains in this file.

Closes #174

## Tests

- Added `modules/dateRange.test.ts`: multi-day rows, a single-row
  case, a last-day-with-multiple-events case (the array's final entry
  has `date: undefined`, so the helper must fall back to the last row
  that *does* carry a date), and the empty-`rows` edge case (`[]` in,
  `['', '']` out).
- Added a case to `organisms/Calendar.test.tsx` that renders the real
  component and asserts the rendered header text matches the
  `since`/`until` derived from the actual `data.json` rows -- an
  integration-level check on the component wiring itself, not just
  the pure helper.
- Verified locally: a production build's prerendered HTML
  (`dist/index.html`) shows the date span `08/14〜08/20`, matching
  `data.json`'s first and last row dates exactly. Because both the
  server prerender and the client hydration pass now read the same
  static `data.json` content instead of independent wall-clock reads,
  the two can no longer disagree by construction.

## Verification

- `pnpm run lint` -- clean (two pre-existing oxlint warnings in files
  this diff does not touch).
- `pnpm run test` -- 123/123 passing across the workspace, including
  all new cases above.
- Two independent critique passes: the first (on the initial diff)
  found two low-severity, non-blocking notes -- thin component-level
  test coverage, and an undocumented pre-sorted-`rows` assumption in
  the new helper -- both addressed in a follow-up commit. A second
  independent pass on the combined diff found no remaining issues.

## Out of scope

Per the issue: the clock-interval removal in #152 is not reopened or
reverted.
