### PR TITLE
fix(web): stop the calendar logo from polluting the heading outline

### DIFF
--- a/packages/web/src/components/atoms/Logo.test.tsx
+++ b/packages/web/src/components/atoms/Logo.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Logo } from './Logo.js';
+
+afterEach(() => cleanup());
+
+describe('Logo', () => {
+  it('renders an h1 by default when level is omitted', () => {
+    render(() => <Logo />);
+    const wordmark = screen
+      .getByText('Kuroné')
+      .closest('h1, h2, h3, h4, h5, h6, p');
+    expect(wordmark?.tagName).toBe('H1');
+  });
+
+  it('renders the requested heading level when level is a number', () => {
+    render(() => <Logo level={3} />);
+    const wordmark = screen
+      .getByText('Kuroné')
+      .closest('h1, h2, h3, h4, h5, h6, p');
+    expect(wordmark?.tagName).toBe('H3');
+  });
+
+  it('renders no heading element when level is false', () => {
+    const { container } = render(() => <Logo level={false} />);
+    const wordmark = screen
+      .getByText('Kuroné')
+      .closest('h1, h2, h3, h4, h5, h6, p');
+    expect(wordmark?.tagName).toBe('P');
+    expect(container.querySelectorAll('h1, h2, h3, h4, h5, h6')).toHaveLength(
+      0,
+    );
+  });
+});

--- a/packages/web/src/components/atoms/Logo.tsx
+++ b/packages/web/src/components/atoms/Logo.tsx
@@ -7,10 +7,12 @@ import type { IntRange } from 'type-fest';
 /** Type definition for the properties. */
 export interface LogoProps extends JSX.AriaAttributes {
   /**
-   * The heading level.
+   * The heading level, or `false` to render the wordmark without a
+   * heading element at all (for decorative or repeated occurrences that
+   * must not appear in the document's heading outline).
    * @default 1
    */
-  readonly level?: IntRange<1, 7> | undefined;
+  readonly level?: IntRange<1, 7> | false | undefined;
 
   /** The CSS classes. */
   readonly class?: string | undefined;
@@ -38,7 +40,7 @@ export const Logo: Component<LogoProps> = (props) => {
     >
       <Dynamic
         class="-ml-[3.5cqh] break-all p-0 text-[44.5cqh] font-black leading-[32.8cqh] after:absolute after:bottom-[1cqh] after:right-[2.1cqh] after:text-[5cqh] after:font-black after:leading-none after:content-['TM']"
-        component={`h${local.level}` as const}
+        component={local.level === false ? 'p' : (`h${local.level}` as const)}
       >
         <span class="-tracking-[4.5cqh]">Kuroné</span>
         <span class="-tracking-[7.4cqh]">Kito</span>

--- a/packages/web/src/components/molecules/calendar/Header.test.tsx
+++ b/packages/web/src/components/molecules/calendar/Header.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Header } from './Header.js';
+
+afterEach(() => cleanup());
+
+describe('calendar Header molecule', () => {
+  it('renders the date-span text as the section h3, with no other headings', () => {
+    const { container } = render(() => <Header dateSpan="10/21〜10/27" />);
+    const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.tagName).toBe('H3');
+    expect(headings[0]?.textContent).toContain('10/21〜10/27');
+  });
+
+  it('does not render the decorative calendar logo as a heading element', () => {
+    const { container } = render(() => <Header dateSpan="10/21〜10/27" />);
+    const wordmark = container.querySelectorAll('p');
+    const wordmarkTexts = Array.from(wordmark).map((el) => el.textContent);
+    expect(wordmarkTexts.some((text) => text?.includes('Kuroné'))).toBe(true);
+  });
+});

--- a/packages/web/src/components/molecules/calendar/Header.tsx
+++ b/packages/web/src/components/molecules/calendar/Header.tsx
@@ -20,11 +20,15 @@ export interface HeaderProps {
 export const Header: Component<HeaderProps> = (props) => (
   <header class="flex items-end gap-4 drop-shadow lg:basis-4/12 lg:flex-col-reverse">
     <div class="relative w-full basis-3/12 sm:basis-4/12">
-      <Logo class="lg:text-stroke-3 max-md:opacity-80" level={3} />
-      <Logo aria-hidden class="absolute top-0 w-full max-md:hidden" level={3} />
+      <Logo class="lg:text-stroke-3 max-md:opacity-80" level={false} />
+      <Logo
+        aria-hidden
+        class="absolute top-0 w-full max-md:hidden"
+        level={false}
+      />
     </div>
     <div class="text-stroke-3">
-      <h4 class="text-[4.5cqi] font-semibold lg:text-[3.1cqi] xl:text-[3.2cqi] 2xl:text-[3.1cqi]">
+      <h3 class="text-[4.5cqi] font-semibold lg:text-[3.1cqi] xl:text-[3.2cqi] 2xl:text-[3.1cqi]">
         予定表:
         <Show when={props.dateSpan}>
           &nbsp;
@@ -33,7 +37,7 @@ export const Header: Component<HeaderProps> = (props) => (
             {props.dateSpan}
           </span>
         </Show>
-      </h4>
+      </h3>
       <p class="font-semibold md:text-[2.8cqi] lg:text-[2.7cqi]">
         #️⃣&nbsp;
         <Anchor


### PR DESCRIPTION
## Summary

The calendar `Header` rendered the brand `Logo` twice as a decorative
`<h3>` (one `aria-hidden`, both purely visual), while the section's own
date-range text was hardcoded as an `<h4>` — one level deeper than its
only sibling heading. A screen-reader user jumping by heading heard the
brand name three times total and got no signal about where the section's
actual content sits in the outline.

- `atoms/Logo.tsx` gains a `level={false}` escape hatch that renders the
  wordmark without a heading element. Callers that omit `level` keep the
  existing default (`h1`), so `molecules/KitoWithLogo.tsx`'s hero heading
  is unaffected — no change needed there.
- Both `molecules/calendar/Header.tsx` `Logo` calls switch from
  `level={3}` to `level={false}`.
- The date-range `<h4>` is promoted to `<h3>`, becoming the section's
  first and only heading.
- Adds `Logo.test.tsx` and `Header.test.tsx` covering the default/level/
  no-heading rendering paths.

Verified against a production build: each of `dist/index.html`,
`dist/ja/index.html`, `dist/en/index.html` now contains exactly one
heading with the wordmark text (the page's `<h1>`), and the calendar
section's date-range text is inside an `<h3>`.

Closes #211

## Test plan

- [x] `pnpm run build`, then confirmed in `dist/{,ja/,en/}index.html`:
      exactly one heading contains the wordmark and it is `<h1>`; the
      calendar section's date-range text is inside an `<h3>`.
- [x] `pnpm run lint`
- [x] `pnpm run test` (all packages, 128 web tests including the two new
      files)
- [ ] Storybook stories for `Logo`, `KitoWithLogo`, and calendar
      `Header` — `pnpm run build:storybook` currently fails locally with
      a CJS/ESM `ReferenceError` that reproduces identically on
      unmodified `main` (Node 23.6.1 vs. the `>=24.2.0` engine floor);
      unrelated to this diff. The equivalent Solid rendering path is
      exercised by `pnpm run build` and the new component tests instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved calendar header heading hierarchy for clearer navigation.
  * Decorative calendar logos no longer appear as headings.

* **Enhancements**
  * Logos can now render as paragraph text instead of heading elements when needed.

* **Tests**
  * Added coverage for logo heading levels and calendar header semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->