### PR TITLE
refactor(a11y): replace non-native ARIA-role wrappers with native elements

### DIFF
--- a/packages/web/src/components/atoms/CarouselItem.tsx
+++ b/packages/web/src/components/atoms/CarouselItem.tsx
@@ -17,13 +17,13 @@ export interface CarouselItemProps
 export const CarouselItem: Component<CarouselItemProps> = (props) => {
   const [local, rest] = splitProps(props, ['class']);
   return (
-    <div class={twMerge('aspect-video', local.class)} role="listitem">
+    <li class={twMerge('aspect-video', local.class)}>
       <img
         class="rounded-box saturate-100 transition-[filter] duration-500 hover:saturate-100 lg:saturate-[.33]"
         decoding="async"
         fetchpriority="low"
         {...rest}
       />
-    </div>
+    </li>
   );
 };

--- a/packages/web/src/components/atoms/IconContainer.test.tsx
+++ b/packages/web/src/components/atoms/IconContainer.test.tsx
@@ -7,7 +7,7 @@ afterEach(() => cleanup());
 describe('IconContainer', () => {
   it('is decorative by default: aria-hidden, no role', () => {
     const { container } = render(() => <IconContainer />);
-    const icon = container.querySelector('i');
+    const icon = container.querySelector('span');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
     expect(icon).not.toHaveAttribute('role');
     expect(icon).not.toHaveAttribute('aria-label');
@@ -15,7 +15,7 @@ describe('IconContainer', () => {
 
   it('exposes an accessible name when a label is given', () => {
     const { container } = render(() => <IconContainer label="A named icon" />);
-    const icon = container.querySelector('i');
+    const icon = container.querySelector('span');
     expect(icon).toHaveAttribute('role', 'img');
     expect(icon).toHaveAttribute('aria-label', 'A named icon');
     expect(icon).not.toHaveAttribute('aria-hidden');
@@ -23,7 +23,7 @@ describe('IconContainer', () => {
 
   it('treats a blank (empty or whitespace-only) label as decorative', () => {
     const { container } = render(() => <IconContainer label="   " />);
-    const icon = container.querySelector('i');
+    const icon = container.querySelector('span');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
     expect(icon).not.toHaveAttribute('role');
     expect(icon).not.toHaveAttribute('aria-label');

--- a/packages/web/src/components/atoms/IconContainer.tsx
+++ b/packages/web/src/components/atoms/IconContainer.tsx
@@ -29,13 +29,13 @@ export const IconContainer: Component<IconProps> = (props) => {
   /** Whether a non-blank accessible name was given. */
   const isNamed = () => (concProps.label ?? '').trim() !== '';
   return (
-    <i
+    <span
       aria-hidden={isNamed() ? undefined : true}
       aria-label={isNamed() ? concProps.label : undefined}
       class={twMerge('not-italic', concProps.class)}
       role={isNamed() ? 'img' : undefined}
     >
       {concProps.children}
-    </i>
+    </span>
   );
 };

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -30,13 +30,12 @@ export interface SceneCarouselProps {
  */
 export const Carousel: Component<SceneCarouselProps> = (props) => (
   <div class="bg-base-100 px-0.5 py-12">
-    <figure
+    <ul
       aria-label={props.label}
       class={twMerge(
         'carousel carousel-center focus-visible:outline-primary aspect-[19/9] h-auto w-full space-x-4 px-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:aspect-[27/9] xl:aspect-[28/9] 2xl:aspect-[43/9]',
         props.class,
       )}
-      role="list"
       tabindex="0"
     >
       <Index each={props.items}>
@@ -50,6 +49,6 @@ export const Carousel: Component<SceneCarouselProps> = (props) => (
           />
         )}
       </Index>
-    </figure>
+    </ul>
   </div>
 );


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/kit.black/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/kit.black/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/kit.black/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Replaces two non-native ARIA-role wrapper patterns with the native
HTML elements the ARIA-in-HTML mapping table already provides for the
same structure:

- `molecules/Carousel.tsx`: `<figure role="list" tabindex="0"
  aria-label={props.label}>` → `<ul tabindex="0"
  aria-label={props.label}>` (the redundant `role="list"` is dropped;
  `tabindex="0"` and `aria-label` are preserved verbatim from #157's
  keyboard-accessibility work).
- `atoms/CarouselItem.tsx`: `<div role="listitem">` → `<li>`.
- `atoms/IconContainer.tsx`: `<i>` wrapper → `<span>` (all
  `aria-hidden`/`aria-label`/`role="img"` decision logic and the
  `not-italic` class are unchanged; only the tag name changes).
- `atoms/IconContainer.test.tsx`: updates the three
  `container.querySelector('i')` calls to `querySelector('span')` to
  match.

This is a simplification, not a correctness fix — the prior pattern
was valid ARIA, not a spec violation.

Closes #213

## Verification

- `pnpm run build` (packages/web) succeeds.
- `npx html-validate "dist/**/*.html"` (run from `packages/web`)
  reports zero `prefer-native-element` findings for the carousel
  (was 28 before this change).
- Built `dist/**/*.html` contains `<ul aria-label="..." tabindex="0">`
  and `<li>` for the carousel, no `role="list"`/`role="listitem"`
  anywhere, and `<span aria-hidden="true" class="not-italic">` for
  icons — no `<i>` tags remain.
- `pnpm run lint` and `pnpm run test` pass (128 tests, including the
  updated `IconContainer.test.tsx`).
- Two independent critique passes (plan-stage and diff-stage) found no
  blocking issues — only two low-severity, non-blocking notes: (1) the
  standalone `CarouselItem.stories.ts` story renders an isolated `<li>`
  outside a `<ul>`/`<ol>` (pre-existing story-design smell, not a
  production defect — `CarouselItem` is always correctly nested inside
  `Carousel`'s new `<ul>`); (2) dropping `role="list"` while relying on
  the native `<ul>` role is a commonly-cited but disputed
  accessibility-tree simplification technique, which this issue
  explicitly specified.

## Out of scope (per the issue)

- The splash overlay's `role="status"` (intentional, already reviewed).
- The activities-carousel `role="list"`/`role="listitem"` pattern was
  not a spec violation to begin with — this PR is the deliberate
  simplification the issue asked for, not a correctness fix.
