### PR TITLE
fix(a11y): name the duplicate complementary landmarks and switch

### DIFF
--- a/packages/web/src/components/atoms/ToggleTheme.stories.ts
+++ b/packages/web/src/components/atoms/ToggleTheme.stories.ts
@@ -9,8 +9,6 @@ export const Default: StoryObj<Target> = {};
 
 export default {
   args: {
-    labelToDark: 'Dark',
-    labelToLight: 'Light',
     themes: ['light', 'dark'],
     toggleTooltip: 'Toggle theme',
   },

--- a/packages/web/src/components/atoms/ToggleTheme.test.tsx
+++ b/packages/web/src/components/atoms/ToggleTheme.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ToggleTheme } from './ToggleTheme.js';
+
+afterEach(() => cleanup());
+
+describe('ToggleTheme', () => {
+  it('names the switch control directly instead of relying on sibling icons', () => {
+    const { container } = render(() => (
+      <ToggleTheme toggleTooltip="Toggle theme" />
+    ));
+    const input = container.querySelector('input[role="switch"]');
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('aria-label', 'Toggle theme');
+  });
+
+  it('makes the sun and moon icons decorative so they never carry a competing accessible name', () => {
+    const { container } = render(() => (
+      <ToggleTheme toggleTooltip="Toggle theme" />
+    ));
+    const icons = container.querySelectorAll('svg');
+    expect(icons).toHaveLength(2);
+    for (const icon of icons) {
+      expect(icon).not.toHaveAttribute('aria-label');
+      expect(icon).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+});

--- a/packages/web/src/components/atoms/ToggleTheme.tsx
+++ b/packages/web/src/components/atoms/ToggleTheme.tsx
@@ -3,12 +3,6 @@ import { Component, mergeProps, Ref } from 'solid-js';
 
 /** Type definition for the properties. */
 export interface ToggleThemeProps {
-  /** The label to change to dark mode. */
-  readonly labelToDark?: string | undefined;
-
-  /** The label to change to light mode. */
-  readonly labelToLight?: string | undefined;
-
   /** The reference to the input element. */
   readonly ref?: Ref<HTMLInputElement> | undefined;
 
@@ -33,6 +27,7 @@ export const ToggleTheme: Component<ToggleThemeProps> = (props) => {
     >
       <label class="swap swap-rotate pointer-events-auto">
         <input
+          aria-label={concProps.toggleTooltip}
           data-toggle-theme={concProps.themes.join(',')}
           onKeyDown={(e) => e.key === 'Enter' && e.currentTarget.click()}
           ref={concProps.ref}
@@ -41,11 +36,11 @@ export const ToggleTheme: Component<ToggleThemeProps> = (props) => {
           value="dark"
         />
         <FaSolidSun
-          aria-label={concProps.labelToDark}
+          aria-hidden={true}
           class="fill-primary-content swap-off h-6 w-6"
         />
         <FaSolidMoon
-          aria-label={concProps.labelToLight}
+          aria-hidden={true}
           class="fill-primary-content swap-on h-6 w-6"
         />
       </label>

--- a/packages/web/src/components/organisms/Footer.test.tsx
+++ b/packages/web/src/components/organisms/Footer.test.tsx
@@ -1,0 +1,19 @@
+import { MemoryRouter, Route } from '@solidjs/router';
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Footer } from './Footer.js';
+
+afterEach(() => cleanup());
+
+describe('Footer organism', () => {
+  it('names the complementary landmark so it is distinguishable from other asides', () => {
+    const { container } = render(() => (
+      <MemoryRouter>
+        <Route path="/:language?" component={Footer} />
+      </MemoryRouter>
+    ));
+    const aside = container.querySelector('aside');
+    expect(aside).not.toBeNull();
+    expect(aside?.getAttribute('aria-label')?.trim()).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/organisms/Footer.tsx
+++ b/packages/web/src/components/organisms/Footer.tsx
@@ -12,7 +12,11 @@ export const Footer: Component = () => {
   const t = useTranslator();
   return (
     <footer class="footer footer-center bg-base-300 text-base-content px-safe pb-safe-or-6 pt-6 font-extralight">
-      <aside class="flex font-thin tracking-wide" translate="no">
+      <aside
+        aria-label={t('footerCredits')}
+        class="flex font-thin tracking-wide"
+        translate="no"
+      >
         <p>
           &copy; 2018-{new Date().getFullYear()} {t('author')}
         </p>

--- a/packages/web/src/components/organisms/ToggleTheme.tsx
+++ b/packages/web/src/components/organisms/ToggleTheme.tsx
@@ -24,8 +24,6 @@ export const ToggleTheme: Component = () => {
   const t = useTranslator();
   return (
     <InternalToggleTheme
-      labelToDark={t('toDark')}
-      labelToLight={t('toLight')}
       ref={ref}
       themes={themes}
       toggleTooltip={t('toggleTheme')}

--- a/packages/web/src/components/organisms/Works.test.tsx
+++ b/packages/web/src/components/organisms/Works.test.tsx
@@ -1,0 +1,19 @@
+import { MemoryRouter, Route } from '@solidjs/router';
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Works } from './Works.js';
+
+afterEach(() => cleanup());
+
+describe('Works organism', () => {
+  it('names the complementary landmark so it is distinguishable from other asides', () => {
+    const { container } = render(() => (
+      <MemoryRouter>
+        <Route path="/:language?" component={Works} />
+      </MemoryRouter>
+    ));
+    const aside = container.querySelector('aside');
+    expect(aside).not.toBeNull();
+    expect(aside?.getAttribute('aria-label')?.trim()).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/organisms/Works.tsx
+++ b/packages/web/src/components/organisms/Works.tsx
@@ -144,6 +144,7 @@ export const Works: Component = () => {
         />
       </ul>
       <aside
+        aria-label={t('worksMore')}
         class="prose [&_a]:link [&_a]:link-primary [&_a]:font-semibold"
         innerHTML={aside('text')}
       />

--- a/packages/web/src/i18n/dictionaries.test.ts
+++ b/packages/web/src/i18n/dictionaries.test.ts
@@ -11,4 +11,18 @@ describe('i18n dictionaries', () => {
     // loop that catches a key added to one locale and not the other.
     expect(Object.keys(ja).sort()).toStrictEqual(Object.keys(en).sort());
   });
+
+  it.each([
+    ['en', en],
+    ['ja', ja],
+  ])(
+    'gives the two complementary-landmark asides distinct accessible names in %s',
+    (_locale, resources) => {
+      // The two `<aside>` landmarks (Footer, Works) must have distinct
+      // accessible names -- html-validate's `unique-landmark` rule
+      // fails when duplicate `complementary` regions share a name,
+      // not merely when either is empty.
+      expect(resources.footerCredits).not.toBe(resources.worksMore);
+    },
+  );
 });

--- a/packages/web/src/i18n/en.ts
+++ b/packages/web/src/i18n/en.ts
@@ -10,6 +10,7 @@ const resources: Resources = {
   calendar:
     'The following live streaming schedule is automatically generated based on information extracted from the Calendar app eight times daily.',
   downloadCalendar: 'Save the schedule calendar as an image',
+  footerCredits: 'Copyright and site links',
   hamburgerMenu: 'Menu',
   heroAbout: 'About Kuroné Kito',
   heroIntroduction: 'Kuroné Kito’s introduction',
@@ -25,13 +26,12 @@ const resources: Resources = {
   siteDescription:
     'The official site of Kuroné Kito (くろねきと), a black cat VTuber.',
   splashLoading: 'Loading the website',
-  toDark: 'Switch to dark mode',
   toggleTheme: 'Toggle theme',
-  toLight: 'Switch to light mode',
   wishlist: 'Wishlist',
   worksDescription:
     'Kuroné Kito has developed several apps using live programming. Here, we’ll introduce some of the main ones.',
   worksHeading: 'Kuroné Kito’s works',
+  worksMore: 'More of Kuroné Kito’s works on GitHub',
 };
 
 export default resources;

--- a/packages/web/src/i18n/ja.ts
+++ b/packages/web/src/i18n/ja.ts
@@ -10,6 +10,7 @@ const resources: Resources = {
   calendar:
     '以下の配信スケジュールは、カレンダー アプリから毎日 8 回抽出した情報に基づき、自動生成しております。',
   downloadCalendar: 'スケジュール表を画像として保存',
+  footerCredits: '著作権表示とサイトリンク',
   hamburgerMenu: 'メニュー',
   heroAbout: '黒音キトについて',
   heroIntroduction: '黒音キトの自己紹介',
@@ -25,13 +26,12 @@ const resources: Resources = {
   siteDescription:
     '黒猫にゃんにゃん VTuber、黒音キト (くろねきと) の公式サイトです。',
   splashLoading: 'ウェブサイトを読み込み中',
-  toDark: 'ダークモードにする',
   toggleTheme: 'テーマ切り替え',
-  toLight: 'ライトモードにする',
   wishlist: 'ほしい物リスト',
   worksDescription:
     '黒音キトはライブ プログラミングでいくつかのアプリを開発しています。そのうち主要なものを幾つか紹介いたします。',
   worksHeading: '黒音キトの主な作品',
+  worksMore: '黒音キトの GitHub 上のその他の作品',
 };
 
 export default resources;

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -13,6 +13,7 @@ export type ResourcesKeys =
   | 'avatarNext'
   | 'calendar'
   | 'downloadCalendar'
+  | 'footerCredits'
   | 'hamburgerMenu'
   | 'heroAbout'
   | 'heroIntroduction'
@@ -27,9 +28,8 @@ export type ResourcesKeys =
   | 'repository'
   | 'siteDescription'
   | 'splashLoading'
-  | 'toDark'
   | 'toggleTheme'
-  | 'toLight'
   | 'wishlist'
   | 'worksDescription'
-  | 'worksHeading';
+  | 'worksHeading'
+  | 'worksMore';


### PR DESCRIPTION
## Summary

Fixes the two remaining accessibility defects tracked by issue #212
(the last open track of roadmap #214):

- The `<aside>` landmarks in `Footer.tsx` and `Works.tsx` had no
  accessible name, so `html-validate` reported duplicate
  `complementary` landmarks (`unique-landmark`). Each now carries a
  distinct, translated `aria-label`.
- The theme-switch `<input role="switch">` in `ToggleTheme.tsx` had no
  accessible name of its own; instead, two sibling `FaSolidSun`/
  `FaSolidMoon` icons each carried an `aria-label` on a raw `<svg>`
  with no `role="img"`, which `html-validate` flagged as
  `aria-label-misuse` (x2). The accessible name now lives on the
  input itself, and both icons are marked `aria-hidden` since they no
  longer need to carry a name.
- The now-unused `labelToDark`/`labelToLight` prop pair (and the
  `toDark`/`toLight` i18n keys that fed them) were removed, since
  nothing reads them once the icons stopped carrying their own label.

## Verification

- `pnpm run lint` and `pnpm run test` pass (134/134 tests in
  `packages/web`, including 6 new/updated targeted tests).
- `pnpm run build` then `npx html-validate "dist/**/*.html"` (from
  `packages/web`) reports zero `unique-landmark` and zero
  `aria-label-misuse` findings across `/`, `/en/`, and `/ja/`.
- Manually confirmed distinct, non-empty `aria-label` values on both
  `<aside>` elements and the switch `<input>` in all three built
  locale variants.

Closes #212

## Follow-up

None — this is the last remaining track of roadmap #214.