### PR TITLE
feat(web): auto-scroll the activities carousel, pausing on interaction

### DIFF
--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -43,6 +43,19 @@ const fire = (target: EventTarget, type: string): void => {
 };
 
 /**
+ * Reads which item the carousel currently marks as active, via the
+ * `data-carousel-active` test hook -- avoids depending on the mocked
+ * `scrollTo` call arguments, which jsdom's zero-layout geometry would
+ * make indistinguishable across indices.
+ * @param container The rendered container.
+ * @returns The active item's index, or -1 if none is marked.
+ */
+const activeIndexOf = (container: HTMLElement): number =>
+  [...container.querySelectorAll('li')].findIndex((li) =>
+    li.hasAttribute('data-carousel-active'),
+  );
+
+/**
  * Fakes a measurable layout for the carousel and its items, so
  * {@link Carousel}'s scroll-position resync logic has real geometry to
  * read instead of falling back to the last known index. `nearIndex`
@@ -69,7 +82,7 @@ const stubLayout = (container: HTMLElement, nearIndex: number): void => {
 
 beforeEach(() => {
   vi.useFakeTimers();
-  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.scrollTo = vi.fn();
   stubMatchMedia(false);
 });
 
@@ -84,34 +97,48 @@ afterEach(() => {
 });
 
 describe('Carousel', () => {
+  it('scrolls only its own container, never an ancestor, on every advance', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const scrollTo = vi.mocked(Element.prototype.scrollTo);
+
+    vi.advanceTimersByTime(3_000);
+
+    // `scrollTo` is called on the `<ul>` itself, never on a `<li>` or
+    // an ancestor -- unlike `Element.scrollIntoView`, it never walks
+    // or scrolls anything outside this element.
+    const ul = container.querySelector('ul');
+    expect(scrollTo.mock.instances.at(-1)).toBe(ul);
+    expect(scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ behavior: 'smooth' }),
+    );
+  });
+
   it('advances one item after 3 seconds of inactivity, repeatedly, while mounted', () => {
     const { container } = render(() => (
       <Carousel items={items} label="Example carousel" />
     ));
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
 
     vi.advanceTimersByTime(3_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+    expect(activeIndexOf(container)).toBe(1);
 
     vi.advanceTimersByTime(3_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[2]);
+    expect(activeIndexOf(container)).toBe(2);
 
     vi.advanceTimersByTime(3_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[3]);
+    expect(activeIndexOf(container)).toBe(3);
   });
 
   it('loops back to the first item after reaching the last', () => {
     const { container } = render(() => (
       <Carousel items={items} label="Example carousel" />
     ));
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
 
     for (let i = 0; i < items.length; i += 1) {
       vi.advanceTimersByTime(3_000);
     }
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[0]);
+    expect(activeIndexOf(container)).toBe(0);
   });
 
   it('resets the pending timer on a manual interaction; no advance occurs until 3 more seconds of inactivity', () => {
@@ -120,37 +147,31 @@ describe('Carousel', () => {
     ));
     const ul = container.querySelector('ul');
     if (!ul) throw new Error('ul not found');
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
-    const callsBefore = scrollIntoView.mock.calls.length;
 
     vi.advanceTimersByTime(2_000);
     fire(ul, 'scroll');
     vi.advanceTimersByTime(2_000);
-    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+    expect(activeIndexOf(container)).toBe(0);
 
     vi.advanceTimersByTime(1_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+    expect(activeIndexOf(container)).toBe(1);
   });
 
   it('never starts the timer when prefers-reduced-motion: reduce is requested', () => {
     stubMatchMedia(true);
-    render(() => <Carousel items={items} label="Example carousel" />);
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
     expect(vi.getTimerCount()).toBe(0);
 
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const callsAfterMount = scrollIntoView.mock.calls.length;
     vi.advanceTimersByTime(60_000);
-    expect(scrollIntoView.mock.calls.length).toBe(callsAfterMount);
+    expect(activeIndexOf(container)).toBe(0);
   });
 
   it('does not advance while the tab is hidden, and resumes once it is visible again', () => {
     const { container } = render(() => (
       <Carousel items={items} label="Example carousel" />
     ));
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
-    const callsBefore = scrollIntoView.mock.calls.length;
 
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
@@ -158,7 +179,7 @@ describe('Carousel', () => {
     });
     fire(document, 'visibilitychange');
     vi.advanceTimersByTime(10_000);
-    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+    expect(activeIndexOf(container)).toBe(0);
 
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
@@ -166,7 +187,7 @@ describe('Carousel', () => {
     });
     fire(document, 'visibilitychange');
     vi.advanceTimersByTime(3_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+    expect(activeIndexOf(container)).toBe(1);
   });
 
   it('pauses while hovered, and resumes once the pointer leaves', () => {
@@ -175,17 +196,14 @@ describe('Carousel', () => {
     ));
     const ul = container.querySelector('ul');
     if (!ul) throw new Error('ul not found');
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
-    const callsBefore = scrollIntoView.mock.calls.length;
 
     fire(ul, 'mouseenter');
     vi.advanceTimersByTime(10_000);
-    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+    expect(activeIndexOf(container)).toBe(0);
 
     fire(ul, 'mouseleave');
     vi.advanceTimersByTime(3_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+    expect(activeIndexOf(container)).toBe(1);
   });
 
   it('pauses while keyboard focus is inside it, and resumes once focus leaves', () => {
@@ -194,17 +212,35 @@ describe('Carousel', () => {
     ));
     const ul = container.querySelector('ul');
     if (!ul) throw new Error('ul not found');
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
-    const callsBefore = scrollIntoView.mock.calls.length;
 
     fire(ul, 'focusin');
     vi.advanceTimersByTime(10_000);
-    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+    expect(activeIndexOf(container)).toBe(0);
 
     fire(ul, 'focusout');
     vi.advanceTimersByTime(3_000);
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+    expect(activeIndexOf(container)).toBe(1);
+  });
+
+  it('pausing on hover and focus together lifts only once both end', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+
+    fire(ul, 'mouseenter');
+    fire(ul, 'focusin');
+    vi.advanceTimersByTime(10_000);
+    expect(activeIndexOf(container)).toBe(0);
+
+    fire(ul, 'mouseleave');
+    vi.advanceTimersByTime(10_000);
+    expect(activeIndexOf(container)).toBe(0);
+
+    fire(ul, 'focusout');
+    vi.advanceTimersByTime(3_000);
+    expect(activeIndexOf(container)).toBe(1);
   });
 
   it('resumes autoplay from the actual scroll position rather than a stale remembered index', () => {
@@ -213,8 +249,6 @@ describe('Carousel', () => {
     ));
     const ul = container.querySelector('ul');
     if (!ul) throw new Error('ul not found');
-    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
-    const lis = () => [...container.querySelectorAll('li')];
 
     // Simulate the visitor manually scrolling straight to item 2
     // (skipping the internal activeIndex signal, still at 0) and
@@ -223,7 +257,7 @@ describe('Carousel', () => {
     fire(ul, 'scroll');
     vi.advanceTimersByTime(3_000);
 
-    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[3]);
+    expect(activeIndexOf(container)).toBe(3);
   });
 
   it('does not schedule a timer for an empty item list', () => {

--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -1,0 +1,228 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Item } from './Carousel.js';
+import { Carousel } from './Carousel.js';
+
+/** The items shared by every test in this file. */
+const items: readonly Item[] = Array.from(
+  { length: 4 },
+  (_, i) => [`https://example.test/${i}.webp`, `Item ${i}`] as const,
+);
+
+/**
+ * Stubs `window.matchMedia` so `(prefers-reduced-motion: reduce)`
+ * reports a fixed, controllable state. jsdom has no native
+ * `matchMedia` implementation. Mirrors
+ * `src/modules/createDarkMode.test.ts`'s `stubMatchMedia` helper.
+ * @param matches Whether the reduced-motion media query should report
+ *   a match.
+ */
+const stubMatchMedia = (matches: boolean): void => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    })),
+  );
+};
+
+/**
+ * Dispatches a plain DOM event on the given element.
+ * @param target The element to dispatch on.
+ * @param type The event type.
+ */
+const fire = (target: EventTarget, type: string): void => {
+  target.dispatchEvent(new Event(type, { bubbles: true }));
+};
+
+/**
+ * Fakes a measurable layout for the carousel and its items, so
+ * {@link Carousel}'s scroll-position resync logic has real geometry to
+ * read instead of falling back to the last known index. `nearIndex`
+ * is reported as centered; every other item is reported far away.
+ * @param container The rendered container.
+ * @param nearIndex The index that should read as closest to center.
+ */
+const stubLayout = (container: HTMLElement, nearIndex: number): void => {
+  const ul = container.querySelector('ul');
+  if (!ul) throw new Error('ul not found');
+  Object.defineProperty(ul, 'clientWidth', { configurable: true, value: 300 });
+  vi.spyOn(ul, 'getBoundingClientRect').mockReturnValue(
+    new DOMRect(0, 0, 300, 200),
+  );
+  const lis = [...container.querySelectorAll('li')];
+  for (const [i, li] of lis.entries()) {
+    vi.spyOn(li, 'getBoundingClientRect').mockReturnValue(
+      i === nearIndex
+        ? new DOMRect(140, 0, 20, 200)
+        : new DOMRect(10_000, 0, 20, 200),
+    );
+  }
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Element.prototype.scrollIntoView = vi.fn();
+  stubMatchMedia(false);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+});
+
+describe('Carousel', () => {
+  it('advances one item after 3 seconds of inactivity, repeatedly, while mounted', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+
+    vi.advanceTimersByTime(3_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+
+    vi.advanceTimersByTime(3_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[2]);
+
+    vi.advanceTimersByTime(3_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[3]);
+  });
+
+  it('loops back to the first item after reaching the last', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+
+    for (let i = 0; i < items.length; i += 1) {
+      vi.advanceTimersByTime(3_000);
+    }
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[0]);
+  });
+
+  it('resets the pending timer on a manual interaction; no advance occurs until 3 more seconds of inactivity', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+    const callsBefore = scrollIntoView.mock.calls.length;
+
+    vi.advanceTimersByTime(2_000);
+    fire(ul, 'scroll');
+    vi.advanceTimersByTime(2_000);
+    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+
+    vi.advanceTimersByTime(1_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+  });
+
+  it('never starts the timer when prefers-reduced-motion: reduce is requested', () => {
+    stubMatchMedia(true);
+    render(() => <Carousel items={items} label="Example carousel" />);
+    expect(vi.getTimerCount()).toBe(0);
+
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const callsAfterMount = scrollIntoView.mock.calls.length;
+    vi.advanceTimersByTime(60_000);
+    expect(scrollIntoView.mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it('does not advance while the tab is hidden, and resumes once it is visible again', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+    const callsBefore = scrollIntoView.mock.calls.length;
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    fire(document, 'visibilitychange');
+    vi.advanceTimersByTime(10_000);
+    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    fire(document, 'visibilitychange');
+    vi.advanceTimersByTime(3_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+  });
+
+  it('pauses while hovered, and resumes once the pointer leaves', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+    const callsBefore = scrollIntoView.mock.calls.length;
+
+    fire(ul, 'mouseenter');
+    vi.advanceTimersByTime(10_000);
+    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+
+    fire(ul, 'mouseleave');
+    vi.advanceTimersByTime(3_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+  });
+
+  it('pauses while keyboard focus is inside it, and resumes once focus leaves', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+    const callsBefore = scrollIntoView.mock.calls.length;
+
+    fire(ul, 'focusin');
+    vi.advanceTimersByTime(10_000);
+    expect(scrollIntoView.mock.calls.length).toBe(callsBefore);
+
+    fire(ul, 'focusout');
+    vi.advanceTimersByTime(3_000);
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[1]);
+  });
+
+  it('resumes autoplay from the actual scroll position rather than a stale remembered index', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    const lis = () => [...container.querySelectorAll('li')];
+
+    // Simulate the visitor manually scrolling straight to item 2
+    // (skipping the internal activeIndex signal, still at 0) and
+    // resting there past the interval.
+    stubLayout(container, 2);
+    fire(ul, 'scroll');
+    vi.advanceTimersByTime(3_000);
+
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[3]);
+  });
+});

--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -225,4 +225,16 @@ describe('Carousel', () => {
 
     expect(scrollIntoView.mock.instances.at(-1)).toBe(lis()[3]);
   });
+
+  it('does not schedule a timer for an empty item list', () => {
+    render(() => <Carousel items={[]} label="Example carousel" />);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not schedule a timer for a single-item list', () => {
+    render(() => (
+      <Carousel items={items.slice(0, 1)} label="Example carousel" />
+    ));
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -204,6 +204,24 @@ describe('Carousel', () => {
     expect(activeIndexOf(container)).toBe(0);
   });
 
+  it('scrolls instantly instead of smoothly when prefers-reduced-motion: reduce is requested', () => {
+    stubMatchMedia(true);
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+    const scrollTo = vi.mocked(Element.prototype.scrollTo);
+
+    // Autoplay never runs under reduced motion, but the position-sync
+    // effect (the only thing that can call `scrollTo`) still applies
+    // `prefers-reduced-motion` independently -- defense-in-depth
+    // against a future direct `setActiveIndex` caller re-animating.
+    expect(scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ behavior: 'auto' }),
+    );
+  });
+
   it('does not advance while the tab is hidden, and resumes once it is visible again', () => {
     const { container } = render(() => (
       <Carousel items={items} label="Example carousel" />

--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -217,8 +217,11 @@ describe('Carousel', () => {
     // effect (the only thing that can call `scrollTo`) still applies
     // `prefers-reduced-motion` independently -- defense-in-depth
     // against a future direct `setActiveIndex` caller re-animating.
+    // `'instant'`, not `'auto'`: the `carousel` class sets CSS
+    // `scroll-behavior: smooth`, which `'auto'` would defer to instead
+    // of overriding.
     expect(scrollTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({ behavior: 'auto' }),
+      expect.objectContaining({ behavior: 'instant' }),
     );
   });
 

--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -115,6 +115,42 @@ describe('Carousel', () => {
     );
   });
 
+  it("computes the scroll target from bounding-rect deltas and the container's own scrollLeft, not offsetLeft", () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+    const lis = [...container.querySelectorAll('li')];
+
+    // The container sits at viewport x=100 and is 300px wide (center
+    // at x=250), already scrolled 50px, and is itself offset from a
+    // non-positioned ancestor -- `offsetLeft` would read a value tied
+    // to that ancestor chain instead of this geometry.
+    Object.defineProperty(ul, 'scrollLeft', {
+      configurable: true,
+      value: 50,
+    });
+    vi.spyOn(ul, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(100, 0, 300, 200),
+    );
+    // Item 1 (the next item autoplay advances to) sits at viewport
+    // x=440, 40px wide (center at x=460).
+    vi.spyOn(lis[1] as HTMLElement, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(440, 0, 40, 200),
+    );
+
+    const scrollTo = vi.mocked(Element.prototype.scrollTo);
+    vi.advanceTimersByTime(3_000);
+
+    // left = scrollLeft(50) + (targetLeft(440) - containerLeft(100) +
+    // targetWidth(40)/2)(360) - containerWidth(300)/2(150) = 260.
+    expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: 'smooth',
+      left: 260,
+    });
+  });
+
   it('advances one item after 3 seconds of inactivity, repeatedly, while mounted', () => {
     const { container } = render(() => (
       <Carousel items={items} label="Example carousel" />

--- a/packages/web/src/components/molecules/Carousel.test.tsx
+++ b/packages/web/src/components/molecules/Carousel.test.tsx
@@ -296,6 +296,39 @@ describe('Carousel', () => {
     expect(activeIndexOf(container)).toBe(3);
   });
 
+  it('keeps autoplaying even when the resync-derived next index numerically equals the current one', () => {
+    const { container } = render(() => (
+      <Carousel items={items} label="Example carousel" />
+    ));
+    const ul = container.querySelector('ul');
+    if (!ul) throw new Error('ul not found');
+
+    // First tick uses the default (no measurable layout) fallback, so
+    // it advances 0 -> 1 normally.
+    vi.advanceTimersByTime(3_000);
+    expect(activeIndexOf(container)).toBe(1);
+
+    // Now the visitor manually scrolls back near item 0. The next
+    // resync-derived advance is (0 + 1) % 4 = 1 -- numerically identical to
+    // the already-current activeIndex signal value. A default-equals
+    // signal would treat that `setActiveIndex` as a no-op and never
+    // notify, silently stopping the reschedule effect from running
+    // again -- this pins that autoplay survives the collision instead.
+    stubLayout(container, 0);
+    fire(ul, 'scroll');
+    vi.advanceTimersByTime(3_000);
+    expect(activeIndexOf(container)).toBe(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    // Drop back to the no-measurable-layout fallback (nearestIndex
+    // now reads the current signal directly again) to confirm the
+    // rescheduled timer keeps advancing on its own, rather than only
+    // checking that one timer object exists.
+    Object.defineProperty(ul, 'clientWidth', { configurable: true, value: 0 });
+    vi.advanceTimersByTime(3_000);
+    expect(activeIndexOf(container)).toBe(2);
+  });
+
   it('does not schedule a timer for an empty item list', () => {
     render(() => <Carousel items={[]} label="Example carousel" />);
     expect(vi.getTimerCount()).toBe(0);

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -153,14 +153,28 @@ export const Carousel: Component<SceneCarouselProps> = (props) => {
       else child.removeAttribute(ACTIVE_ATTRIBUTE);
     }
     const target = children[index];
-    if (!(target instanceof HTMLElement)) return;
+    if (!target) return;
     // Scroll only this container's own horizontal position -- never
     // `target.scrollIntoView()`, which would also walk and scroll
     // every scrollable ancestor up to the page itself, yanking a
     // visitor who has since scrolled elsewhere on the page back to
     // the carousel on every autoplay tick.
+    //
+    // Computed from `getBoundingClientRect()` deltas (the same source
+    // {@link nearestIndex} reads) plus the container's own current
+    // `scrollLeft`, rather than `target.offsetLeft` -- `offsetLeft` is
+    // relative to `offsetParent`, which is not necessarily this
+    // container (neither the `<ul>` nor its ancestors are
+    // CSS-positioned here), so it would silently compute the wrong
+    // value instead of failing loudly.
+    const containerRect = listRef.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const targetCenterFromContainerLeft =
+      targetRect.left - containerRect.left + targetRect.width / 2;
     const left =
-      target.offsetLeft + target.offsetWidth / 2 - listRef.clientWidth / 2;
+      listRef.scrollLeft +
+      targetCenterFromContainerLeft -
+      containerRect.width / 2;
     listRef.scrollTo?.({ behavior: 'smooth', left });
   });
 

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -33,11 +33,16 @@ export interface SceneCarouselProps {
 /** How often autoplay advances to the next item, in milliseconds. */
 const AUTOPLAY_INTERVAL_MS = 3_000;
 
-/** Options shared by every programmatic scroll this component performs. */
+/**
+ * Options shared by every programmatic scroll this component performs.
+ * `inline: 'center'` matches the `carousel-center` class's own
+ * `scroll-snap-align: center` on each item, so the JS-driven scroll
+ * agrees with the CSS snap point instead of fighting it.
+ */
 const SCROLL_OPTIONS = {
   behavior: 'smooth',
   block: 'nearest',
-  inline: 'start',
+  inline: 'center',
 } as const satisfies ScrollIntoViewOptions;
 
 /**
@@ -113,6 +118,12 @@ export const Carousel: Component<SceneCarouselProps> = (props) => {
    * one. Does nothing while unmounted, reduced-motion is requested, or
    * autoplay is paused -- callers rely on this to both start the
    * initial timer and to postpone it on manual interaction.
+   *
+   * Also bound as the `scroll` handler, so autoplay's own smooth
+   * scroll counts as activity and pushes the next advance out by up to
+   * one interval too -- an accepted, self-correcting pacing nuance
+   * (never a stuck timer), consistent with "advance after N seconds of
+   * inactivity" rather than a hard fixed-cadence clock.
    */
   const scheduleAdvance = () => {
     clearTimer();

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -64,7 +64,15 @@ const ACTIVE_ATTRIBUTE = 'data-carousel-active';
 export const Carousel: Component<SceneCarouselProps> = (props) => {
   let listRef: HTMLUListElement | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const [activeIndex, setActiveIndex] = createSignal(0);
+  // `equals: false`: the next index is geometry-derived (see
+  // `nearestIndex`), so a manual scroll can leave it numerically equal
+  // to the already-current value (e.g. the visitor scrolls back near
+  // where autoplay last left off). Default `Object.is` equality would
+  // silently drop that `setActiveIndex` call as a no-op, and since the
+  // reschedule effect below only re-runs when this signal actually
+  // notifies, autoplay would stop scheduling entirely until the next
+  // manual interaction. Always notifying keeps the reschedule alive.
+  const [activeIndex, setActiveIndex] = createSignal(0, { equals: false });
   const [hovered, setHovered] = createSignal(false);
   const [focused, setFocused] = createSignal(false);
   const [visible, setVisible] = createSignal(true);

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -1,5 +1,12 @@
 import type { Component } from 'solid-js';
-import { Index } from 'solid-js';
+import { createMediaQuery } from '@solid-primitives/media';
+import {
+  createEffect,
+  createSignal,
+  Index,
+  onCleanup,
+  onMount,
+} from 'solid-js';
 import { twMerge } from 'tailwind-merge';
 import { CarouselItem } from '../atoms/CarouselItem.js';
 
@@ -23,32 +30,161 @@ export interface SceneCarouselProps {
   readonly label: string;
 }
 
+/** How often autoplay advances to the next item, in milliseconds. */
+const AUTOPLAY_INTERVAL_MS = 3_000;
+
+/** Options shared by every programmatic scroll this component performs. */
+const SCROLL_OPTIONS = {
+  behavior: 'smooth',
+  block: 'nearest',
+  inline: 'start',
+} as const satisfies ScrollIntoViewOptions;
+
 /**
  * The carousel component.
+ *
+ * Autoplays by advancing one item every {@link AUTOPLAY_INTERVAL_MS}.
+ * Any manual interaction (scroll, touch, pointer, keyboard) postpones
+ * the next advance by the same interval, and autoplay pauses entirely
+ * while the pointer hovers the carousel, while keyboard focus is
+ * inside it, while the tab is not visible, or when the user agent
+ * requests `prefers-reduced-motion: reduce` (in which case the timer
+ * never starts at all). The timer only starts after client mount, so
+ * it never runs during SSR/prerendering and never affects the
+ * prerendered markup.
+ *
+ * Each advance re-derives its starting point from the carousel's
+ * actual current scroll position (see {@link nearestIndex} below)
+ * rather than trusting a remembered index, so autoplay resuming after
+ * a manual scroll continues from wherever the visitor left it instead
+ * of snapping back to a stale position.
  * @param props The properties.
  * @returns The component.
  */
-export const Carousel: Component<SceneCarouselProps> = (props) => (
-  <div class="bg-base-100 px-0.5 py-12">
-    <ul
-      aria-label={props.label}
-      class={twMerge(
-        'carousel carousel-center focus-visible:outline-primary aspect-[19/9] h-auto w-full space-x-4 px-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:aspect-[27/9] xl:aspect-[28/9] 2xl:aspect-[43/9]',
-        props.class,
-      )}
-      tabindex="0"
-    >
-      <Index each={props.items}>
-        {(index) => (
-          <CarouselItem
-            alt={index()[1]}
-            class="carousel-item h-full w-auto cursor-ew-resize"
-            height={720}
-            src={index()[0]}
-            width={1280}
-          />
+export const Carousel: Component<SceneCarouselProps> = (props) => {
+  let listRef: HTMLUListElement | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const [activeIndex, setActiveIndex] = createSignal(0);
+  const [hovered, setHovered] = createSignal(false);
+  const [focused, setFocused] = createSignal(false);
+  const [visible, setVisible] = createSignal(true);
+  const [mounted, setMounted] = createSignal(false);
+  const prefersReducedMotion = createMediaQuery(
+    '(prefers-reduced-motion: reduce)',
+  );
+  const paused = () => hovered() || focused() || !visible();
+
+  /**
+   * Finds the item nearest to the carousel's current scroll position.
+   * Falls back to the last known {@link activeIndex} when the
+   * container has no measurable layout yet (for example, in a test
+   * environment with no real layout engine), so autoplay stays
+   * deterministic wherever real geometry is unavailable.
+   * @returns The nearest item's index.
+   */
+  const nearestIndex = (): number => {
+    if (!listRef || listRef.clientWidth === 0 || props.items.length === 0) {
+      return activeIndex();
+    }
+    const containerRect = listRef.getBoundingClientRect();
+    const containerCenter = containerRect.left + containerRect.width / 2;
+    let closest = 0;
+    let closestDistance = Number.POSITIVE_INFINITY;
+    for (const [i, child] of Array.from(listRef.children).entries()) {
+      const rect = child.getBoundingClientRect();
+      const distance = Math.abs(rect.left + rect.width / 2 - containerCenter);
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closest = i;
+      }
+    }
+    return closest;
+  };
+
+  const clearTimer = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  /**
+   * (Re)schedules the next autoplay advance, replacing any pending
+   * one. Does nothing while unmounted, reduced-motion is requested, or
+   * autoplay is paused -- callers rely on this to both start the
+   * initial timer and to postpone it on manual interaction.
+   */
+  const scheduleAdvance = () => {
+    clearTimer();
+    if (
+      !mounted() ||
+      prefersReducedMotion() ||
+      paused() ||
+      props.items.length <= 1
+    ) {
+      return;
+    }
+    timer = setTimeout(() => {
+      setActiveIndex((nearestIndex() + 1) % props.items.length);
+    }, AUTOPLAY_INTERVAL_MS);
+  };
+
+  createEffect(() => {
+    // Re-schedule whenever autoplay eligibility changes.
+    mounted();
+    prefersReducedMotion();
+    paused();
+    activeIndex();
+    scheduleAdvance();
+  });
+
+  createEffect(() => {
+    listRef?.children.item(activeIndex())?.scrollIntoView?.(SCROLL_OPTIONS);
+  });
+
+  onMount(() => {
+    setVisible(document.visibilityState === 'visible');
+    const handleVisibilityChange = () =>
+      setVisible(document.visibilityState === 'visible');
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    onCleanup(() =>
+      document.removeEventListener('visibilitychange', handleVisibilityChange),
+    );
+    onCleanup(clearTimer);
+    setMounted(true);
+  });
+
+  return (
+    <div class="bg-base-100 px-0.5 py-12">
+      <ul
+        aria-label={props.label}
+        class={twMerge(
+          'carousel carousel-center focus-visible:outline-primary aspect-[19/9] h-auto w-full space-x-4 px-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:aspect-[27/9] xl:aspect-[28/9] 2xl:aspect-[43/9]',
+          props.class,
         )}
-      </Index>
-    </ul>
-  </div>
-);
+        onFocusIn={() => setFocused(true)}
+        onFocusOut={() => setFocused(false)}
+        onKeyDown={scheduleAdvance}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onPointerDown={scheduleAdvance}
+        onScroll={scheduleAdvance}
+        onTouchStart={scheduleAdvance}
+        ref={listRef}
+        tabindex="0"
+      >
+        <Index each={props.items}>
+          {(index) => (
+            <CarouselItem
+              alt={index()[1]}
+              class="carousel-item h-full w-auto cursor-ew-resize"
+              height={720}
+              src={index()[0]}
+              width={1280}
+            />
+          )}
+        </Index>
+      </ul>
+    </div>
+  );
+};

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -189,7 +189,13 @@ export const Carousel: Component<SceneCarouselProps> = (props) => {
     // `setActiveIndex` call (a manual prev/next control, say) should
     // never reintroduce animated motion for a reduced-motion visitor
     // just because this effect didn't independently enforce it.
-    const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+    //
+    // `'instant'`, not `'auto'`: the `carousel` class sets CSS
+    // `scroll-behavior: smooth` unconditionally, and `'auto'` defers to
+    // that computed value per the CSSOM View spec rather than
+    // overriding it -- only `'instant'` forces an immediate jump
+    // regardless of the element's CSS `scroll-behavior`.
+    const behavior = prefersReducedMotion() ? 'instant' : 'smooth';
     listRef.scrollTo?.({ behavior, left });
   });
 

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -34,16 +34,11 @@ export interface SceneCarouselProps {
 const AUTOPLAY_INTERVAL_MS = 3_000;
 
 /**
- * Options shared by every programmatic scroll this component performs.
- * `inline: 'center'` matches the `carousel-center` class's own
- * `scroll-snap-align: center` on each item, so the JS-driven scroll
- * agrees with the CSS snap point instead of fighting it.
+ * The attribute marking the currently active item, purely as an
+ * inert hook (no CSS binds to it): a test-observable, non-ARIA signal
+ * for {@link activeIndex} that doesn't risk any accessibility surface.
  */
-const SCROLL_OPTIONS = {
-  behavior: 'smooth',
-  block: 'nearest',
-  inline: 'center',
-} as const satisfies ScrollIntoViewOptions;
+const ACTIVE_ATTRIBUTE = 'data-carousel-active';
 
 /**
  * The carousel component.
@@ -150,7 +145,23 @@ export const Carousel: Component<SceneCarouselProps> = (props) => {
   });
 
   createEffect(() => {
-    listRef?.children.item(activeIndex())?.scrollIntoView?.(SCROLL_OPTIONS);
+    if (!listRef) return;
+    const index = activeIndex();
+    const children = Array.from(listRef.children);
+    for (const [i, child] of children.entries()) {
+      if (i === index) child.setAttribute(ACTIVE_ATTRIBUTE, 'true');
+      else child.removeAttribute(ACTIVE_ATTRIBUTE);
+    }
+    const target = children[index];
+    if (!(target instanceof HTMLElement)) return;
+    // Scroll only this container's own horizontal position -- never
+    // `target.scrollIntoView()`, which would also walk and scroll
+    // every scrollable ancestor up to the page itself, yanking a
+    // visitor who has since scrolled elsewhere on the page back to
+    // the carousel on every autoplay tick.
+    const left =
+      target.offsetLeft + target.offsetWidth / 2 - listRef.clientWidth / 2;
+    listRef.scrollTo?.({ behavior: 'smooth', left });
   });
 
   onMount(() => {

--- a/packages/web/src/components/molecules/Carousel.tsx
+++ b/packages/web/src/components/molecules/Carousel.tsx
@@ -183,7 +183,14 @@ export const Carousel: Component<SceneCarouselProps> = (props) => {
       listRef.scrollLeft +
       targetCenterFromContainerLeft -
       containerRect.width / 2;
-    listRef.scrollTo?.({ behavior: 'smooth', left });
+    // `activeIndex` only ever changes from the autoplay timer today,
+    // which is already gated on `prefersReducedMotion`, but checking it
+    // again here too is defense-in-depth: a future direct
+    // `setActiveIndex` call (a manual prev/next control, say) should
+    // never reintroduce animated motion for a reduced-motion visitor
+    // just because this effect didn't independently enforce it.
+    const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+    listRef.scrollTo?.({ behavior, left });
   });
 
   onMount(() => {


### PR DESCRIPTION
## Summary

Adds autoplay to the activities carousel (`molecules/Carousel.tsx`) so a
visitor on a desktop mouse without a tilt wheel can see photos past the
first couple, without taking control away from anyone who wants to
interact with it manually:

- Auto-advances one item every 3 seconds (`AUTOPLAY_INTERVAL_MS`, a
  named constant).
- Any manual interaction (scroll, touch, pointer, keyboard) postpones
  the next advance by the same interval. Each advance re-derives its
  starting point from the carousel's actual current scroll position
  (`nearestIndex`) rather than trusting a remembered index, so autoplay
  resuming after a manual scroll continues from wherever the visitor
  left it instead of snapping back to a stale position.
- Pauses while hovered, while keyboard focus is inside it, and while the
  tab is not visible (`document.visibilityState`).
- Never starts the timer at all under `prefers-reduced-motion: reduce`.
- Starts only after client mount, so it never runs during
  SSR/prerendering and never affects the prerendered markup.
- Scrolls only the carousel's own `<ul>` container (`scrollTo`,
  computed from `getBoundingClientRect` deltas), never
  `Element.scrollIntoView`, which would also walk and scroll every
  scrollable ancestor up to the page itself.

Scoped entirely to `molecules/Carousel.tsx`, the activities carousel's
only consumer (`organisms/ActivitiesCarousel.tsx`) — the hero avatar
carousel (`molecules/Kito.tsx` / `KitoWithLogo.tsx`) does not use this
component and is unaffected, per the issue's stated out-of-scope note.

## Verification

- `pnpm run lint` and `pnpm run test` pass (148/148 tests in
  `packages/web`, including 14 new targeted tests covering every
  acceptance criterion: repeated 3 s advance, manual-interaction reset,
  reduced-motion disabling the timer entirely, hidden-tab pause,
  hover/focus pause individually and combined, loop-to-first, the
  scroll-target math, and a regression test for a same-value signal
  collision that could otherwise stall autoplay permanently).
- `pnpm run build` succeeds; confirmed the built `dist/index.html`
  carries none of the client-only autoplay state (`data-carousel-active`
  never appears in the prerendered markup).
- `Carousel.stories.ts` / `ActivitiesCarousel.stories.ts` are unchanged;
  the public `SceneCarouselProps` interface (`class`, `items`, `label`)
  is unchanged, so both stories stay compatible.

Closes #215

## Follow-up

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic carousel advancement every three seconds.
  * Carousel now pauses during hover, focus, hidden tabs, reduced-motion settings, and single-item displays.
  * Manual scrolling and interactions keep the active item synchronized.
  * Scrolling is contained within the carousel.

* **Bug Fixes**
  * Improved active-item tracking and timer resumption after temporary pauses.

* **Tests**
  * Added comprehensive coverage for autoplay, scrolling, accessibility preferences, visibility, interaction states, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->