### PR TITLE
chore(lint): exclude the vendored IDD helper bundle from lint/format

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": ["scripts/**", "schemas/**", "fixtures/schemas/**"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -38,7 +38,9 @@ profiles/
 # re-synced verbatim from kurone-kito/idd-skill; carries generated-from
 # banners that must stay byte-identical to upstream across every
 # re-import). prettier-plugin-sh and prettier-plugin-sort-json would
-# reformat these on every run, so they are excluded entirely.
-scripts/
-schemas/
-fixtures/schemas/
+# reformat these on every run, so they are excluded entirely. Anchored
+# to the repository root so nested package dirs of the same name (e.g.
+# packages/web/scripts/) are not accidentally swept in.
+/scripts/
+/schemas/
+/fixtures/schemas/

--- a/.prettierignore
+++ b/.prettierignore
@@ -33,3 +33,12 @@ docs/reference.md
 docs/onboarding/
 profiles/
 .githooks/
+
+# Vendored IDD helper bundle (scripts/, schemas/, fixtures/schemas/,
+# re-synced verbatim from kurone-kito/idd-skill; carries generated-from
+# banners that must stay byte-identical to upstream across every
+# re-import). prettier-plugin-sh and prettier-plugin-sort-json would
+# reformat these on every run, so they are excluded entirely.
+scripts/
+schemas/
+fixtures/schemas/

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -8,9 +8,9 @@ import:
 ignorePaths:
   - node_modules
   - storybook-static
-  - scripts
-  - schemas
-  - fixtures/schemas
+  - /scripts
+  - /schemas
+  - /fixtures/schemas
 version: '0.2'
 words:
   - agentic

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -8,6 +8,9 @@ import:
 ignorePaths:
   - node_modules
   - storybook-static
+  - scripts
+  - schemas
+  - fixtures/schemas
 version: '0.2'
 words:
   - agentic

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,1 +1,16 @@
-export { default } from '@kurone-kito/eslint-config-solid';
+import solidConfig from '@kurone-kito/eslint-config-solid';
+
+/**
+ * The ESLint configuration for this project.
+ *
+ * Extends the shared preset with a local `ignores` entry for the
+ * vendored IDD helper bundle (`scripts/`, `schemas/`, `fixtures/schemas/`),
+ * re-synced verbatim from `kurone-kito/idd-skill` and required to stay
+ * byte-identical to upstream across every re-import.
+ *
+ * @type {import('eslint').Linter.Config[]}
+ */
+export default [
+  ...solidConfig,
+  { ignores: ['scripts/**', 'schemas/**', 'fixtures/schemas/**'] },
+];


### PR DESCRIPTION
## Summary

Excludes the vendored IDD helper bundle paths (`scripts/`, `schemas/`,
`fixtures/schemas/`) from every autofixing or failing lint/format
surface in this repository, ahead of the sibling tracks that vendor
those trees from `kurone-kito/idd-skill` (#225, #226) and the track
that switches `helperRuntime.profile` to `vendored-node` (#228).

- `.prettierignore` — new block following the existing "Vendored IDD
  workflow surfaces" convention, excluding the three paths entirely
  (they carry generated-from banners that must stay byte-identical to
  upstream; `prettier-plugin-sh` and `prettier-plugin-sort-json` would
  otherwise reformat them on every run).
- `eslint.config.mjs` — switched from a bare preset re-export to
  importing the preset and appending a flat-config `{ ignores: [...] }`
  object for the same three paths (the shared-preset config itself is
  unchanged).
- `.oxlintrc.json` (new) — minimal `ignorePatterns` config; verified
  that plain `oxlint` (the command `lint:oxlint:check` already runs)
  auto-discovers this file, and that the rest of the tree keeps the
  same rule/file count as before this change.
- `cspell.config.yml` — added the same three paths to the existing
  `ignorePaths` list.

No files are vendored in this PR, and `.gitattributes` /
`.github/idd/config.json` are untouched — both belong to sibling
tracks.

## Verification

- `pnpm run lint` passes.
- `pnpm run test` passes except the pre-existing `packages/web`
  `Calendar.test.tsx` failure caused by a missing `data.json` fixture
  that requires live Google Calendar API credentials unavailable in
  this environment — unrelated to this diff (confirmed unaffected by
  this change; hosted CI has the credentials).

Closes #222
