### PR TITLE
perf(web): give Avatar an eager high-priority mode for the hero avatar

### DIFF
--- a/packages/web/src/components/atoms/Avatar.test.tsx
+++ b/packages/web/src/components/atoms/Avatar.test.tsx
@@ -26,4 +26,22 @@ describe('Avatar', () => {
     ));
     expect(container.querySelector('a')).toBeNull();
   });
+
+  it('defaults the image to fetchpriority="low" when the prop is omitted', () => {
+    const { container } = render(() => <Avatar nextId="next" src="a.webp" />);
+    expect(container.querySelector('img')).toHaveAttribute(
+      'fetchpriority',
+      'low',
+    );
+  });
+
+  it('renders fetchpriority="high" when explicitly requested', () => {
+    const { container } = render(() => (
+      <Avatar fetchpriority="high" nextId="next" src="a.webp" />
+    ));
+    expect(container.querySelector('img')).toHaveAttribute(
+      'fetchpriority',
+      'high',
+    );
+  });
 });

--- a/packages/web/src/components/atoms/Avatar.tsx
+++ b/packages/web/src/components/atoms/Avatar.tsx
@@ -6,7 +6,7 @@ import { twMerge } from 'tailwind-merge';
 export interface AvatarProps
   extends Pick<
     Readonly<JSX.ImgHTMLAttributes<HTMLImageElement>>,
-    'alt' | 'class' | 'height' | 'id' | 'src' | 'width'
+    'alt' | 'class' | 'fetchpriority' | 'height' | 'id' | 'src' | 'width'
   > {
   /** The CSS classes for anchor. */
   readonly anchorClass?: string | undefined;
@@ -36,7 +36,7 @@ export const Avatar: Component<AvatarProps> = (props) => (
       alt={props.alt}
       class="w-full object-contain drop-shadow-lg"
       decoding="async"
-      fetchpriority="low"
+      fetchpriority={props.fetchpriority ?? 'low'}
       height={props.height}
       src={props.src}
       width={props.width}

--- a/packages/web/src/components/molecules/Kito.test.tsx
+++ b/packages/web/src/components/molecules/Kito.test.tsx
@@ -1,0 +1,19 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Kito } from './Kito.js';
+
+afterEach(() => cleanup());
+
+describe('Kito', () => {
+  it('fetches the hero (kito) avatar eagerly at high priority', () => {
+    const { container } = render(() => <Kito id="hero" />);
+    const images = container.querySelectorAll('img');
+    expect(images[0]).toHaveAttribute('fetchpriority', 'high');
+  });
+
+  it('keeps the second (momoneko) avatar at the default low priority', () => {
+    const { container } = render(() => <Kito id="hero" />);
+    const images = container.querySelectorAll('img');
+    expect(images[1]).toHaveAttribute('fetchpriority', 'low');
+  });
+});

--- a/packages/web/src/components/molecules/Kito.test.tsx
+++ b/packages/web/src/components/molecules/Kito.test.tsx
@@ -7,13 +7,13 @@ afterEach(() => cleanup());
 describe('Kito', () => {
   it('fetches the hero (kito) avatar eagerly at high priority', () => {
     const { container } = render(() => <Kito id="hero" />);
-    const images = container.querySelectorAll('img');
-    expect(images[0]).toHaveAttribute('fetchpriority', 'high');
+    const image = container.querySelector('#hero-avatar-kito img');
+    expect(image).toHaveAttribute('fetchpriority', 'high');
   });
 
   it('keeps the second (momoneko) avatar at the default low priority', () => {
     const { container } = render(() => <Kito id="hero" />);
-    const images = container.querySelectorAll('img');
-    expect(images[1]).toHaveAttribute('fetchpriority', 'low');
+    const image = container.querySelector('#hero-avatar-momoneko img');
+    expect(image).toHaveAttribute('fetchpriority', 'low');
   });
 });

--- a/packages/web/src/components/molecules/Kito.tsx
+++ b/packages/web/src/components/molecules/Kito.tsx
@@ -42,6 +42,7 @@ export const Kito: Component<KitoProps> = (props) => {
         alt={props.altKito}
         anchorClass="right-[3cqw] top-[3cqh] h-[7cqh] w-[20cqw]"
         class="carousel-item @container-[size]/kito"
+        fetchpriority="high"
         height={2403}
         id={kitoId}
         nextId={momonekoId}


### PR DESCRIPTION
## Summary

`atoms/Avatar.tsx` hardcoded `fetchpriority="low"` on its rendered
`<img>`. The first avatar rendered by `molecules/Kito.tsx`
(`assets/avatars/kito.webp`, 1242x2403, 89.9 KB) is the largest
above-the-fold element on the landing page and its LCP candidate, so
`fetchpriority="low"` told the browser to fetch it *after* other
resources -- the opposite of what an LCP image wants. This adds an
opt-in high-priority mode instead of a global flip, since every other
`Avatar` caller (today, just the second avatar in `Kito.tsx`) is
correctly low-priority.

- `atoms/Avatar.tsx` -- `AvatarProps` now also picks `fetchpriority`
  from `JSX.ImgHTMLAttributes<HTMLImageElement>` (the same
  `"high" | "low" | "auto"` typing already used elsewhere in this
  codebase), and the `<img>` reads `props.fetchpriority ?? 'low'`
  instead of the hardcoded literal -- a caller that passes nothing
  keeps exactly today's behavior.
- `molecules/Kito.tsx` -- the first (`kito`) `Avatar` instance now
  passes `fetchpriority="high"`. The second (`momoneko`) instance is
  unchanged and keeps the default low-priority behavior.
- No `width`/`height` attribute was touched, and no `loading` attribute
  was added -- the `<img>` already has no `loading` attribute, so it
  is already fetched eagerly by default; only fetch priority changes.

The other half of the originating issue (#151) -- responsive `srcset`
variants -- stays out of scope here and is held separately in #221
pending a build-time-approach decision.

## Verification

- `pnpm run lint` passes.
- `pnpm run test` passes except the pre-existing `packages/web`
  `Calendar.test.tsx` failure caused by a missing `data.json` fixture
  that requires live Google Calendar API credentials unavailable in
  this environment -- unrelated to this diff (hosted CI has the
  credentials).
- Added test coverage: `Avatar.test.tsx` now asserts the default
  `fetchpriority="low"` and the explicit `fetchpriority="high"` case;
  a new `Kito.test.tsx` asserts the hero avatar renders
  `fetchpriority="high"` while the second avatar stays `"low"`.

Closes #220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved avatar image loading by assigning low priority by default.
  * Prioritized the primary Kito avatar image for faster loading.
  * Preserved support for explicitly configured image priority values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->