### PR TITLE
chore(idd): vendor the idd helper scripts

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1,0 +1,1592 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/advisory-convergence.mts
+//
+// The scripts/advisory-convergence.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only policy-engine helper (#1340): deterministically asserts whether
+// the primary advisory bot's ("Copilot's") review has *converged* on the
+// current PR HEAD -- see issue #1340 and roadmap #1342. This closes a gap
+// where the existing evidence collectors (`pre-merge-readiness.mjs`,
+// `review-disposition-verify.mjs`, `advisory-wait-state.mjs`) report JSON
+// for the model to interpret, but no single helper asserts the invariant
+// with a hard exit code.
+//
+// Reuse map (no duplicated review-parsing logic):
+//   - `readAdvisoryPrimaryBotLogin` / `resolveAdvisoryPrimaryBotLogin` --
+//     Copilot identity resolution.
+//   - `resolveAdvisoryBotLogins`, `resolveTrustedMarkerActors` -- the same
+//     trust/identity resolution every other helper uses.
+//   - `resolveLatestCopilotReviewClause`, `fetchReviewsAndHeadCommit`,
+//     `isVerifiedCopilotAuthor` (which itself reuses
+//     `isCopilotReviewerLogin`'s login-string check) -- the latest-review
+//     Clause 1 evidence, extracted to `review-clause.mts` (#1806) so
+//     `rerun-advisory-convergence.mts` can reuse the exact same evidence
+//     for its own live-coverage recovery signal, without importing this
+//     whole file.
+//   - `summarizeDispositionEvidenceForGate` -- reused UNFILTERED for
+//     per-thread disposition-marker validity; this file only adds a thin
+//     Copilot-authorship filter on top of its `missingThreads` output.
+//   - `summarizeClaimValidation`, `summarizeExternalCheckWaivers` -- reused
+//     verbatim for the deadline/waiver escape hatch, auto-discovering the
+//     PR's linked issue exactly as `external-check-waiver.mts`'s own
+//     `--apply` path already does, so no claim flag is required to call
+//     this helper (`--pr <n> --assert` is sufficient -- see docs).
+//   - `resolveCollaboratorMarkerTrust`, `isAuthorizedForcedHandoffActor`,
+//     `operationalMarkerPrefix` -- reused, matching `pre-merge-readiness.mts`
+//     exactly (#1344), to thread forced-handoff-aware claim resolution and
+//     collaborator-marker trust into the same `summarizeClaimValidation`
+//     call above, so this gate does not disagree with the sibling F2/F3
+//     helpers when a repository opts into either (both stay no-ops
+//     otherwise).
+//
+// This helper never mutates GitHub state: it only reads PR/review/thread/
+// comment data and prints a verdict.
+//
+// #1511: bounded same-HEAD advisory reroll evidence. `itemCount` (Clause 1
+// above) is a STATIC snapshot of the primary bot's review comment count at
+// submission time -- rejecting/resolving those items in triage never
+// changes it, so `converged` can stay false PERMANENTLY on a HEAD the bot
+// has already reviewed, even once every one of its findings has a valid
+// disposition. The `sameHeadReroll` field group below surfaces exactly
+// when that residual is the ONLY thing blocking convergence, plus a
+// bounded counter (backed by a distinct `advisory-reroll:` marker, kept
+// separate from the advisory-wait `REQUEST_CAP`) so instructions (AW6 in
+// idd-advisory-wait.instructions.md, invoked only from F2) can request a
+// few fresh same-HEAD re-reviews before falling through to the existing
+// deadline+waiver/hold backstop. This is PURELY ADDITIVE evidence:
+// `converged`/`waived`/`ready` below are computed with ZERO reference to
+// `sameHeadReroll.*` (see the tests asserting this), so the carve-out can
+// never let the gate pass on anything other than the primary bot's own
+// real signal -- it only tells a caller when requesting a reroll is safe
+// and how much budget remains.
+import {
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
+  DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
+  DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP,
+  DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP,
+  DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES,
+  readAdvisoryConvergenceDeadlineMinutes,
+  readAdvisoryPrimaryBotLogin,
+  readAdvisoryRecoveryCycleCap,
+  readAdvisorySameHeadRerollCap,
+  readAdvisoryTerminalWindowMinutes,
+  readAdvisoryWaitPolicy,
+} from './advisory-wait-policy.mjs';
+import { buildCopilotRecoverySummary } from './advisory-wait-state.mjs';
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
+import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
+import {
+  GH_TEXT_LOOP_OPTIONS,
+  ghApiJson,
+  ghGraphql,
+  ghText,
+  safeGhText,
+} from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mjs';
+import {
+  normalizePolicyConfig,
+  parseIsoDurationToMs,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mjs';
+import {
+  DEFAULT_STALE_AGE_MS,
+  normalizeTrustedMarkerLogins,
+  operationalMarkerPrefix,
+  resolveAdvisoryBotLogins,
+  resolvePrFirstCommitAt,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+  summarizeDispositionEvidenceForGate,
+  summarizeExternalCheckWaivers,
+} from './protocol-helpers.mjs';
+import {
+  fetchReviewsAndHeadCommit,
+  isVerifiedCopilotAuthor,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mjs';
+/** The external-check-waiver selector this gate recognizes (documented in
+ * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
+ * check is expected to register under the same name). #1570: re-exported
+ * from the shared `advisory-wait-policy.mts` constant (rather than declared
+ * standalone) so `protocol-helpers.mts`'s `buildPreMergeReadinessSummary`
+ * can filter terminal-unavailability waiver evidence by the identical
+ * selector string without importing this module (which would create an
+ * import cycle back through `advisory-wait-state.mts`). The exported name
+ * and value are unchanged for existing consumers. */
+export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+/** #1719: stable, machine-readable tokens for
+ * `sameHeadReroll.ineligibleReasons` -- one per boolean term of the
+ * `eligible` conjunction, in the same order the conjunction is written in
+ * `computeAdvisoryConvergenceVerdict` below, so a report-mode caller can
+ * self-diagnose a stuck AW6 reroll without re-deriving the eligibility rule
+ * from `idd-advisory-wait.instructions.md` by hand. Exported (rather than
+ * inlined as string literals at each call site) so tests reference the same
+ * single source of truth the implementation does. */
+export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
+  SCOPE_NOT_APPLICABLE: 'scope-not-applicable',
+  REVIEW_PENDING: 'review-pending',
+  UNRESOLVED_COPILOT_THREADS: 'unresolved-copilot-threads',
+  MISSING_REGULAR_COMMENT_DISPOSITION: 'missing-regular-comment-disposition',
+  REVIEW_ITEM_COUNT_UNKNOWN: 'review-item-count-unknown',
+  REVIEW_ITEM_COUNT_NOT_POSITIVE: 'review-item-count-not-positive',
+};
+/**
+ * Compute the deterministic advisory-convergence verdict from already-
+ * fetched PR evidence. Pure (no I/O), so it is directly unit-testable with
+ * fixtures -- mirrors `buildPreMergeReadinessSummary` /
+ * `buildAdvisoryWaitSummary` in `protocol-helpers.mts`.
+ */
+export function computeAdvisoryConvergenceVerdict(inputs, options) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  // Lowercased before validating, so a mixed-/upper-case 40-hex SHA is
+  // accepted (normalized), not rejected -- the error message below
+  // describes the post-normalization shape, not a case restriction on the
+  // input.
+  const prHeadSha = String(inputs.prHeadSha ?? '').toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character hexadecimal commit SHA');
+  }
+  const primaryBotLogin =
+    String(options.primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins(
+    options.trustedMarkerLogins ?? [],
+  );
+  const reviews = inputs.reviews ?? [];
+  const threads = inputs.threads ?? [];
+  const comments = inputs.comments ?? [];
+  const claimEvents = inputs.claimEvents ?? [];
+  const reasons = [];
+  const claim = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins,
+    // #1344: parity with `pre-merge-readiness.mts`'s own
+    // `summarizeClaimValidation` call -- see `AdvisoryConvergenceOptions`
+    // for why each field is a no-op when the caller omits it.
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+    staleAgeMs: options.staleAgeMs,
+  });
+  const activeClaimId = claim.activeClaim?.claimId ?? '';
+  // `idd-claimed` narrows this gate to verified IDD-owned PRs; the default
+  // `all-prs` behavior keeps the gate applicable everywhere else.
+  const convergenceScope =
+    options.convergenceScope === 'idd-claimed' ? 'idd-claimed' : 'all-prs';
+  const prHeadRefName = String(options.prHeadRefName ?? '').trim();
+  const activeClaimBranch = String(claim.activeClaim?.branch ?? '').trim();
+  // #1686: evidence the CLI-collection layer computes over EVERY candidate
+  // claim issue (not just whichever one -- if any -- ended up "active"), so
+  // the applicability gate can tell a genuinely non-IDD PR apart from an
+  // IDD-shaped PR whose claim linkage is currently broken. See each field's
+  // own doc comment on `AdvisoryConvergenceInputs` for the full rationale.
+  //
+  // #1821: the TS type already requires both fields at compile time, but
+  // that guard is erased at emit -- an untyped caller of the exported
+  // `.mjs` (or a hand-written JS caller) can still pass `undefined` or a
+  // non-boolean value through. Reject that here instead of silently
+  // coercing it to `false`, matching this function's existing
+  // error-handling convention for invalid inputs (see the `now` /
+  // `prHeadSha` validation above).
+  if (typeof inputs.claimMarkerHistoryPresent !== 'boolean') {
+    throw new Error('claimMarkerHistoryPresent must be a boolean');
+  }
+  if (typeof inputs.claimCandidateAmbiguous !== 'boolean') {
+    throw new Error('claimCandidateAmbiguous must be a boolean');
+  }
+  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent;
+  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous;
+  // #1906: read as `=== true` on both sides -- see each field's own doc
+  // comment (`AdvisoryConvergenceInputs.prAuthorIsBot`,
+  // `AdvisoryConvergenceOptions.exemptBotAuthoredPrs`) for why neither is
+  // required-with-throw like the two claim-evidence booleans above.
+  const exemptBotAuthoredPrs = options.exemptBotAuthoredPrs === true;
+  const prAuthorIsBot = inputs.prAuthorIsBot === true;
+  const applicability =
+    convergenceScope === 'idd-claimed'
+      ? !claim.activeClaimPresent
+        ? claimCandidateAmbiguous
+          ? {
+              scope: convergenceScope,
+              status: 'indeterminate',
+              reason: 'idd-claimed-multiple-resolving-claim-candidates',
+            }
+          : claimMarkerHistoryPresent
+            ? {
+                scope: convergenceScope,
+                status: 'indeterminate',
+                reason: 'idd-claimed-claim-history-without-active-claim',
+              }
+            : {
+                scope: convergenceScope,
+                status: 'not_applicable',
+                reason: 'idd-claimed-no-verified-linked-issue-claim',
+              }
+        : !prHeadRefName
+          ? {
+              scope: convergenceScope,
+              status: 'applicable',
+              reason: 'idd-claimed-head-branch-unavailable',
+            }
+          : !activeClaimBranch
+            ? {
+                scope: convergenceScope,
+                status: 'applicable',
+                reason: 'idd-claimed-linked-claim-branch-unavailable',
+              }
+            : activeClaimBranch !== prHeadRefName
+              ? {
+                  scope: convergenceScope,
+                  status: 'indeterminate',
+                  reason: 'idd-claimed-branch-mismatch',
+                }
+              : {
+                  scope: convergenceScope,
+                  status: 'applicable',
+                  reason: 'idd-claimed-branch-matched',
+                }
+      : // #1906: opt-in bot-authored-PR exemption, `all-prs` scope only --
+        // `idd-claimed` already resolves this exact PR shape to
+        // `not_applicable` via its own `idd-claimed-no-verified-linked-
+        // issue-claim` branch above, untouched by this addition.
+        exemptBotAuthoredPrs && prAuthorIsBot && !claimMarkerHistoryPresent
+        ? {
+            scope: convergenceScope,
+            status: 'not_applicable',
+            reason: 'bot-authored-no-claim-history',
+          }
+        : {
+            scope: convergenceScope,
+            status: 'applicable',
+            reason: 'all-prs',
+          };
+  // `scopeNotApplicable` keeps its pre-#1686 meaning EXACTLY -- `status ===
+  // 'not_applicable'` only -- since it still gates the waiver-evidence
+  // bookkeeping (`waived` below) and the unconditional `ready` pass for a
+  // genuinely non-IDD PR. `scopeIndeterminate` is the new third state:
+  // unlike `not_applicable`, it must NEVER let `ready` become true through
+  // the ordinary convergence path (`converged` below is forced `false` for
+  // it, same as `not_applicable` blocks evaluating convergence at all) --
+  // only the existing deadline/terminal-plus-maintainer-waiver escape hatch
+  // can still clear it (`waived` stays gated by `scopeNotApplicable` alone,
+  // deliberately NOT `scopeBlocksConvergenceEval`, so a trusted maintainer
+  // marker can still resolve an indeterminate verdict same as any other
+  // non-converged one -- see the module header and PR discussion for why
+  // hard-blocking indeterminate with no waiver escape at all would leave a
+  // required check with no recovery path for a repository under
+  // `required_approving_review_count: 0`).
+  const scopeNotApplicable = applicability.status === 'not_applicable';
+  const scopeIndeterminate = applicability.status === 'indeterminate';
+  const scopeBlocksConvergenceEval = scopeNotApplicable || scopeIndeterminate;
+  if (scopeIndeterminate) {
+    reasons.push(
+      `applicability is indeterminate (${applicability.reason}): this PR carries evidence of IDD claim activity but its claim linkage cannot be resolved cleanly -- repair the claim/PR-body linkage (or, for a confirmed benign case, have a trusted maintainer post an idd-external-check-waiver marker) before this check can converge`,
+    );
+  }
+  // --- Clause 1: latest Copilot review is clean on the current HEAD -----
+  const review = resolveLatestCopilotReviewClause(
+    reviews,
+    prHeadSha,
+    primaryBotLogin,
+  );
+  const pending = scopeBlocksConvergenceEval ? false : !review.matchesHead;
+  if (!scopeBlocksConvergenceEval && pending) {
+    reasons.push(
+      review.found
+        ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
+        : `${primaryBotLogin} has not reviewed this pull request yet`,
+    );
+  }
+  // --- Clause 2: every current Copilot-authored thread is resolved or ---
+  // --- validly dispositioned (reusing summarizeDispositionEvidenceForGate)
+  const copilotThreadIds = classifyCopilotAuthoredThreadIds(
+    threads,
+    primaryBotLogin,
+  );
+  const dispositionEvidence = summarizeDispositionEvidenceForGate(
+    { comments, threads },
+    {
+      // `summarizeDispositionEvidenceForGate` requires a recognized
+      // "IDD agent" login to accept an Accept/Reject/AMD marker as a fresh
+      // disposition (see `hasFreshDisposition`). This gate has no separate
+      // notion of "IDD agent" from "trusted marker actor" -- both mean the
+      // same thing here (whoever is authorized to post operational markers
+      // on this repo) -- so the trusted set is reused for both, avoiding an
+      // extra CLI flag / config surface the issue does not ask for.
+      iddAgentLogins: trustedMarkerLogins,
+      trustedMarkerLogins,
+      advisoryBotLogins: normalizeTrustedMarkerLogins(
+        options.advisoryBotLogins ?? [],
+      ),
+      prAuthorLogin: String(options.prAuthorLogin ?? '')
+        .trim()
+        .toLowerCase(),
+      // Deliberately no `snapshotBoundaryAt`: this claim-independent gate has
+      // no F2 review-watermark to anchor one to, and threading a sentinel
+      // (e.g. `now`) through would make every resolved thread's feedback
+      // trivially predate it -- silently turning the boundary-gated
+      // ack-only-post-disposition classification (`classifyThreadAckOnly-
+      // PostDisposition`, protocol-helpers.mts) into permanent dead code
+      // instead of the deliberate carve-out it looks like. "Resolved is
+      // sufficient" (below) is handled directly, without relying on that
+      // classification at all.
+    },
+  );
+  // Clause 2 per the issue: "resolved OR carries a valid disposition
+  // marker." `missingThreads` (computed without a boundary, above) flags
+  // BOTH an unresolved thread lacking a fresh marker AND a resolved thread
+  // lacking one (`reason: 'missing-fresh-disposition'`) -- the latter is not
+  // a Clause-2 blocker here, since resolution alone already satisfies it, so
+  // only the genuinely unresolved entries count.
+  const copilotBlocking = dispositionEvidence.missingThreads.filter(
+    (thread) =>
+      copilotThreadIds.has(String(thread.id ?? '')) &&
+      thread.isResolved === false,
+  );
+  const threadClause = {
+    copilotThreadCount: copilotThreadIds.size,
+    blockingIds: copilotBlocking.map((thread) => String(thread.id ?? '')),
+    blockingCount: copilotBlocking.length,
+    satisfied: copilotBlocking.length === 0,
+  };
+  // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
+  // `threadClause` is available -- deliberately deferred from the `pending`
+  // check above (whose own `if` already exhausts the pending case, so
+  // `reasons` order is unaffected: pending and not-satisfied are mutually
+  // exclusive, and this still precedes Clause 2's own thread-blocking
+  // reason below).
+  //
+  // #1719: reported adopter incident -- the primary bot's review on current
+  // HEAD carried `itemCount: 1` while every visible GraphQL review thread
+  // was already `isResolved: true`; the actual cause was a "Comments
+  // suppressed due to low confidence" item embedded in the review's
+  // top-level BODY TEXT rather than posted as a review thread -- it
+  // contributes to `itemCount` but is invisible to any `reviewThreads`
+  // query, so it can never be resolved the normal way, and nothing in this
+  // gate's output pointed there. When every visible Copilot-authored thread
+  // is already resolved and `itemCount` is still positive, no thread query
+  // can explain it -- point directly at the review body instead of leaving
+  // an agent to re-derive this by hand a second time.
+  //
+  // #1880: a related but distinct incident shape -- the primary bot's
+  // review on current HEAD carries `itemCount: 0` (zero POSTED comments)
+  // while its top-level body still embeds a `Suppressed comments (N)`
+  // block for a finding it chose not to post as a comment at all. The
+  // #1719 branch above only fires when `itemCount > 0`, so this case fell
+  // through to full convergence with an empty `reasons[]` until now (PR
+  // #1875 commit 9711d404). `review.satisfied` (review-clause.mts) is
+  // already gated on `suppressedCount === 0`, so `converged` is already
+  // correctly `false` here -- this branch only supplies the explanation.
+  if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
+    if (review.itemCount === 0 && review.suppressedCount > 0) {
+      reasons.push(
+        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread`,
+      );
+    } else {
+      const itemCountReason =
+        review.itemCount === null
+          ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+          : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
+      // A review can carry both posted comments (itemCount > 0) AND a
+      // suppressed-comments section at once; append a pointer to the
+      // latter rather than silently dropping it from the reported reason.
+      const suppressedSuffix =
+        review.suppressedCount > 0
+          ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
+          : '';
+      reasons.push(
+        threadClause.satisfied &&
+          review.itemCount !== null &&
+          review.itemCount > 0
+          ? `${itemCountReason}${suppressedSuffix} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+          : `${itemCountReason}${suppressedSuffix}`,
+      );
+    }
+  }
+  if (!scopeBlocksConvergenceEval && !threadClause.satisfied) {
+    reasons.push(
+      `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
+    );
+  }
+  // #1719: eligibility-relevant `dispositionEvidence` counters, exposed on
+  // the report object -- see `AdvisoryConvergenceDispositionEvidence`'s doc
+  // comment for why this is a narrow counters-only projection, not the same
+  // shape as `pre-merge-readiness.mjs`'s own `dispositionEvidence` field.
+  const dispositionEvidenceReport = {
+    missingRegularCommentCount: dispositionEvidence.missingRegularCommentCount,
+    missingThreadCount: dispositionEvidence.missingThreadCount,
+  };
+  const converged =
+    !scopeBlocksConvergenceEval &&
+    !pending &&
+    review.satisfied &&
+    threadClause.satisfied;
+  // --- Same-HEAD advisory reroll evidence (#1511) ------------------------
+  // Purely additive: `converged` above is already final and is never
+  // recomputed or referenced below this point -- see the module header and
+  // the "sameHeadReroll never affects converged/ready" test.
+  // `dispositionEvidence.missingRegularCommentCount` reuses the SAME
+  // evidence F2's own separate "missingRegularComments.length == 0"
+  // condition already reads -- an ad hoc regular PR comment (not part of
+  // a review thread) can still be an unaddressed, possibly-PATH-A item
+  // even when every Copilot-authored THREAD is resolved/dispositioned.
+  // Without this, `eligible` could fire while genuine triage work is
+  // still outstanding, spending a bounded reroll attempt on a HEAD that
+  // was not actually done yet -- and if the bot does not answer quickly,
+  // that attempt is permanently consumed before the real blocker is even
+  // cleared (PR #1517 review).
+  //
+  // #1719: each of the six eligibility terms above is ALSO computed as its
+  // own named boolean, paired with a stable token in `sameHeadRerollTerms` --
+  // `sameHeadRerollEligible` (`.every()`) and
+  // `sameHeadRerollIneligibleReasons` (`.filter().map()`) are BOTH derived
+  // from that one array, so they cannot disagree; a term added to the
+  // conjunction without a paired token here would be a compile-time
+  // array-literal edit, not a
+  // hand-maintained parallel expression. `reviewItemCountPositiveTerm` is
+  // deliberately written as "unknown counts as satisfied"
+  // (`itemCount === null || itemCount > 0`), not the bare `itemCount > 0`
+  // the original two-line conjunct implied standalone: this keeps the two
+  // item-count terms mutually exclusive in `ineligibleReasons` (an unknown
+  // count reports ONLY `review-item-count-unknown`, never also
+  // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
+  // reviewItemCountPositiveTerm` together still reduce to exactly the
+  // original `itemCount !== null && itemCount > 0` conjunct.
+  // #1880: `reviewItemCountPositiveTerm` ALSO counts `suppressedCount > 0`
+  // as "positive" -- `itemCount` and `suppressedCount` are both read from
+  // the SAME static review snapshot (never updated by later disposition
+  // activity, same as `itemCount`'s own doc comment on
+  // `AdvisoryConvergenceReviewClause`), so a suppressed-only block is the
+  // identical "nothing else can clear this except a fresh review" shape
+  // #1511's reroll exists for. The token's FAILURE condition stays exactly
+  // as precise as before: `REVIEW_ITEM_COUNT_NOT_POSITIVE` now fires only
+  // when itemCount is a known 0 AND suppressedCount is also 0 -- i.e.
+  // genuinely nothing (posted or suppressed) to reroll for, still an
+  // accurate reading of the existing token name/doc row.
+  // #1686: `indeterminate` now also disqualifies a same-HEAD reroll --
+  // offering to reroll Copilot is pointless while the underlying claim
+  // linkage itself is broken/ambiguous, so this term (and its
+  // `SCOPE_NOT_APPLICABLE` token; see that token's doc row in
+  // docs/idd-helper-scripts.md) fires for either non-`applicable` status.
+  const scopeApplicableTerm = !scopeBlocksConvergenceEval;
+  const reviewNotPendingTerm = !pending;
+  const threadsSatisfiedTerm = threadClause.satisfied;
+  const noMissingRegularCommentsTerm =
+    dispositionEvidence.missingRegularCommentCount === 0;
+  const reviewItemCountKnownTerm = review.itemCount !== null;
+  const reviewItemCountPositiveTerm =
+    review.itemCount === null ||
+    review.itemCount > 0 ||
+    review.suppressedCount > 0;
+  const sameHeadRerollTerms = [
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
+      satisfied: scopeApplicableTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_PENDING,
+      satisfied: reviewNotPendingTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.UNRESOLVED_COPILOT_THREADS,
+      satisfied: threadsSatisfiedTerm,
+    },
+    {
+      token:
+        SAME_HEAD_REROLL_INELIGIBLE_REASON.MISSING_REGULAR_COMMENT_DISPOSITION,
+      satisfied: noMissingRegularCommentsTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_UNKNOWN,
+      satisfied: reviewItemCountKnownTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_NOT_POSITIVE,
+      satisfied: reviewItemCountPositiveTerm,
+    },
+  ];
+  const sameHeadRerollEligible = sameHeadRerollTerms.every(
+    (term) => term.satisfied,
+  );
+  const sameHeadRerollIneligibleReasons = sameHeadRerollTerms
+    .filter((term) => !term.satisfied)
+    .map((term) => term.token);
+  const sameHeadRerollCap =
+    Number.isInteger(options.sameHeadRerollCap) &&
+    Number(options.sameHeadRerollCap) > 0
+      ? Number(options.sameHeadRerollCap)
+      : DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP;
+  const pendingWindowMinutesForReroll =
+    Number.isFinite(options.pendingWindowMinutes) &&
+    Number(options.pendingWindowMinutes) > 0
+      ? Number(options.pendingWindowMinutes)
+      : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES;
+  const rerollMarkers = summarizeSameHeadRerollMarkers(
+    comments,
+    prHeadSha,
+    trustedMarkerLogins,
+  );
+  // A fresh primary-bot review submitted AT OR AFTER the latest reroll
+  // marker's own GitHub `created_at` means that request has already been
+  // answered -- regardless of what the fresh review's itemCount turned out
+  // to be (a "1 -> 3" surprise is still an answer; it is simply not a
+  // converging one, and the normal E1/E4 triage path handles it, never this
+  // evidence). `>=`, not `>`: the marker's `created_at` comes from the REST
+  // comments endpoint while the review's `submittedAt` is fetched
+  // separately via GraphQL, so an equal recorded server timestamp (e.g.
+  // both landing in the same second) must still count as answered -- a
+  // strict `>` would otherwise wait out the full pending window on a tie
+  // that already represents a genuine response (PR #1517 review). A
+  // missing/invalid `submittedAt` fails closed toward "not yet answered"
+  // (never toward a false "landed"), same direction as `isValidIsoTimestamp`
+  // guards elsewhere in this file.
+  const hasFreshReviewSinceLastReroll =
+    rerollMarkers.latestAt !== '' &&
+    isValidIsoTimestamp(review.submittedAt) &&
+    Date.parse(review.submittedAt) >= Date.parse(rerollMarkers.latestAt);
+  const rerollElapsedMinutes =
+    rerollMarkers.latestAt !== ''
+      ? minutesBetween(rerollMarkers.latestAt, now)
+      : 0;
+  // Bounding "in flight" by the same advisoryWait.pendingWindow the AW3
+  // decision table already uses for "bot is pending a re-request" (no new
+  // duration knob) is what makes resume/restart exact: an old, never-
+  // answered reroll self-describes as no-longer-in-flight once the window
+  // elapses, instead of blocking a retry forever if the bot goes silent.
+  const sameHeadRerollInFlight =
+    !scopeBlocksConvergenceEval &&
+    rerollMarkers.latestAt !== '' &&
+    !hasFreshReviewSinceLastReroll &&
+    rerollElapsedMinutes < pendingWindowMinutesForReroll;
+  const sameHeadRerollExhausted = rerollMarkers.count >= sameHeadRerollCap;
+  const sameHeadReroll = {
+    eligible: sameHeadRerollEligible,
+    ineligibleReasons: sameHeadRerollIneligibleReasons,
+    count: rerollMarkers.count,
+    cap: sameHeadRerollCap,
+    exhausted: sameHeadRerollExhausted,
+    latestAt: rerollMarkers.latestAt,
+    inFlight: sameHeadRerollInFlight,
+    requestable:
+      sameHeadRerollEligible &&
+      !sameHeadRerollExhausted &&
+      !sameHeadRerollInFlight,
+  };
+  // --- Deadline clock, anchored on the current HEAD commit's own --------
+  // --- timestamp (not an IDD marker -- see module header for why) -------
+  const deadlineMinutes = Number.isFinite(options.deadlineMinutes)
+    ? Number(options.deadlineMinutes)
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+  const headCommittedAt = String(options.headCommittedAt ?? '');
+  const elapsedMinutes = isValidIsoTimestamp(headCommittedAt)
+    ? minutesBetween(headCommittedAt, now)
+    : null;
+  const deadlinePassed =
+    elapsedMinutes !== null && elapsedMinutes >= deadlineMinutes;
+  const deadline = {
+    minutes: deadlineMinutes,
+    headCommittedAt,
+    elapsedMinutes,
+    passed: deadlinePassed,
+  };
+  // --- Terminal Copilot-unavailability evidence (#1570/#1572) ------------
+  // Reuses `review.commitId` (Clause 1's absolute-latest Copilot review, `''`
+  // when none exists) as the `lastCopilotCommit` input -- the same fetched
+  // evidence, no separate lookup. Purely additive: computed unconditionally,
+  // reported in its own `terminal` field (never merged into `deadline`
+  // above), and -- per `buildCopilotRecoverySummary`'s own contract --
+  // `state: "COPILOT_UNAVAILABLE"` is waiver *eligibility* only. It is
+  // structurally impossible for `terminal` alone to set `converged`/`ready`:
+  // see the waiver-gate and `ready` computation below, both of which require
+  // a valid waiver in addition to `terminalUnavailable`.
+  // Note: `pre-merge-readiness.mts` resolves `lastCopilotCommit` differently
+  // (submittedAt-sorted via `findLastCopilotReviewCommit`, not fetch-order
+  // `.at(-1)`), so under a force-push/revert ordering the two gates could
+  // disagree on terminal state. Tolerable by construction: both gates must
+  // independently pass to merge, so any disagreement fails closed (the
+  // stricter side blocks; a waiver resolves it) -- never an unsafe merge.
+  const recoveryCycleCap =
+    Number.isFinite(options.recoveryCycleCap) &&
+    Number(options.recoveryCycleCap) > 0
+      ? Number(options.recoveryCycleCap)
+      : DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP;
+  const terminalWindowMinutesOption =
+    Number.isFinite(options.terminalWindowMinutes) &&
+    Number(options.terminalWindowMinutes) > 0
+      ? Number(options.terminalWindowMinutes)
+      : DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES;
+  const terminal = buildCopilotRecoverySummary(
+    { comments, prHeadSha, lastCopilotCommit: review.commitId },
+    {
+      now,
+      trustedMarkerLogins,
+      claimId: activeClaimId,
+      agentId: claim.activeClaim?.agentId ?? '',
+      recoveryCycleCap,
+      terminalWindowMinutes: terminalWindowMinutesOption,
+    },
+  );
+  const terminalUnavailable = terminal.state === 'COPILOT_UNAVAILABLE';
+  // --- Waiver escape hatch (reachable once the deadline has passed, or ---
+  // --- once terminal Copilot unavailability is proven -- either one ------
+  // --- independently opens the SAME waiver-evidence check below) ---------
+  const waiverMode = String(options.waiverMode ?? 'disabled');
+  const waiverCheckSelector =
+    String(options.waiverCheckSelector ?? '').trim() ||
+    ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  let validWaiverCount = 0;
+  if (
+    !converged &&
+    (deadlinePassed || terminalUnavailable) &&
+    waiverMode === 'maintainer-authorized'
+  ) {
+    const waiverEvidence = summarizeExternalCheckWaivers(comments, {
+      prHeadSha,
+      activeClaimId,
+      trustedMarkerLogins,
+      now,
+      // The REAL configured `ciGate.externalChecks.waivable` list (not a
+      // hardcoded single-entry override for this gate's own selector):
+      // respects the existing two-dimensional waiver opt-in
+      // (`externalCheckWaivers.mode` AND a per-check `waivable`
+      // registration) instead of silently making this gate waivable the
+      // moment ANY external check is opted into waiver mode (see PR #1343
+      // review). An absent/empty list waives nothing, matching
+      // `summarizeExternalCheckWaivers`'s own "empty list waives nothing"
+      // contract.
+      waivableSelectors: [...(options.waivableSelectors ?? [])],
+      maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
+    });
+    // Even when the configured list makes SOME check waivable, only count a
+    // waiver whose own marker selector is THIS gate's selector -- a valid
+    // waiver for an unrelated external check must never satisfy this one.
+    // The SAME evidence collection satisfies either precondition above: a
+    // maintainer posts one waiver marker for this selector/HEAD/claim, and
+    // whichever precondition (ordinary deadline, or terminal eligibility)
+    // is currently open consumes it -- see the `ready` computation below,
+    // which still requires the precondition it corresponds to.
+    validWaiverCount = waiverEvidence.valid.filter(
+      (entry) => entry.checkSelector === waiverCheckSelector,
+    ).length;
+  }
+  const waiver = {
+    mode: waiverMode,
+    checkSelector: waiverCheckSelector,
+    activeClaimId,
+    validCount: validWaiverCount,
+  };
+  const waived = !scopeNotApplicable && validWaiverCount > 0;
+  if (!scopeNotApplicable && !converged && terminalUnavailable && !waived) {
+    reasons.push(
+      waiverMode === 'maintainer-authorized'
+        ? `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        : `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
+    );
+  } else if (!scopeNotApplicable && !converged && deadlinePassed && !waived) {
+    reasons.push(
+      waiverMode === 'maintainer-authorized'
+        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        : `deadline (${deadlineMinutes}m) passed and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
+    );
+  }
+  const ready =
+    scopeNotApplicable ||
+    converged ||
+    ((deadlinePassed || terminalUnavailable) && waived);
+  return {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    prNumber: inputs.prNumber,
+    prHeadSha,
+    now,
+    primaryBotLogin,
+    applicability,
+    review,
+    threads: threadClause,
+    pending,
+    deadline,
+    waiver,
+    dispositionEvidence: dispositionEvidenceReport,
+    sameHeadReroll,
+    terminal,
+    converged,
+    waived,
+    ready,
+    reasons,
+  };
+}
+// `isVerifiedCopilotAuthor` (#1686 defense-in-depth on top of
+// `isCopilotReviewerLogin`'s login-string check) and
+// `resolveLatestCopilotReviewClause` (Clause 1 evaluation against the
+// single, absolute-latest Copilot review) now live in `review-clause.mts`
+// and are imported above -- both used here unchanged, with
+// `isVerifiedCopilotAuthor` also reused directly by
+// `classifyCopilotAuthoredThreadIds` below.
+/** Thread IDs whose *originating* (first) comment is Copilot-authored.
+ * `summarizeReviewThreadsForGate` classifies by latest-commenter identity
+ * for a different purpose (backlog gating) and is not bot-scoped, so this
+ * is new, narrow logic -- the disposition-marker validity it feeds into
+ * still comes entirely from the reused `summarizeDispositionEvidenceForGate`
+ * output. */
+export function classifyCopilotAuthoredThreadIds(threads, primaryBotLogin) {
+  const ids = new Set();
+  threads.forEach((thread, index) => {
+    // GitHub's GraphQL `comments` connection on a review thread returns
+    // comments in creation order -- the same assumption `fetchReviewThreads`
+    // / `fetchThreadCommentPages` already rely on when appending paginated
+    // results without re-sorting -- so the thread-opening comment is always
+    // `nodes[0]`. Deliberately not timestamp-sorted: `compareIsoTimestamps`
+    // sorts a missing/invalid `createdAt` BEFORE any valid one (by design,
+    // for existing "pick the latest, ignore garbage" call sites elsewhere),
+    // which would let a later reply with a bad timestamp silently usurp
+    // "originating" status and make a genuinely Copilot-opened thread
+    // invisible to this gate.
+    const originating = (thread.comments?.nodes ?? [])[0];
+    if (
+      originating &&
+      isVerifiedCopilotAuthor(originating.author, primaryBotLogin)
+    ) {
+      // Match `summarizeDispositionEvidenceForGate`'s own
+      // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
+      // thread with an empty/missing GraphQL id still round-trips through
+      // the `.has()` lookup in the caller instead of silently diverging.
+      ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
+    }
+  });
+  return ids;
+}
+/**
+ * Same-HEAD advisory reroll marker evidence (#1511): count and latest
+ * GitHub `created_at` of trusted `advisory-reroll:` comments whose embedded
+ * HEAD SHA matches the current HEAD. Mirrors `summarizeAdvisoryWaitMarkers`
+ * (protocol-helpers.mts)'s same-head-scoped half, but kept local to this
+ * file rather than added there -- matching the `classifyCopilotAuthored-
+ * ThreadIds` precedent above (new, gate-specific logic that no other
+ * helper needs). Deliberately does NOT feed `advisory-wait:`'s unscoped
+ * REQUEST_CAP counting: separateness from that cap is a named #1511
+ * acceptance criterion, achieved simply by using a distinct marker prefix
+ * that `summarizeAdvisoryWaitMarkers`'s own regexes never match.
+ */
+function summarizeSameHeadRerollMarkers(
+  comments,
+  prHeadSha,
+  trustedMarkerLogins,
+) {
+  const trusted = new Set(trustedMarkerLogins);
+  // prHeadSha is already validated to `^[0-9a-f]{40}$` by the caller (see
+  // the top of computeAdvisoryConvergenceVerdict), so it is safe to embed
+  // directly in a RegExp literal with no escaping -- a hex string has no
+  // regex-special characters. Requires the FULL canonical marker shape --
+  // a valid trailing ISO-8601 timestamp, end-anchored -- matching the
+  // `advisory-reroll:` entry in `OPERATIONAL_MARKERS` (marker-helpers.mts)
+  // exactly, not merely a loose prefix+SHA check: an accidental or
+  // malformed trusted comment (a typo'd timestamp, or appended prose after
+  // the SHA) must never consume one of the bounded reroll attempts, since
+  // that budget is small (default 2) and a false increment costs much more
+  // proportionally than it would against the much larger REQUEST_CAP
+  // (PR #1517 review).
+  const pattern = new RegExp(
+    `^advisory-reroll:\\s+\\S+\\s+${prHeadSha}\\s+\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z\\s*$`,
+  );
+  let count = 0;
+  let latestAt = '';
+  for (const comment of comments) {
+    const body = String(comment.body ?? '').trimEnd();
+    if (!pattern.test(body)) continue;
+    const login = String(comment.author?.login ?? comment.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!trusted.has(login)) continue;
+    count += 1;
+    // GitHub server `createdAt`/`created_at` ONLY -- never an embedded,
+    // agent-supplied timestamp. Same "clock anchor is marker created_at,
+    // not embedded text" invariant AW2 already states for advisory-wait:,
+    // load-bearing here since `inFlight` compares this against
+    // `review.submittedAt`, another GitHub server timestamp.
+    const createdAt = String(comment.createdAt ?? comment.created_at ?? '');
+    if (
+      isValidIsoTimestamp(createdAt) &&
+      (!latestAt || Date.parse(createdAt) > Date.parse(latestAt))
+    ) {
+      latestAt = createdAt;
+    }
+  }
+  return { count, latestAt };
+}
+/** Whole minutes elapsed from `start` to `end`, clamped to 0 and floored --
+ * matching `minutesBetweenIso` (protocol-helpers.mts) exactly, so a clock-
+ * skew or malformed-timestamp edge case can never make `deadline.elapsed-
+ * Minutes` negative or fractional. Not reused directly since that helper is
+ * not exported. */
+function minutesBetween(start, end) {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return 0;
+  }
+  return Math.floor((endMs - startMs) / 60000);
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const ADVISORY_CONVERGENCE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--claim-issue': { type: 'string' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--advisory-bot-logins': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--assert': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, ADVISORY_CONVERGENCE_FLAG_SPEC);
+  return {
+    // Both resolve-to-null on an invalid/absent value (fails closed at the
+    // caller) -- the established contract this migration must preserve;
+    // see "an invalid --pr resolves to null" in tests/advisory-convergence.
+    // test.mts.
+    prNumber: parseCanonicalIntegerOrNull(values.pr),
+    owner: values.owner,
+    repo: values.repo,
+    claimIssueNumber: parseCanonicalIntegerOrNull(values['claim-issue']),
+    trustedMarkerLogins: values['trusted-marker-logins'],
+    advisoryBotLogins: values['advisory-bot-logins'],
+    now: values.now,
+    assert: values.assert,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert] [--help]
+
+Read-only: asserts whether the primary advisory bot's review has converged
+on the current PR HEAD. Every invocation other than --help/-h prints the
+JSON verdict to stdout. Without --assert, always exits 0 (report-only).
+With --assert, exits non-zero unless the verdict is "ready" (converged, or
+validly waived past the configured deadline).
+`);
+}
+const defaultDeps = { collect: collectFromGitHub };
+/**
+ * Parse argv, collect evidence (via `deps.collect`, real `gh` calls by
+ * default), compute the verdict, and derive the `--assert` exit code.
+ * Mirrors `idd-merge-execute.mts`'s `runMergeExecute` DI pattern so tests
+ * can substitute a fake `collect` instead of shelling out to `gh`.
+ */
+export function runAdvisoryConvergence(argv, deps = defaultDeps) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { verdict: null, exitCode: 0, help: true };
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const { inputs, options } = deps.collect(args);
+  const verdict = computeAdvisoryConvergenceVerdict(inputs, options);
+  const exitCode = args.assert ? (verdict.ready ? 0 : 1) : 0;
+  return { verdict, exitCode, help: false };
+}
+// --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
+/**
+ * `gh` options for the viewer-login probe (`gh api user`).
+ *
+ * Under GitHub Actions the workflow token is a GitHub App installation token
+ * with no authenticated user, so `gh api user` always returns 403 ("Resource
+ * not accessible by integration"). That is expected and harmless here:
+ * {@link safeGhText} swallows it and `viewerLogin === ''` is the correct value
+ * in CI (there is no runner "self" whose markers should be trusted). Only the
+ * inherited stderr leaks the confusing 403 line into the run log, so under
+ * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
+ *
+ * Outside Actions (a local/interactive run) the probe normally succeeds; if it
+ * genuinely fails we deliberately **inherit** stderr so the failure stays
+ * visible — a silently-empty `viewerLogin` narrows self-marker trust, the same
+ * fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ *
+ * Both branches set `stdio` **explicitly** rather than leaning on
+ * `execFileSync`'s default: that default already writes the child's stderr to
+ * the parent (so a bare call would leak the 403), but relying on it is
+ * non-obvious. `pipe` captures stderr (silent); `inherit` forwards it to the
+ * parent (visible). stdin is `ignore` on both, matching `GH_TEXT_LOOP_OPTIONS`'
+ * stdin-safety.
+ */
+export function viewerProbeGhOptions(env = process.env) {
+  return {
+    stdio:
+      env.GITHUB_ACTIONS === 'true'
+        ? ['ignore', 'pipe', 'pipe']
+        : ['ignore', 'pipe', 'inherit'],
+  };
+}
+function collectFromGitHub(args) {
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText(
+    ['api', 'user', '--jq', '.login'],
+    viewerProbeGhOptions(),
+  ).toLowerCase();
+  const rawConfig = loadIddConfig();
+  const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: rawConfig,
+  });
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,headRefName,closingIssuesReferences,author,url',
+    ]),
+  );
+  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
+  const prHeadRefName = String(pr.headRefName ?? '').trim();
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const prUrl = String(pr.url ?? '');
+  // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
+  // marker-shaped PR comment can be detected before that set is used to
+  // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    {
+      paginate: true,
+    },
+  );
+  // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
+  // `readCollaboratorTrustEnabled` exactly, except reusing the already-
+  // loaded `rawConfig` instead of a second `.github/idd/config.json` read
+  // (`resolveCollaboratorMarkerTrust` and `loadIddConfig` are both already
+  // null-safe, so no extra try/catch is needed for that simplification).
+  const collaboratorTrustEnabled = resolveCollaboratorMarkerTrust(
+    rawConfig,
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
+  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
+    owner,
+    repo,
+    Number(args.prNumber),
+  );
+  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+  // #1347: fetch every claim-issue candidate's raw comments (pure I/O)
+  // BEFORE computing `trustedMarkerLogins`, so collaborator-marker trust
+  // can be resolved from ALL candidates' comments -- not just whichever
+  // one the presence-check below eventually picks. Folding trust only
+  // from the already-picked candidate is circular: a lone candidate's
+  // claim-establishing marker, authored by a login trusted only via
+  // collaborator-marker trust, would never register as "active" for the
+  // presence check to pick it in the first place, discarding the real
+  // claim data before that trust is ever computed. See
+  // `pickResolvingClaimEvents`'s doc comment for the full history.
+  const claimCandidates = fetchClaimEventCandidates(
+    owner,
+    repo,
+    args.claimIssueNumber,
+    pr.closingIssuesReferences,
+  );
+  // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
+  // other locally-collected sets in this file that scope broader trust for
+  // marker *parsing*): every sibling helper (advisory-wait-state.mts,
+  // pre-merge-readiness.mts) keeps `trustedMarkerLogins` and
+  // `advisoryBotLogins` disjoint, and this specific set also authorizes
+  // `--assert`-gating external-check waivers (via `summarizeExternalCheck-
+  // Waivers`, below) -- folding a configured advisory bot login in here
+  // would let that bot's own comment count as a "maintainer-authorized"
+  // waiver author.
+  //
+  // #1344/#1347: folds collaborator-marker trust over the UNION of PR
+  // comments and EVERY claim-issue candidate's comments, matching
+  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union in
+  // spirit (extended here to all candidates, since this gate -- unlike
+  // pre-merge-readiness.mts -- auto-discovers among several linked issues
+  // rather than requiring a single explicit one). Scanning `comments`
+  // alone would make `collaboratorTrustEnabled` a no-op for claim and
+  // forced-handoff markers: those are always posted to the claim ISSUE,
+  // never the PR (see `forced-handoff-marker.mts`), and
+  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any
+  // claim/forced-handoff parsing -- an untrusted-author's marker never
+  // even reaches the authorization check.
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+          ...comments,
+          ...claimCandidates.flat(),
+        ])
+      : []),
+  ]);
+  // #1810: delegates to `resolveClaimEvidence` (below `hasTrustedClaimMarker-
+  // History`'s definition) instead of calling `pickResolvingClaimEvents` /
+  // `classifyClaimCandidateAmbiguity` / `hasTrustedClaimMarkerHistory`
+  // separately here -- see that function's doc comment for why this call
+  // site's own compute-and-forward wiring needed a direct test, not just
+  // the three underlying helpers.
+  const { claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent } =
+    resolveClaimEvidence(
+      claimCandidates,
+      trustedMarkerLogins,
+      Boolean(args.claimIssueNumber),
+    );
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
+  // #1511: bounded same-HEAD reroll cap, plus the existing pendingWindow
+  // (reused, not a new duration knob) that bounds how long a reroll can
+  // stay "in flight" before a caller may safely retry.
+  const sameHeadRerollCap = readAdvisorySameHeadRerollCap();
+  const { pendingWindowMinutes } = readAdvisoryWaitPolicy();
+  // #1570/#1572: bounded per-PR-HEAD Copilot stall-recovery cycle cap and
+  // 12h terminal-unavailability window, read independently of the five-key
+  // `AdvisoryWaitPolicy` shape above for the same reason `sameHeadRerollCap`
+  // is (see advisory-wait-policy.mts's own doc comments on each resolver).
+  const recoveryCycleCap = readAdvisoryRecoveryCycleCap();
+  const terminalWindowMinutes = readAdvisoryTerminalWindowMinutes();
+  // No manual cast: `normalizePolicyConfig`'s inferred return type already
+  // carries `ciGate.externalCheckWaivers.{mode,maxValidity}` precisely (see
+  // `external-check-waiver.mts`'s `NormalizedPolicy` alias for the same
+  // pattern) -- re-declaring the shape here would silently stop tracking
+  // that source of truth on drift.
+  const policy = normalizePolicyConfig(rawConfig);
+  // #1344: forced-handoff-aware claim resolution, matching
+  // `pre-merge-readiness.mts` exactly, except reading `forcedHandoff.mode`/
+  // `authorityPolicy` off the already-loaded/normalized `policy` above
+  // instead of `readForcedHandoffMode()`/`readForcedHandoffAuthorityPolicy()`
+  // (each of which independently re-reads and re-parses
+  // `.github/idd/config.json`) -- `readForcedHandoffPolicy`
+  // (collaborator-permission.mts) computes those two fields via the exact
+  // same `normalizePolicyConfig` call, so `policy.forcedHandoff.*` is
+  // identical, not an approximation.
+  const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
+  const forcedHandoffEnabled = policy.forcedHandoff.mode === 'human-gated';
+  const forcedHandoffPermissionCache = new Map();
+  // Part B (#1058): an issue-only handoff that predates the PR is honored
+  // even against a PR-backed claim. Resolved only when forced handoffs are
+  // enabled, and fails closed to `null` (reject) on any lookup/parse error
+  // so a transient commits-API failure never widens what this gate accepts.
+  let prFirstCommitAt = null;
+  if (forcedHandoffEnabled) {
+    try {
+      const prCommits = ghApiJson(
+        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+        { paginate: true },
+      );
+      prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
+    } catch {
+      prFirstCommitAt = null;
+    }
+  }
+  const staleAgeMs =
+    parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
+  const convergenceScope =
+    policy?.advisoryWait?.convergenceScope === 'idd-claimed'
+      ? 'idd-claimed'
+      : 'all-prs';
+  // #1906: opt-in, off by default, and only ever consulted under
+  // `all-prs` scope (`idd-claimed` never reaches the new applicability
+  // branch -- see `computeAdvisoryConvergenceVerdict`). Fetch the PR's
+  // own author `__typename` only when BOTH the flag is enabled AND
+  // scope is `all-prs`, so a repository that enables the flag under
+  // `idd-claimed` (where it can never apply) still pays for zero extra
+  // GraphQL round trips, matching the "no behavior/cost change unless
+  // genuinely applicable" goal the plain opt-in-off case already gets.
+  // Fails closed to `false` ("not a Bot-typed author", today's
+  // `applicable`/`all-prs` outcome) on any fetch error, matching
+  // `prFirstCommitAt` above: a transient GraphQL failure must never
+  // widen what this gate accepts.
+  const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
+  let prAuthorIsBot = false;
+  if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
+    try {
+      prAuthorIsBot =
+        fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
+    } catch {
+      prAuthorIsBot = false;
+    }
+  }
+  return {
+    inputs: {
+      prNumber: Number(args.prNumber),
+      prHeadSha,
+      reviews,
+      threads,
+      comments,
+      claimEvents,
+      claimMarkerHistoryPresent,
+      claimCandidateAmbiguous,
+      prAuthorIsBot,
+    },
+    options: {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      primaryBotLogin,
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      convergenceScope,
+      exemptBotAuthoredPrs,
+      prHeadRefName,
+      prAuthorLogin,
+      headCommittedAt,
+      deadlineMinutes,
+      waiverMode: String(
+        policy?.ciGate?.externalCheckWaivers?.mode ?? 'disabled',
+      ),
+      waiverMaxValidity: String(
+        policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
+      ),
+      waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
+      sameHeadRerollCap,
+      pendingWindowMinutes,
+      recoveryCycleCap,
+      terminalWindowMinutes,
+      forcedHandoffEnabled,
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+      expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      prFirstCommitAt,
+      staleAgeMs,
+    },
+  };
+}
+/**
+ * Fetch one issue's comments and normalize them to the `author.login` /
+ * `createdAt` shape `resolveActiveClaim`/`applyClaimEvent`
+ * (`protocol-helpers.mts`) require. Unlike `summarizeDispositionEvidence-
+ * ForGate` / `summarizeExternalCheckWaivers`, the claim resolver has NO
+ * `user.login` / `created_at` REST fallback (`event.author?.login ?? ''`,
+ * `event.createdAt ?? ''`, verbatim) -- passing raw `gh api` REST comments
+ * through unnormalized silently resolves `activeClaimPresent: false` for
+ * every real claim, breaking the entire waiver escape hatch without any
+ * error. `pre-merge-readiness.mts`'s own `normalizeClaimComment` does the
+ * same normalization for the identical reason; mirrored here rather than
+ * imported since it is not exported.
+ */
+function fetchClaimComments(owner, repo, issueNumber) {
+  const raw = ghApiJson(
+    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    {
+      paginate: true,
+    },
+  );
+  return raw.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.createdAt ?? comment.created_at ?? '',
+    author: { login: comment.author?.login ?? comment.user?.login ?? '' },
+  }));
+}
+/**
+ * Fetch the claim-issue candidate(s)' raw comment streams -- pure I/O, no
+ * trust judgment. When `explicitIssueNumber` (`--claim-issue`) is given,
+ * fetch it alone -- no ambiguity to resolve. Otherwise a PR can close more
+ * than one issue (`pr.closingIssuesReferences`), so fetch every candidate's
+ * comments; {@link pickResolvingClaimEvents} disambiguates them afterward.
+ *
+ * Split out from a single `resolveClaimEvents` (#1344) so the
+ * `trustedMarkerLogins` used for disambiguation can be computed from ALL
+ * candidates' comments first (see the `collectFromGitHub` call site) --
+ * #1347 found that resolving trust from only the eventually-picked
+ * candidate is circular: a lone candidate's claim-establishing marker,
+ * authored by a login trusted only via collaborator-marker trust, would
+ * never be recognized as "active" long enough to be picked in the first
+ * place, discarding the real claim data before that trust is ever folded
+ * in.
+ */
+function fetchClaimEventCandidates(owner, repo, explicitIssueNumber, refs) {
+  if (explicitIssueNumber) {
+    return [fetchClaimComments(owner, repo, explicitIssueNumber)];
+  }
+  const candidateNumbers = [
+    ...new Set(
+      (refs ?? []).map((ref) => ref?.number).filter((n) => Number.isInteger(n)),
+    ),
+  ];
+  return candidateNumbers.map((issueNumber) =>
+    fetchClaimComments(owner, repo, issueNumber),
+  );
+}
+/** Candidate claim-issue comment streams whose *active claim* actually
+ * resolves (`summarizeClaimValidation`). Shared by
+ * {@link pickResolvingClaimEvents} and {@link classifyClaimCandidateAmbiguity}
+ * (#1686) so both read the identical disambiguation result instead of two
+ * independently-maintained filters that could drift. */
+function filterResolvingClaimCandidates(candidates, trustedMarkerLogins) {
+  return candidates.filter((comments) =>
+    Boolean(
+      summarizeClaimValidation(comments, { trustedMarkerLogins })
+        .activeClaimPresent,
+    ),
+  );
+}
+/**
+ * Resolve the linked (claim) issue's comment stream for waiver-claim
+ * binding, given already-fetched candidate comment streams
+ * ({@link fetchClaimEventCandidates}) and a `trustedMarkerLogins` already
+ * fully resolved (including any collaborator-marker-trust fold) over ALL
+ * candidates' comments. Pure -- no I/O -- so it is directly unit-testable.
+ *
+ * `isExplicit` mirrors `fetchClaimEventCandidates`'s own
+ * `explicitIssueNumber` check: an explicit `--claim-issue` candidate is
+ * returned unconditionally, no ambiguity to resolve. Otherwise, keep only
+ * the candidate whose *active claim* actually resolves
+ * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
+ * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
+ * active-claim presence rather than requiring a single closing reference.
+ * Zero or multiple resolving candidates fail closed to `[]` (no waiver
+ * claim can bind unambiguously), same as before #1344/#1347 -- and
+ * unchanged by #1686: {@link classifyClaimCandidateAmbiguity} below is the
+ * new, separate signal that lets a caller tell the "zero resolving" and
+ * "multiple resolving" cases apart without touching this function's own
+ * fail-closed-to-`[]` contract (pinned by
+ * "pickResolvingClaimEvents: zero or multiple resolving candidates still
+ * fail closed to [] (unchanged from pre-#1344/#1347 behavior)" in
+ * tests/advisory-convergence.test.mts).
+ */
+export function pickResolvingClaimEvents(
+  candidates,
+  trustedMarkerLogins,
+  isExplicit,
+) {
+  if (isExplicit) {
+    return candidates[0] ?? [];
+  }
+  const resolving = filterResolvingClaimCandidates(
+    candidates,
+    trustedMarkerLogins,
+  );
+  return resolving.length === 1 ? resolving[0] : [];
+}
+/**
+ * #1686: true when two or more claim-issue candidates each independently
+ * resolve an active trusted claim -- the specific disambiguation-failure
+ * case {@link pickResolvingClaimEvents} already fails closed to `[]` for
+ * (see its own doc comment above and the module header's path 2). Surfaced
+ * as an explicit signal so the `idd-claimed` applicability gate
+ * (`computeAdvisoryConvergenceVerdict`) can distinguish "this PR's closing
+ * references are ambiguous between two actively-claimed issues" from the
+ * ordinary "no candidate resolves at all" case, which
+ * `pickResolvingClaimEvents`'s own collapsed `[]` output cannot
+ * distinguish by itself. An explicit `--claim-issue` target has no
+ * ambiguity to resolve -- always `false`, mirroring
+ * `pickResolvingClaimEvents`'s own `isExplicit` short-circuit.
+ */
+export function classifyClaimCandidateAmbiguity(
+  candidates,
+  trustedMarkerLogins,
+  isExplicit,
+) {
+  if (isExplicit) {
+    return false;
+  }
+  return (
+    filterResolvingClaimCandidates(candidates, trustedMarkerLogins).length > 1
+  );
+}
+/**
+ * #1686: true when at least one TRUSTED, syntactically valid `claimed-by`
+ * marker exists anywhere in `candidates`' raw comment streams -- regardless
+ * of whether it currently resolves to an ACTIVE claim. A released
+ * (`unclaimed-by`), superseded-without-a-qualifying-takeover, or otherwise
+ * no-longer-current claim still counts: this function answers "did real IDD
+ * claim activity ever happen here", not "is a claim active right now" (that
+ * question is `summarizeClaimValidation(...).activeClaimPresent`, already
+ * computed elsewhere).
+ *
+ * Note on *why* this function is needed rather than an age comparison:
+ * `resolveActiveClaim` (protocol-helpers.mts) has no `now` parameter and
+ * never expires a claim by elapsed time alone -- staleness there only
+ * matters when a LATER claim event attempts to supersede the active one
+ * (`claim.supersedes === activeClaim.claimId && isStale(...)`). A claim
+ * that goes stale on a long-open PR with no subsequent takeover event stays
+ * `activeClaimPresent: true` forever in this codebase; time by itself never
+ * clears it. So the concrete way `activeClaimPresent` becomes `false` while
+ * genuine claim history exists is an explicit release/handoff event (or a
+ * disambiguation failure -- see {@link classifyClaimCandidateAmbiguity}
+ * instead), not a bare age computation -- this function's own test fixtures
+ * demonstrate that shape rather than asserting on elapsed time. See the
+ * module header's path 4 and `AdvisoryConvergenceInputs.claimMarkerHistoryPresent`'s
+ * doc comment.
+ */
+export function hasTrustedClaimMarkerHistory(candidates, trustedMarkerLogins) {
+  const trusted = new Set(trustedMarkerLogins);
+  return candidates.some((candidateComments) =>
+    candidateComments.some((event) => {
+      const login = String(event.author?.login ?? event.user?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (!trusted.has(login)) {
+        return false;
+      }
+      return (
+        parseClaimComment(
+          event.body ?? '',
+          event.createdAt ?? event.created_at ?? '',
+        ) !== null
+      );
+    }),
+  );
+}
+/**
+ * Resolve all three claim-evidence fields `collectFromGitHub` forwards into
+ * {@link AdvisoryConvergenceInputs} from already-fetched claim candidates and
+ * resolved trust -- pure (no I/O), so it is directly unit-testable, mirroring
+ * {@link filterResolvingClaimCandidates}'s existing shared-helper extraction
+ * pattern. `collectFromGitHub` previously called
+ * {@link pickResolvingClaimEvents}, {@link classifyClaimCandidateAmbiguity},
+ * and {@link hasTrustedClaimMarkerHistory} separately and forwarded their
+ * results inline; that compute-and-forward wiring is itself the #1810 gap --
+ * each of the three helpers has direct unit tests, but nothing proved the
+ * real call site actually threads their outputs into the verdict inputs.
+ * Collapsing all three into one exported step makes the call site a trivial,
+ * visually obvious delegation and gives the wiring itself a direct test.
+ */
+export function resolveClaimEvidence(
+  candidates,
+  trustedMarkerLogins,
+  isExplicit,
+) {
+  const claimEvents = pickResolvingClaimEvents(
+    candidates,
+    trustedMarkerLogins,
+    isExplicit,
+  );
+  // #1686: ambiguity is a distinct signal from `claimEvents` above --
+  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
+  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
+  // comment), so this must be computed separately over the same
+  // `candidates`/`trustedMarkerLogins` inputs rather than re-derived from the
+  // already-collapsed `claimEvents`.
+  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
+    candidates,
+    trustedMarkerLogins,
+    isExplicit,
+  );
+  // #1686: true when ANY candidate claim issue ever carried a trusted,
+  // syntactically valid `claimed-by` marker -- computed over the union of
+  // every candidate's RAW comment stream (`candidates`, not the
+  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
+  // otherwise no-longer-active claim still counts as genuine IDD claim
+  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
+  // rationale and the module header's path 4.
+  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
+    candidates,
+    trustedMarkerLogins,
+  );
+  return { claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent };
+}
+/**
+ * Candidate collaborator-marker-trust logins: comment authors whose comment
+ * matches a recognized operational-marker prefix (claim, waiver,
+ * forced-handoff, etc. -- `operationalMarkerPrefix`), permission-checked
+ * and kept only when Write/Maintain/Admin. Mirrors
+ * `pre-merge-readiness.mts`'s function of the same name exactly. The
+ * `collectFromGitHub` call site passes the UNION of PR comments and the
+ * resolved claim issue's own comments (matching `pre-merge-readiness.mts`'s
+ * `[...comments, ...claimComments]` union) -- PR comments alone are not
+ * enough, since forced-handoff and claim markers are always posted to the
+ * claim issue, never the PR (see `forced-handoff-marker.mts`). Only called
+ * when `markerTrust.allowCollaboratorMarkers` / `IDD_TRUST_COLLABORATOR_MARKERS`
+ * is enabled -- a no-op repository never pays for these lookups.
+ */
+function resolveTrustedCollaboratorMarkerLogins(
+  owner,
+  repo,
+  commentLikeEvents,
+) {
+  const markerAuthors = [
+    ...new Set(
+      commentLikeEvents
+        .filter(
+          (comment) => operationalMarkerPrefix(comment.body ?? '') !== null,
+        )
+        .map((comment) => comment.author?.login ?? comment.user?.login ?? '')
+        .filter(Boolean),
+    ),
+  ];
+  return markerAuthors.filter((login) => {
+    const permission = safeGhText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).toLowerCase();
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+}
+// `ghGraphql` now lives in `gh-exec.mts` (imported above) and
+// `fetchReviewsAndHeadCommit` (+ its local `RawReviewNode` shape) now
+// lives in `review-clause.mts` (imported above) -- both used here
+// unchanged. The other two `ghGraphql(...)` call sites in this file
+// (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
+// the same function via the new import.
+/** #1906: fetch the PR's own author `login`/`__typename` via a small
+ * dedicated GraphQL query -- the REST-shaped `gh pr view --json author`
+ * fetch in `collectFromGitHub` only returns `login`, no type
+ * discriminator. Deliberately its own minimal round trip rather than
+ * folded into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
+ * (review-clause.mts): both of those are narrowly-scoped Copilot-review
+ * evidence collectors, the latter shared verbatim with
+ * `rerun-advisory-convergence.mts`, and widening either with an unrelated
+ * PR-author field would blur that scope for no shared benefit. Called by
+ * `collectFromGitHub` only when the opt-in `exemptBotAuthoredPrs` policy
+ * is enabled (see the call site), so a repository that never sets the
+ * flag never pays for this extra request. */
+function fetchPrAuthor(owner, repo, prNumber) {
+  const payload = ghGraphql(
+    `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            author { login __typename }
+          }
+        }
+      }`,
+    { owner, repo, number: prNumber },
+  );
+  return payload?.data?.repository?.pullRequest?.author ?? null;
+}
+function fetchReviewThreads(owner, repo, prNumber) {
+  const nodes = [];
+  let cursor = null;
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  comments(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      body
+                      createdAt
+                      updatedAt
+                      author { login __typename }
+                      pullRequestReview { id }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes.push(
+          ...fetchThreadCommentPages(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        );
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) break;
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+function fetchThreadCommentPages(threadId, afterCursor) {
+  const nodes = [];
+  let cursor = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  body
+                  createdAt
+                  updatedAt
+                  author { login __typename }
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }`,
+      { id: threadId, cursor },
+    );
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
+  }
+  return nodes;
+}
+// CLI: emit the verdict as JSON and set the exit code when invoked directly.
+// Guarded behind `import.meta.main` so importing this module (for unit
+// tests) never parses process.argv, prints usage, or makes a `gh` call.
+if (import.meta.main) {
+  const { verdict, exitCode, help } = runAdvisoryConvergence(
+    process.argv.slice(2),
+  );
+  if (help) {
+    printHelp();
+  } else if (verdict) {
+    process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  }
+  process.exit(exitCode);
+}

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -1,0 +1,414 @@
+// idd-generated-from: src/scripts/advisory-wait-policy.mts
+//
+// The scripts/advisory-wait-policy.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { loadJson, validateConfigSection } from './validate-schemas.mjs';
+export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
+export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
+export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
+export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
+export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// #1571: the default primary bot's GraphQL login (`copilot`) and its REST
+// `requested_reviewers` account login differ -- `gh pr edit --add-reviewer`/
+// `--remove-reviewer` resolve bot logins via GraphQL and some `gh` versions
+// reject the bot login outright, so E14 falls back to this REST identity
+// (see idd-review-fix.instructions.md's gh-then-REST fallback).
+export const DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN =
+  'copilot-pull-request-reviewer[bot]';
+// Shared last-resort fallback for the plural `advisoryBotLogins` config key
+// (distinct from the singular primary-bot-login default above): used by both
+// `merged-pr-feedback-sweep.mts` and `disposition-non-review-notices.mts` so
+// the two stay aligned on which identities count as advisory bots when
+// `.github/idd/config.json` configures none. A single source avoids the
+// drift risk of two independently-maintained literals (see PR #1490 review).
+export const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
+// 24h, matching the `claim-stale-age` and external-check-waiver
+// `maxValidity` defaults so this gate uses a familiar timescale.
+export const DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES = 1440;
+// #1511: bounded same-HEAD advisory reroll budget -- a small, deliberately
+// conservative default. The empirical basis (200 merged PRs, #1511's issue
+// body) shows a fresh same-SHA re-review often drops straight to zero, but
+// K=1 is sometimes insufficient, so 2 balances recovering the common case
+// against not hammering the bot when a residual is genuinely flat.
+export const DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP = 2;
+// #1572: bounded per-PR-HEAD Copilot stall-recovery cycle cap, accounted
+// independently of both DEFAULT_ADVISORY_REQUEST_CAP (ordinary re-review
+// requests) and DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP (same-HEAD reroll
+// budget, #1511). A "recovery cycle" is one trusted, claim-bound,
+// current-HEAD-bound `advisory-recovery` marker -- see
+// `buildCopilotRecoverySummary` in advisory-wait-state.mts. Small and
+// conservative like the reroll cap default, for the same reason: this is a
+// terminal-eligibility budget, not a routine retry budget.
+export const DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP = 2;
+// #1572: 12h terminal unavailability window, matching the `claim-stale-age`
+// and external-check-waiver `maxValidity` distributed defaults so this gate
+// uses the same familiar timescale as other terminal/escalation windows in
+// this repository.
+export const DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES = 720;
+// #1570: the `idd-advisory-convergence` required-check selector name, shared
+// between advisory-convergence.mts (the CI-gate consumer, which re-exports
+// this under its own established `ADVISORY_CONVERGENCE_CHECK_SELECTOR` name
+// for backward compatibility) and protocol-helpers.mts's
+// `buildPreMergeReadinessSummary` (the F2/F3 direct-evidence consumer, which
+// filters external-check-waiver evidence by this same selector for the
+// terminal-unavailability waiver check). A single source avoids the two
+// consumers silently drifting on the registered selector string.
+export const DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR =
+  'idd-advisory-convergence';
+export const ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT = 'phase-specific';
+export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
+  'phase-specific',
+  'hold',
+]);
+const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+export function readAdvisoryWaitPolicy(path = '.github/idd/config.json') {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359): an unrelated invalid
+    // field elsewhere in the document must not zero out an otherwise-valid
+    // advisoryWait section.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return resolveAdvisoryWaitPolicy({});
+    }
+    return resolveAdvisoryWaitPolicy(config);
+  } catch {
+    return resolveAdvisoryWaitPolicy({});
+  }
+}
+export function resolveAdvisoryWaitPolicy(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return {
+    requestCap: normalizeConfiguredPositiveInteger(
+      advisoryWait.requestCap,
+      DEFAULT_ADVISORY_REQUEST_CAP,
+    ),
+    pendingWindowMinutes: normalizeConfiguredDurationMinutes(
+      advisoryWait.pendingWindow,
+      DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
+    ),
+    settledWindowMinutes: normalizeConfiguredDurationMinutes(
+      advisoryWait.settledWindow,
+      DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+    ),
+    pollIntervalMinutes: normalizeConfiguredDurationMinutes(
+      advisoryWait.pollInterval,
+      DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
+    ),
+    capExhaustedRoute: normalizeConfiguredCapExhaustedRoute(
+      advisoryWait.capExhaustedRoute,
+    ),
+  };
+}
+function normalizeConfiguredPrimaryBotLogin(value) {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim().toLowerCase()
+    : DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+}
+/**
+ * Resolve the configured primary advisory bot login from a parsed policy
+ * object, defaulting to Copilot so the advisory-wait gate is behavior-
+ * preserving when `advisoryWait.primaryBotLogin` is absent. Kept separate
+ * from {@link resolveAdvisoryWaitPolicy} so the timing-policy shape stays a
+ * stable five-key object.
+ */
+export function resolveAdvisoryPrimaryBotLogin(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredPrimaryBotLogin(advisoryWait.primaryBotLogin);
+}
+/**
+ * Read the configured primary advisory bot login from a policy file, failing
+ * closed to Copilot when the file is missing, unreadable, or schema-invalid.
+ */
+export function readAdvisoryPrimaryBotLogin(path = '.github/idd/config.json') {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+    }
+    return resolveAdvisoryPrimaryBotLogin(config);
+  } catch {
+    return DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  }
+}
+/**
+ * Resolve the REST API identity for the configured primary advisory bot
+ * (#1571), used only when the `gh pr edit --add-reviewer` /
+ * `--remove-reviewer` GraphQL mutation fails to resolve a bot login (E14's
+ * documented gh-then-REST fallback; see
+ * idd-review-fix.instructions.md#e14). For the default Copilot bot, the REST
+ * identity differs from the GraphQL login; a configured non-default bot's
+ * REST login equals its GraphQL login, since a configured login is already a
+ * real account login. Pure and fails closed to the default REST login when
+ * `primaryBotLogin` is blank.
+ */
+export function resolveAdvisoryBotRestLogin(
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  const normalized = normalizeConfiguredPrimaryBotLogin(primaryBotLogin);
+  return normalized === DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN
+    ? DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN
+    : normalized;
+}
+/**
+ * Normalize a configured secondary advisory bot login. Unlike the primary
+ * (which fails closed to Copilot), the secondary is OPTIONAL: an absent,
+ * blank, or non-string value resolves to `''` so an unconfigured secondary
+ * stays fully disabled — the supplement never fires and behavior is identical
+ * to the primary-only path.
+ */
+function normalizeConfiguredSecondaryBotLogin(value) {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim().toLowerCase()
+    : '';
+}
+/**
+ * Resolve the OPTIONAL secondary advisory bot login from a parsed policy
+ * object, returning `''` (disabled) when `advisoryWait.secondaryBotLogin` is
+ * absent. The secondary is a non-gating supplement, so it has no Copilot
+ * default — absence must read as "no secondary".
+ */
+export function resolveAdvisorySecondaryBotLogin(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredSecondaryBotLogin(advisoryWait.secondaryBotLogin);
+}
+/**
+ * Read the OPTIONAL secondary advisory bot login from a policy file, failing
+ * closed to `''` (disabled) when the file is missing, unreadable, or
+ * schema-invalid.
+ */
+export function readAdvisorySecondaryBotLogin(
+  path = '.github/idd/config.json',
+) {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return '';
+    }
+    return resolveAdvisorySecondaryBotLogin(config);
+  } catch {
+    return '';
+  }
+}
+/**
+ * Resolve the configured advisory-convergence deadline (in minutes) from a
+ * parsed policy object. Once a PR HEAD has gone this long without a
+ * zero-item Copilot review, `advisory-convergence.mts`'s only pass path is a
+ * valid maintainer external-check waiver for that HEAD. Kept separate from
+ * {@link resolveAdvisoryWaitPolicy} for the same reason the bot-login
+ * resolvers are separate: it is not part of the five-key active-wait timing
+ * shape, and defaults to Copilot-advisory-preserving behavior when absent.
+ */
+export function resolveAdvisoryConvergenceDeadlineMinutes(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredDurationMinutes(
+    advisoryWait.convergenceDeadline,
+    DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
+  );
+}
+/**
+ * Read the configured advisory-convergence deadline from a policy file,
+ * failing closed to the 24h default when the file is missing, unreadable, or
+ * schema-invalid.
+ */
+export function readAdvisoryConvergenceDeadlineMinutes(
+  path = '.github/idd/config.json',
+) {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+    }
+    return resolveAdvisoryConvergenceDeadlineMinutes(config);
+  } catch {
+    return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+  }
+}
+/**
+ * Resolve the configured bounded same-HEAD advisory reroll cap (#1511) from
+ * a parsed policy object. Kept separate from {@link resolveAdvisoryWaitPolicy}
+ * for the same reason the deadline/bot-login resolvers are separate: it is
+ * not part of the five-key active-wait timing shape, and it defaults to a
+ * fixed, conservative cap when absent.
+ */
+export function resolveAdvisorySameHeadRerollCap(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredPositiveInteger(
+    advisoryWait.sameHeadRerollCap,
+    DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP,
+  );
+}
+/**
+ * Read the configured bounded same-HEAD advisory reroll cap from a policy
+ * file, failing closed to the default cap when the file is missing,
+ * unreadable, or schema-invalid.
+ */
+export function readAdvisorySameHeadRerollCap(
+  path = '.github/idd/config.json',
+) {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP;
+    }
+    return resolveAdvisorySameHeadRerollCap(config);
+  } catch {
+    return DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP;
+  }
+}
+/**
+ * Read the configured bounded per-PR-HEAD Copilot stall-recovery cycle cap
+ * from a policy file, failing closed to the default cap when the file is
+ * missing, unreadable, or schema-invalid.
+ */
+export function readAdvisoryRecoveryCycleCap(path = '.github/idd/config.json') {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP;
+    }
+    return resolveAdvisoryRecoveryCycleCap(config);
+  } catch {
+    return DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP;
+  }
+}
+/**
+ * Resolve the configured bounded per-PR-HEAD Copilot stall-recovery cycle cap
+ * (#1572) from a parsed policy object. Kept separate from
+ * {@link resolveAdvisoryWaitPolicy} for the same reason the deadline/reroll-cap
+ * resolvers are separate: it is not part of the five-key active-wait timing
+ * shape, and it defaults to a fixed, conservative cap when absent. Accounted
+ * independently of {@link resolveAdvisoryWaitPolicy}'s `requestCap` and
+ * {@link resolveAdvisorySameHeadRerollCap} -- a distinct counter for a
+ * distinct (terminal-eligibility) budget.
+ */
+export function resolveAdvisoryRecoveryCycleCap(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredPositiveInteger(
+    advisoryWait.recoveryCycleCap,
+    DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP,
+  );
+}
+/**
+ * Read the configured 12h terminal-unavailability window (in minutes) from a
+ * policy file, failing closed to the default window when the file is
+ * missing, unreadable, or schema-invalid.
+ */
+export function readAdvisoryTerminalWindowMinutes(
+  path = '.github/idd/config.json',
+) {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
+      return DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES;
+    }
+    return resolveAdvisoryTerminalWindowMinutes(config);
+  } catch {
+    return DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES;
+  }
+}
+/**
+ * Resolve the configured 12h terminal-unavailability window (in minutes,
+ * #1572) from a parsed policy object. Kept separate from
+ * {@link resolveAdvisoryWaitPolicy} for the same reason the pending/settled
+ * windows are not: this window gates a distinct terminal `COPILOT_UNAVAILABLE`
+ * signal (see advisory-wait-state.mts's `buildCopilotRecoverySummary`), not
+ * the active-wait poll loop.
+ */
+export function resolveAdvisoryTerminalWindowMinutes(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredDurationMinutes(
+    advisoryWait.terminalWindow,
+    DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES,
+  );
+}
+export function normalizeAdvisoryWaitRuntimeOptions(options = {}) {
+  const o = options ?? {};
+  return {
+    requestCap: normalizePositiveInteger(
+      o.requestCap,
+      DEFAULT_ADVISORY_REQUEST_CAP,
+    ),
+    pendingWindowMinutes: normalizePositiveNumber(
+      o.pendingWindowMinutes,
+      DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
+    ),
+    settledWindowMinutes: normalizePositiveNumber(
+      o.settledWindowMinutes,
+      DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+    ),
+    pollIntervalMinutes: normalizePositiveNumber(
+      o.pollIntervalMinutes,
+      DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
+    ),
+    capExhaustedRoute: normalizeCapExhaustedRoute(o.capExhaustedRoute),
+  };
+}
+function normalizePositiveInteger(value, fallback) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+function normalizeConfiguredPositiveInteger(value, fallback) {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+function normalizePositiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+function normalizeConfiguredDurationMinutes(value, fallback) {
+  const milliseconds = parseConfiguredDurationToMs(value);
+  return milliseconds && milliseconds > 0 ? milliseconds / 60000 : fallback;
+}
+function normalizeConfiguredCapExhaustedRoute(value) {
+  return typeof value === 'string' && ADVISORY_CAP_EXHAUSTED_ROUTES.has(value)
+    ? value
+    : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
+}
+function normalizeCapExhaustedRoute(value) {
+  const route = String(value ?? '').trim();
+  return ADVISORY_CAP_EXHAUSTED_ROUTES.has(route)
+    ? route
+    : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
+}
+function parseConfiguredDurationToMs(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?)?$/.exec(value);
+  if (!match) return null;
+  const hasTimeDesignator = value.includes('T');
+  const hasAnyTimeUnit = match[2] !== undefined || match[3] !== undefined;
+  if (hasTimeDesignator && !hasAnyTimeUnit) return null;
+  const days = Number.parseInt(match[1] ?? '0', 10);
+  const hours = Number.parseInt(match[2] ?? '0', 10);
+  const minutes = Number.parseInt(match[3] ?? '0', 10);
+  const totalMilliseconds = ((days * 24 + hours) * 60 + minutes) * 60000;
+  if (totalMilliseconds <= 0 || totalMilliseconds % 60000 !== 0) {
+    return null;
+  }
+  return totalMilliseconds;
+}

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -1,0 +1,568 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/advisory-wait-state.mts
+//
+// The scripts/advisory-wait-state.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import {
+  DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP,
+  DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES,
+  readAdvisoryPrimaryBotLogin,
+  readAdvisoryRecoveryCycleCap,
+  readAdvisorySecondaryBotLogin,
+  readAdvisoryTerminalWindowMinutes,
+  readAdvisoryWaitPolicy,
+} from './advisory-wait-policy.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghText,
+  safeGhText,
+} from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import {
+  buildAdvisoryWaitSummary,
+  compareIsoTimestamps,
+  computeCopilotPendingCoversHead,
+  isValidIsoTimestamp,
+  normalizeTrustedMarkerLogins,
+  parseAdvisoryRecoveryComment,
+  parsePaginatedGhNdjson,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mjs';
+
+const COPILOT_RECOVERY_REASONS = {
+  activeClaimNotProvided: 'active-claim-not-provided',
+  noTrustedRecoveryMarkers: 'no-trusted-recovery-markers',
+  capNotExhausted: 'recovery-cap-not-exhausted',
+  windowNotElapsed: 'terminal-window-not-elapsed',
+  currentHeadReviewExists: 'current-head-review-exists',
+  copilotUnavailable:
+    'recovery-cap-exhausted-and-terminal-window-elapsed-and-no-current-head-review',
+};
+function minutesBetweenIso(start, end) {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return 0;
+  }
+  return Math.floor((endMs - startMs) / 60000);
+}
+/**
+ * Compute the `#1572` terminal Copilot stall-recovery state from
+ * already-fetched PR comments plus the already-computed
+ * `buildAdvisoryWaitSummary` evidence (`prHeadSha`, `lastCopilotCommit`).
+ * Pure and network-free -- issues no `gh` calls of its own, so calling it
+ * twice with the same input is trivially idempotent, and its output is a
+ * deterministic function of the observed marker *set* (order-independent),
+ * matching `findActivationNonceWinner`'s and `summarizeAdvisoryWaitMarkers`'s
+ * shared "re-read must reconverge" design.
+ *
+ * A candidate `advisory-wait-recovery:` comment counts as one completed
+ * recovery cycle only when ALL of the following hold -- any single failure
+ * excludes it from both `completedCycleCount` and `clockAnchor` (fail
+ * closed; never a whole-computation abort):
+ *  - the comment author is a trusted marker actor (else: untrusted);
+ *  - the body parses as the BOUND form via `parseAdvisoryRecoveryComment`
+ *    (a malformed body, or the legacy unbound 3-field form, both parse to
+ *    `null`: malformed / unbound);
+ *  - the marker's `agentId` equals the supplied `agentId` (else:
+ *    foreign-agent);
+ *  - the marker's `claimId` equals the supplied `claimId` (else:
+ *    mismatched-claim);
+ *  - the marker's `headSha` equals `prHeadSha` (else: mismatched-HEAD,
+ *    including both an earlier and a later HEAD than the current one);
+ *  - the comment's GitHub `created_at` validates as an ISO 8601 UTC
+ *    timestamp (else: ambiguous-created-at -- excluded from BOTH counting
+ *    and anchoring, never counted with a missing anchor contribution).
+ */
+export function buildCopilotRecoverySummary(
+  { comments = [], prHeadSha, lastCopilotCommit },
+  options,
+) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  // Validate the raw string WITHOUT lowercasing first, matching
+  // buildAdvisoryWaitSummary's convention (protocol-helpers.mts): callers
+  // are expected to already supply a canonical lowercase SHA (e.g. from
+  // buildAdvisoryWaitSummary's own output), and an uppercase SHA is
+  // rejected rather than silently normalized -- lowercasing before
+  // validation would accept input the error message claims is rejected.
+  const normalizedPrHeadSha = String(prHeadSha ?? '');
+  if (!/^[0-9a-f]{40}$/.test(normalizedPrHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+  }
+  const cap = normalizePositiveIntegerOption(
+    options.recoveryCycleCap,
+    DEFAULT_ADVISORY_RECOVERY_CYCLE_CAP,
+  );
+  const terminalWindowMinutes = normalizePositiveNumberOption(
+    options.terminalWindowMinutes,
+    DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES,
+  );
+  const trustedLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const claimId = String(options.claimId ?? '').trim();
+  const agentId = String(options.agentId ?? '').trim();
+  const activeClaimProvided = claimId !== '' && agentId !== '';
+  let completedCycleCount = 0;
+  let clockAnchor = '';
+  if (activeClaimProvided) {
+    for (const comment of comments) {
+      const login = String(comment?.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (!trustedLogins.has(login)) {
+        continue; // untrusted
+      }
+      const marker = parseAdvisoryRecoveryComment(
+        String(comment?.body ?? ''),
+        String(comment?.createdAt ?? ''),
+      );
+      if (!marker) {
+        continue; // malformed or the legacy unbound form
+      }
+      if (marker.agentId !== agentId) {
+        continue; // foreign-agent
+      }
+      if (marker.claimId !== claimId) {
+        continue; // mismatched-claim
+      }
+      if (marker.headSha !== normalizedPrHeadSha) {
+        continue; // mismatched-HEAD (earlier or later)
+      }
+      if (!isValidIsoTimestamp(marker.createdAt)) {
+        // Ambiguous server createdAt (parse helpers set this to 'none' when
+        // the caller-supplied timestamp did not validate): exclude from
+        // BOTH cycle counting and clock anchoring, not anchoring alone.
+        // Otherwise an evidence gap could still consume recovery-cycle
+        // budget without ever contributing a trustworthy clock anchor,
+        // contradicting the "both counting and anchoring must be derived
+        // from trusted server-created_at evidence" fail-closed contract.
+        continue;
+      }
+      completedCycleCount += 1;
+      if (
+        !clockAnchor ||
+        compareIsoTimestamps(marker.createdAt, clockAnchor) < 0
+      ) {
+        clockAnchor = marker.createdAt;
+      }
+    }
+  }
+  const remainingBudget = Math.max(cap - completedCycleCount, 0);
+  const capExhausted = completedCycleCount >= cap;
+  const elapsedMinutes = clockAnchor ? minutesBetweenIso(clockAnchor, now) : 0;
+  const windowElapsed =
+    clockAnchor !== '' && elapsedMinutes >= terminalWindowMinutes;
+  const currentHeadReviewExists =
+    String(lastCopilotCommit ?? '').toLowerCase() === normalizedPrHeadSha;
+  let state = 'NOT_TERMINAL';
+  let reason;
+  if (!activeClaimProvided) {
+    reason = COPILOT_RECOVERY_REASONS.activeClaimNotProvided;
+  } else if (clockAnchor === '') {
+    reason = COPILOT_RECOVERY_REASONS.noTrustedRecoveryMarkers;
+  } else if (!capExhausted) {
+    reason = COPILOT_RECOVERY_REASONS.capNotExhausted;
+  } else if (!windowElapsed) {
+    reason = COPILOT_RECOVERY_REASONS.windowNotElapsed;
+  } else if (currentHeadReviewExists) {
+    reason = COPILOT_RECOVERY_REASONS.currentHeadReviewExists;
+  } else {
+    state = 'COPILOT_UNAVAILABLE';
+    reason = COPILOT_RECOVERY_REASONS.copilotUnavailable;
+  }
+  return {
+    cap,
+    completedCycleCount,
+    remainingBudget,
+    capExhausted,
+    terminalWindowMinutes,
+    clockAnchor,
+    elapsedMinutes,
+    windowElapsed,
+    activeClaimProvided,
+    state,
+    reason,
+  };
+}
+const STALE_REQUEST_RECOVERY_REASONS = {
+  activeClaimNotProvided: 'active-claim-not-provided',
+  notPending: 'not-pending',
+  sameHeadMarkerPresent: 'same-head-marker-present',
+  provenCoversHead: 'proven-covers-head',
+  capExhausted: 'recovery-cap-exhausted',
+  attemptEligible: 'recovery-attempt-eligible',
+};
+export function evaluateStaleRequestRecoveryAction(input) {
+  if (!input.activeClaimProvided) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.activeClaimNotProvided,
+    };
+  }
+  if (!input.copilotPending) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.notPending,
+    };
+  }
+  // A same-head marker (ordinary `advisory-wait:` OR a prior recovery cycle's
+  // `advisory-wait-recovery:`) already anchors this HEAD's clock -- mirrors
+  // evaluateAdvisoryWaitOutcome's own `!sameHeadMarkerPresent` gate for both
+  // its RECOVERY_NEEDED and REQUEST_NEEDED/CAP_EXHAUSTED branches, so this
+  // classifier never contradicts the shared outcome machine's routing.
+  if (input.sameHeadMarkerPresent) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.sameHeadMarkerPresent,
+    };
+  }
+  if (input.copilotPendingCoversHead) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.provenCoversHead,
+    };
+  }
+  if (input.remainingBudget <= 0) {
+    return {
+      action: 'cap-exhausted',
+      reason: STALE_REQUEST_RECOVERY_REASONS.capExhausted,
+    };
+  }
+  return {
+    action: 'attempt',
+    reason: STALE_REQUEST_RECOVERY_REASONS.attemptEligible,
+  };
+}
+/**
+ * `#1571` head-race guard: a pure, string-normalized comparison an E14/F2
+ * caller must re-run immediately before every mutating step of the bounded
+ * recovery cycle (removal, re-request, association verification, marker
+ * post) -- see `idd-advisory-wait.instructions.md`'s `AW3-S`. A `true` result
+ * means either the branch moved between the last-known HEAD and this check,
+ * or a comparison side is missing or not a full 40-hex commit SHA (fails
+ * closed on ambiguous evidence the same way an equal-but-abbreviated or
+ * equal-but-empty pair would otherwise misread as "unchanged"): the caller
+ * must abort the current attempt without mutating or counting a cycle, and
+ * restart evaluation fresh (return to E1) against the new HEAD.
+ */
+export function detectRecoveryHeadRace(expectedHeadSha, currentHeadSha) {
+  const expected = String(expectedHeadSha ?? '')
+    .trim()
+    .toLowerCase();
+  const current = String(currentHeadSha ?? '')
+    .trim()
+    .toLowerCase();
+  // Fail closed on missing OR ambiguous evidence: a comparison side that is
+  // empty, or that is not a full 40-hex commit SHA (e.g. an abbreviated
+  // SHA), is not proof HEAD is stable -- even when both sides are identical
+  // non-full-SHA strings, so a naive equality would misread it as
+  // "unchanged". Treating either case as "no race" would let a recovery
+  // mutation proceed on an unresolved or ambiguous HEAD value
+  // (kurone-kito/idd-skill#1645 review).
+  const fullShaPattern = /^[0-9a-f]{40}$/;
+  if (!fullShaPattern.test(expected) || !fullShaPattern.test(current)) {
+    return true;
+  }
+  return expected !== current;
+}
+/**
+ * `#1571` post-mutation association proof: after a recovery cycle's
+ * remove-then-re-request completes, re-fetch the PR timeline for the current
+ * HEAD and call this to verify the fresh request is provably associated with
+ * it (a `review_requested` event for the configured primary bot strictly
+ * after the current HEAD's `committed` event) before posting the bound
+ * `advisory-recovery` marker. Delegates to the same proof
+ * {@link evaluateStaleRequestRecoveryAction}'s caller uses to detect
+ * staleness in the first place (`computeCopilotPendingCoversHead`) -- reusing
+ * one proof for both directions keeps them from silently diverging. Returns
+ * `false` (fails closed, do not post the marker or count a cycle) on missing
+ * or ambiguous timeline evidence, exactly like the staleness check.
+ */
+export function verifyRecoveryRequestCoversHead(
+  timelineEvents,
+  prHeadSha,
+  primaryBotLogin,
+) {
+  return computeCopilotPendingCoversHead(
+    timelineEvents,
+    prHeadSha,
+    primaryBotLogin,
+  );
+}
+function normalizePositiveIntegerOption(value, fallback) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+function normalizePositiveNumberOption(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls main() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see ci-wait-policy.mts's identical note).
+const ADVISORY_WAIT_STATE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  // #1572: OPTIONAL. When both --claim-id and --agent-id are supplied, the
+  // `copilotRecovery` section binds to the active claim; when either is
+  // absent, `copilotRecovery` fails closed to NOT_TERMINAL with
+  // reason: active-claim-not-provided, and every other field this CLI
+  // already prints is unaffected.
+  '--claim-id': { type: 'string', default: '' },
+  '--agent-id': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  main();
+}
+// The CLI body. Guarded behind `import.meta.main` so importing this
+// module (for unit tests) does not parse process.argv, fail, or make a
+// `gh` call.
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: loadIddConfig(),
+    });
+  const prHeadSha = ghText([
+    'pr',
+    'view',
+    String(args.prNumber),
+    '-R',
+    repoRef,
+    '--json',
+    'headRefOid',
+    '--jq',
+    '.headRefOid',
+  ]);
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  );
+  const requestedReviewers = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
+    false,
+  );
+  const timelineEvents = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
+    true,
+    ['-H', 'Accept: application/vnd.github+json'],
+  );
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  );
+  const collaboratorTrustEnabled = isTruthy(
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
+      : []),
+  ]);
+  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha,
+      reviews,
+      requestedReviewers: requestedReviewers.users ?? [],
+      timelineEvents,
+      comments: comments.map(normalizeComment),
+    },
+    {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      requestCap: advisoryWaitPolicy.requestCap,
+      pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+      primaryBotLogin,
+      secondaryBotLogin,
+      viewerLogin,
+      configuredTrustedActors,
+      collaboratorTrustEnabled,
+      trustedMarkerLogins,
+    },
+  );
+  // Reuse summary.now (not a fresh new Date() call) so both computations
+  // agree on the exact same instant.
+  const copilotRecovery = buildCopilotRecoverySummary(
+    {
+      comments: comments.map(normalizeComment),
+      prHeadSha,
+      lastCopilotCommit: summary.lastCopilotCommit,
+    },
+    {
+      now: summary.now,
+      trustedMarkerLogins,
+      claimId: args.claimId,
+      agentId: args.agentId,
+      recoveryCycleCap: readAdvisoryRecoveryCycleCap(),
+      terminalWindowMinutes: readAdvisoryTerminalWindowMinutes(),
+    },
+  );
+  // #1571: bounded stale-request recovery eligibility, derived from the
+  // already-computed AW1-AW3 evidence (summary) plus the #1572 recovery-cycle
+  // budget (copilotRecovery). See evaluateStaleRequestRecoveryAction's own
+  // doc comment for why this is independent of RECOVERY_NEEDED/AW3-R.
+  const staleRequestRecovery = evaluateStaleRequestRecoveryAction({
+    copilotPending: summary.copilotPending,
+    copilotPendingCoversHead: summary.copilotPendingCoversHead,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
+  });
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ...summary,
+        trustedMarkerActors: configuredTrustedActors,
+        trustedMarkerActorsSource,
+        copilotRecovery,
+        staleRequestRecovery,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+/**
+ * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
+ * `Number.parseInt` accepts trailing-garbage ("42abc" -> 42) and
+ * leading-zero ("007" -> 7) tokens the same way the original hand-rolled
+ * `Number.parseInt(value ?? '', 10)` always did, then the original's own
+ * `!Number.isInteger(...) || (... ?? 0) < 1` post-check collapses an
+ * invalid or absent value to `null`. `cli-args.mts`'s
+ * `parseCanonicalIntegerOrNull` is a poor substitute: its canonical-pattern
+ * regex rejects those same permissive tokens outright, which is a real
+ * contract change a CodeRabbit review on PR #1466 caught -- #1450's
+ * acceptance criteria protect the post-parse integer contract as-is, only
+ * flag *syntax* (missing/flag-shaped values, unknown flags) is meant to
+ * tighten.
+ */
+function parseLenientPositiveIntegerOrNull(token) {
+  const value = Number.parseInt(token ?? '', 10);
+  return Number.isInteger(value) && value >= 1 ? value : null;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, ADVISORY_WAIT_STATE_FLAG_SPEC);
+  return {
+    prNumber: parseLenientPositiveIntegerOrNull(values.pr),
+    owner: values.owner,
+    repo: values.repo,
+    trustedMarkerLogins: values['trusted-marker-logins'],
+    claimId: values['claim-id'],
+    agentId: values['agent-id'],
+    now: values.now,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/advisory-wait-state.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--claim-id <id> --agent-id <id>] [--now <ISO8601>]
+
+--claim-id / --agent-id are OPTIONAL (#1572): when both are supplied, the
+copilotRecovery section in the output binds recovery-cycle accounting and the
+terminal clock to that active claim. When either is absent, copilotRecovery
+fails closed to NOT_TERMINAL with reason: active-claim-not-provided.
+`);
+}
+function normalizeComment(comment) {
+  return {
+    author: { login: comment.user?.login ?? '' },
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+  };
+}
+function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
+  const advisoryAuthors = [
+    ...new Set(
+      comments
+        .filter((comment) => advisoryMarkerComment(comment.body ?? ''))
+        .map((comment) => comment.user?.login ?? '')
+        .filter(Boolean),
+    ),
+  ];
+  return advisoryAuthors.filter((login) => {
+    const permission = safeGhText([
+      'api',
+      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+      '--jq',
+      '.permission',
+    ]).toLowerCase();
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+}
+export function advisoryMarkerComment(body) {
+  const normalized = String(body ?? '');
+  return (
+    normalized.startsWith('advisory-wait:') ||
+    normalized.startsWith('advisory-wait-recovery:') ||
+    normalized.startsWith('advisory-reroll:') ||
+    normalized.startsWith('<!-- advisory-wait:')
+  );
+}
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
+}
+function ghApiJson(path, paginate = false, extraArgs = []) {
+  const args = ['api', path, ...extraArgs];
+  if (paginate) {
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    args.splice(1, 0, '--paginate', '--jq', '.[]');
+    return parsePaginatedGhNdjson(
+      ghText(args, { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }),
+    );
+  }
+  return JSON.parse(ghText(args));
+}

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -1,0 +1,1271 @@
+// idd-generated-from: src/scripts/audit-authored-issue.mts
+//
+// The scripts/audit-authored-issue.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Mechanically audits a drafted GitHub issue body against the
+// issue-authoring contract's structural expectations
+// (skills/issue-authoring/references/contract.md): the autopilot-suitability
+// marker's exactly-one/coherent-value rule, its cross-field agreement with
+// the configured blocked-by-human label, markerPrefix consistency across
+// every authoring marker, the declared shape's required section headings,
+// the roadmap-id/blocked-by dependency-marker rules, visible/hidden line
+// agreement for the suitability and effort footers, and an advisory
+// warning-severity check that flags an issue/PR reference used near
+// coordination language (e.g. "before", "once", "requires") with no
+// corresponding Blocked-by/Depends-on/task-list dependency encoding. The
+// advisory check never fails the report or changes the exit code — see
+// checkProseOnlyDependency.
+//
+// All marker value parsing is delegated to the existing
+// autopilot-suitability.mts / effort.mts / marker-regex.mts /
+// policy-helpers.mts helpers; this module only layers shape-aware
+// structural checks on top of them. Pure and network-free — the CLI reads
+// the drafted body from a file or stdin rather than fetching a live issue.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseAutopilotSuitabilityMarker } from './autopilot-suitability.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  extractBlockedByIssueNumbers,
+  extractBlockedByRoadmapMarkers,
+  extractDependencyIssueNumbers,
+} from './discover-readiness-check.mjs';
+import { extractRoadmapMarkerId } from './discover-roadmap-graph.mjs';
+import { parseEffortMarker } from './effort.mjs';
+import { loadIddConfig, loadPolicyConfig } from './idd-config.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// The four authoring-marker suffixes defined in the contract. Operational
+// markers (claimed-by, review-watermark, ...) never take this
+// `{prefix}-{suffix}` shape, so they cannot collide with this scan.
+const AUTHORING_MARKER_SUFFIXES = [
+  'roadmap-id',
+  'blocked-by',
+  'autopilot-suitability',
+  'effort',
+];
+const SHAPE_HEADING_REQUIREMENTS = {
+  orphan: [
+    { anyOf: ['Background', 'Goal'] },
+    { anyOf: ['Proposed change'] },
+    { anyOf: ['Acceptance criteria'] },
+  ],
+  roadmap: [
+    { anyOf: ['Goal'] },
+    { anyOf: ['Background', 'Why this matters'] },
+    { anyOf: ['Tracks'] },
+    { anyOf: ['Success criteria'] },
+  ],
+  child: [
+    { anyOf: ['Background'] },
+    { anyOf: ['Proposed change'] },
+    { anyOf: ['Acceptance criteria'] },
+  ],
+};
+// Coordination-language keywords that, alongside an unencoded issue/PR
+// reference in the same sentence, suggest the reference is being used as a
+// prose-only start-blocking dependency instead of the required `Blocked by`
+// / `Depends on` / task-list encoding. Deliberately broad (an advisory
+// check can tolerate false positives; the author "consciously confirms" per
+// the contract) rather than an exhaustive parse of every possible phrasing.
+const PROSE_DEPENDENCY_KEYWORDS = [
+  'before',
+  'after',
+  'once',
+  'until',
+  'predates',
+  'gate',
+  'gated',
+  'requires',
+  'lands first',
+];
+// Matches a Markdown link whose target is a full GitHub issue/PR URL (e.g.
+// `[PR #1391](https://github.com/owner/repo/pull/1391)`), a bare `#123`
+// issue/PR reference, a bare full GitHub issue/PR URL, or a local
+// `owner/repo#123` shorthand — in that order, capturing each URL/shorthand
+// alternative's owner and repo so callers can tell a local reference from
+// a cross-repo one (see `currentRepo` handling in checkProseOnlyDependency
+// below). The Markdown-link alternative is tried (and, being anchored at
+// the label's own `[`, wins) first specifically so that a cross-repo
+// link's *label* text — which often repeats the same `#N` the URL already
+// names, e.g. the `#1391` above — is consumed as part of that one link
+// match rather than separately re-matched by the bare-`#` alternative and
+// misread as a local reference once the link's URL itself is correctly
+// filtered out as cross-repo. Between the issue/PR number and the link's
+// closing `)`, the Markdown-link alternative also tolerates an optional
+// trailing `/`, an optional URL fragment (`#issuecomment-123`), and an
+// optional quoted title (`"..."` or `'...'`) — each bounded tightly enough
+// (a matching quote character, or a fragment charset that excludes `)`,
+// quotes, and whitespace) that none of them can consume past the link's
+// real closing paren the way a naive `.*\)` would. Without this, any of
+// those three trailing forms would break the Markdown-link match and let
+// the label's own bare `#N` leak through to the bare-`#` alternative
+// below, reintroducing the label-leak false positive the Markdown-link
+// alternative exists to prevent. `#` alone (as in an ATX heading) never
+// matches without trailing digits. The bare-`#` alternative excludes a `#`
+// immediately preceded by a word character or `/` (a negative lookbehind),
+// so cross-repo shorthand like `other/repo#123` does not match on its
+// trailing `#123` — a cross-repo reference cannot be encoded with this
+// repository's local `Blocked by` / `Depends on` markers, so flagging it
+// here would be misleading rather than actionable. The final `owner/repo#N`
+// shorthand alternative recognizes that same shape as a *distinct*,
+// dedicated match (rather than leaving it permanently unmatched) so
+// checkProseOnlyDependency can apply the currentRepo comparison to it —
+// flagging it only when the shorthand names the current repository (see
+// the `currentRepo` JSDoc on `AuditOptions` for the reversed-default-
+// polarity rationale). It reuses the bare-`#` alternative's own
+// `(?<![\w/])` lookbehind so it, too, only starts matching at a natural
+// token boundary rather than mid-path (e.g. inside a 3-segment
+// slash-separated path that happens to end in `#123`).
+//
+// The quoted-title sub-pattern tolerates a backslash-escaped quote
+// matching the title's own delimiter (`\"` inside a `"..."` title, or
+// `\'` inside a `'...'` title) as content instead of letting it close the
+// title early: `(?:\\.|[^"\\\n])*` (and the single-quote equivalent)
+// tries consuming a backslash plus the character right after it as one
+// unit before falling back to "any character that is not the quote, a
+// backslash, or a newline", so an escaped quote is never mistaken for the
+// real closing delimiter. Without this, a title like `"reviewed
+// \"API\""` would close at the first escaped quote, leave the rest of
+// the title as unconsumed content before the link's real closing paren,
+// fail the whole Markdown-link alternative, and re-leak the label's own
+// bare `#N` to the bare-`#` alternative — the same failure mode the
+// trailing-content tolerances above already guard against, just
+// triggered by escaping instead of an unhandled trailing shape.
+//
+// The character class excludes a literal backslash (not just the quote
+// and newline) so the two alternatives never overlap on the same input
+// character: `\\.` is the only alternative that can ever consume a `\`,
+// and the class-based alternative is the only one that can consume
+// anything else. A version that let the class also match a bare `\`
+// (`[^"\n]` alone) would let the engine choose, for every backslash in a
+// run of them, between pairing it with the next character via `\\.` or
+// consuming it alone via the class — an ambiguity that multiplies
+// combinatorially (Fibonacci-many partitions of an N-backslash run) and
+// causes catastrophic backtracking once the overall match fails, i.e.
+// exponential-time behavior on a long run of backslashes with no closing
+// quote (confirmed empirically: a ~30-character adversarial input took
+// several seconds under the ambiguous form; a ~10,000-character one
+// resolves in under a millisecond after excluding the backslash from the
+// class). This is the standard non-overlapping idiom for a
+// backslash-escaped quoted string and applies to both quote styles.
+const ISSUE_OR_PR_REFERENCE_PATTERN =
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+// Matches a Markdown list item marker at the start of a line (unordered
+// `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
+// followed by a task-list checkbox. Captures the leading indentation
+// (group 1) so splitIntoListItemBlocks can tell a deeper-indented
+// nested/child marker from a new marker at the same or shallower
+// indentation as the currently open node at that depth in its
+// indentation-ancestry stack — see that function for how the two are
+// told apart. Declared here (before the CLI entry
+// block below), not next to splitIntoSentences/splitIntoListItemBlocks
+// that use it, because those are hoisted function declarations but this
+// is a module-level `const` — declaring it after the entry block would be
+// a TDZ risk under the CLI path, which calls main() synchronously at this
+// point in module evaluation (see tests/cli-entry-smoke.test.mts).
+const LIST_ITEM_MARKER_PATTERN = /^(\s*)(?:[-*+]|\d+[.)])\s+/;
+// A continuation line (no list-item marker of its own) has no
+// LIST_ITEM_MARKER_PATTERN capture group to read an indentation from,
+// unlike a marker line — its own leading whitespace has to be measured
+// directly (see `lineIndentColumn`, used by splitIntoListItemBlocks's
+// continuation-line branch, #1476). Declared here for the same
+// TDZ reason as LIST_ITEM_MARKER_PATTERN immediately above: this is a
+// module-level `const` reached by the same synchronous CLI call path,
+// not a hoisted function declaration.
+const LEADING_WHITESPACE_PATTERN = /^\s*/;
+// Matches a Markdown reference-style link *usage*: `[text][ref]`, where a
+// separate `[ref]: <target>` definition (matched by
+// LINK_REFERENCE_DEFINITION_PATTERN below) supplies the actual target
+// elsewhere in the document — commonly far from the usage, so this is
+// resolved as a whole-document pre-processing step (see
+// resolveReferenceStyleLinks) rather than as a fifth alternative inside
+// ISSUE_OR_PR_REFERENCE_PATTERN, which cannot look outside its own match
+// to find the target. The ref label must be non-empty — this
+// deliberately excludes the shortcut forms `[text][]` and bare `[text]`
+// (which would resolve the ref from the label text itself); only the
+// explicit-ref shape named in issue #1472 is in scope here. Same
+// TDZ-avoidance placement rationale as LIST_ITEM_MARKER_PATTERN above.
+const REFERENCE_STYLE_LINK_USAGE_PATTERN = /\[([^\]\n]*)\]\[([^\]\n]+)\]/g;
+// Matches a Markdown link reference definition line: optionally indented
+// (up to 3 spaces, per CommonMark), `[label]: target`, with the target
+// read up to the first whitespace. An optional title on the same
+// definition line (e.g. `[ref]: <url> "title"`) is intentionally not
+// captured — only the destination matters for resolving a reference-style
+// link to a GitHub issue/PR URL.
+const LINK_REFERENCE_DEFINITION_PATTERN = /^ {0,3}\[([^\]\n]+)\]:\s*(\S+)/gm;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `shape:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --shape spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls main() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
+  '--help': { type: 'boolean', short: 'h', default: false },
+  '--shape': { type: 'string' },
+  '--body-file': { type: 'string' },
+  '--stdin': { type: 'boolean', default: false },
+  '--marker-prefix': { type: 'string' },
+  '--config': { type: 'string' },
+  '--current-repo': { type: 'string' },
+  '--label': { type: 'string', multiple: true },
+  '--format': { type: 'string', default: 'json' },
+};
+if (import.meta.main) {
+  main();
+}
+/**
+ * Audit a drafted issue body against the issue-authoring contract's
+ * structural expectations for the declared shape. Every check runs
+ * independently (no short-circuit), so one report surfaces every problem
+ * at once instead of stopping at the first failure. One check
+ * (`prose-dependency`) is advisory-only: it always reports `result:
+ * 'pass'` and only ever adds a `severity: 'warning'` marker plus detail,
+ * so it never affects `passed` or the caller's exit code.
+ */
+export function auditAuthoredIssue(body, options) {
+  const rawText = typeof body === 'string' ? body : String(body ?? '');
+  // Strip Markdown code regions (fenced blocks and inline spans) once, up
+  // front, and run every check (marker counting, heading detection,
+  // visible-line scoping) against the result. A pasted template/example
+  // snippet — quoting a marker or heading for illustration — must never
+  // count as the real thing. Reuses the same stripMarkdownCodeRegions
+  // primitive extractRoadmapMarkerId already relies on, rather than a
+  // second, independently-maintained fence tracker.
+  const text = stripMarkdownCodeRegions(rawText);
+  const shape = options.shape;
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const blockedByHumanLabelName =
+    typeof options.blockedByHumanLabelName === 'string' &&
+    options.blockedByHumanLabelName.length > 0
+      ? options.blockedByHumanLabelName
+      : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+  const labels = (options.labels ?? []).map((label) =>
+    String(label).trim().toLowerCase(),
+  );
+  const suitability = parseAutopilotSuitabilityMarker(text, markerPrefix);
+  const suitabilityCount = countMarkerOccurrences(
+    text,
+    markerPrefix,
+    'autopilot-suitability',
+  );
+  const findings = [
+    checkSuitabilityMarker(suitabilityCount, suitability),
+    checkSuitabilityBlockedByHuman(
+      suitability,
+      labels,
+      blockedByHumanLabelName,
+    ),
+    checkMarkerPrefixConsistency(text, markerPrefix),
+    checkRequiredHeadings(text, shape),
+    checkDependencyMarkerRule(text, markerPrefix, shape),
+    checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
+    checkEffortVisibleLineAgreement(text, markerPrefix),
+    checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
+  ];
+  return {
+    shape,
+    markerPrefix,
+    passed: findings.every((finding) => finding.result === 'pass'),
+    findings,
+  };
+}
+function checkSuitabilityMarker(count, suitability) {
+  const id = 'suitability-marker';
+  const name = 'Exactly one coherent autopilot-suitability marker (1-5)';
+  if (count === 0) {
+    return fail(id, name, 'missing autopilot-suitability marker');
+  }
+  if (count > 1) {
+    return fail(
+      id,
+      name,
+      `expected exactly one autopilot-suitability marker, found ${count}`,
+    );
+  }
+  if (suitability.malformed || suitability.value === null) {
+    return fail(
+      id,
+      name,
+      'autopilot-suitability marker value is not a coherent integer 1-5',
+    );
+  }
+  return pass(id, name, `suitability score is ${suitability.value}`);
+}
+function checkSuitabilityBlockedByHuman(
+  suitability,
+  labels,
+  blockedByHumanLabelName,
+) {
+  const id = 'suitability-blocked-by-human';
+  const name = `Suitability score of 1 carries the ${blockedByHumanLabelName} label`;
+  if (suitability.value !== 1) {
+    return pass(id, name, 'not applicable: suitability score is not 1');
+  }
+  const target = blockedByHumanLabelName.trim().toLowerCase();
+  if (labels.includes(target)) {
+    return pass(id, name, `${blockedByHumanLabelName} label is present`);
+  }
+  return fail(
+    id,
+    name,
+    `suitability score is 1 but the ${blockedByHumanLabelName} label was not provided`,
+  );
+}
+function checkMarkerPrefixConsistency(text, markerPrefix) {
+  const id = 'marker-prefix-consistency';
+  const name = 'Every authoring marker uses the resolved target markerPrefix';
+  // The captured prefix is compared by string equality below (never
+  // re-embedded into a regex), so it only needs to exclude the characters
+  // that end a marker prefix syntactically (whitespace, `:`, `>`) — not be
+  // restricted to `[a-z0-9-]`. A namespaced adopter prefix may legitimately
+  // contain other characters (see marker-regex.mts's escapeRegex docstring:
+  // `.`, `+`, `(`, ...); a narrower class here would silently fail to match
+  // any marker (right or wrong prefix) and always report a false pass.
+  // The value after the suffix is optional (`\b[\s\S]*?-->`, mirroring
+  // createMarkerRegex's own shape) rather than requiring a `:` — a
+  // malformed, valueless, wrong-prefix marker (e.g. `<!-- other-roadmap-id
+  // -->`) is still evidence of a prefix leak and must not evade this scan
+  // just because it is also missing its value.
+  const pattern = new RegExp(
+    `<!--\\s*([^\\s>:]+)-(${AUTHORING_MARKER_SUFFIXES.join('|')})\\b[\\s\\S]*?-->`,
+    'gi',
+  );
+  const mismatches = [];
+  for (const match of text.matchAll(pattern)) {
+    const foundPrefix = match[1];
+    if (foundPrefix.toLowerCase() !== markerPrefix.toLowerCase()) {
+      mismatches.push(`${foundPrefix}-${match[2]}`);
+    }
+  }
+  if (mismatches.length > 0) {
+    return fail(
+      id,
+      name,
+      `marker prefix mismatch (expected "${markerPrefix}"): ${mismatches.join(', ')}`,
+    );
+  }
+  return pass(id, name, 'all authoring markers use the resolved markerPrefix');
+}
+function checkRequiredHeadings(text, shape) {
+  const id = 'required-headings';
+  const name = `Required section headings present for the ${shape} shape`;
+  const headings = extractHeadings(text);
+  const missing = SHAPE_HEADING_REQUIREMENTS[shape].filter(
+    (requirement) =>
+      !requirement.anyOf.some((heading) => headings.has(heading)),
+  );
+  if (missing.length > 0) {
+    return fail(
+      id,
+      name,
+      `missing required heading(s): ${missing
+        .map((requirement) => requirement.anyOf.join(' or '))
+        .join('; ')}`,
+    );
+  }
+  return pass(id, name, 'all required headings are present');
+}
+function checkDependencyMarkerRule(text, markerPrefix, shape) {
+  const id = 'dependency-marker-rule';
+  const name = 'roadmap-id / blocked-by marker rule for the declared shape';
+  const roadmapIdCount = countMarkerOccurrences(
+    text,
+    markerPrefix,
+    'roadmap-id',
+  );
+  const blockedByCount = countMarkerOccurrences(
+    text,
+    markerPrefix,
+    'blocked-by',
+  );
+  // A blocked-by marker missing its `: <roadmap-id>` value is invisible to
+  // Discover's own extractBlockedByRoadmapMarkers, so a marker that "looks
+  // present" to the author but resolves to no value would silently defeat
+  // the intended dependency. Reuse that same extractor (rather than a
+  // second hand-rolled value-requiring regex) to require at least one
+  // well-formed value whenever a blocked-by marker is present at all,
+  // wherever the shape permits the marker (roadmap, child).
+  const wellFormedBlockedByCount = extractBlockedByRoadmapMarkers(
+    text,
+    markerPrefix,
+  ).length;
+  if (shape === 'roadmap') {
+    if (roadmapIdCount !== 1) {
+      return fail(
+        id,
+        name,
+        `roadmap issues must carry exactly one roadmap-id marker, found ${roadmapIdCount}`,
+      );
+    }
+    // A single marker occurrence can still be malformed (missing its
+    // `: <roadmap-id>` value) and the loose shape-only count above would
+    // not catch it. extractRoadmapMarkerId requires the value, matching
+    // the same strict form Discover relies on to resolve the marker.
+    if (!extractRoadmapMarkerId(text, markerPrefix)) {
+      return fail(
+        id,
+        name,
+        'the roadmap-id marker is present but malformed (missing its `: <roadmap-id>` value)',
+      );
+    }
+    if (blockedByCount > 0 && wellFormedBlockedByCount === 0) {
+      return fail(
+        id,
+        name,
+        'a blocked-by marker is present but malformed (missing its `: <roadmap-id>` value)',
+      );
+    }
+    return pass(
+      id,
+      name,
+      'exactly one well-formed roadmap-id marker is present',
+    );
+  }
+  if (roadmapIdCount > 0) {
+    return fail(
+      id,
+      name,
+      `${shape} issues must not carry a roadmap-id marker, found ${roadmapIdCount}`,
+    );
+  }
+  if (shape === 'orphan' && blockedByCount > 0) {
+    return fail(
+      id,
+      name,
+      `orphan issues must not carry a blocked-by marker, found ${blockedByCount}`,
+    );
+  }
+  if (
+    shape === 'child' &&
+    blockedByCount > 0 &&
+    wellFormedBlockedByCount === 0
+  ) {
+    return fail(
+      id,
+      name,
+      'a blocked-by marker is present but malformed (missing its `: <roadmap-id>` value)',
+    );
+  }
+  return pass(id, name, `no roadmap-id marker on this ${shape} issue`);
+}
+function checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability) {
+  const id = 'suitability-visible-line-agreement';
+  const name =
+    'Visible autopilot-suitability line agrees with the hidden marker';
+  if (suitability.value === null) {
+    return pass(
+      id,
+      name,
+      'not applicable: no coherent suitability marker value',
+    );
+  }
+  const scope = lastParagraphBeforeMarker(
+    text,
+    markerPrefix,
+    'autopilot-suitability',
+  );
+  const match = /_Autopilot suitability:\s*([0-9]+)\s*\/\s*5/.exec(scope);
+  if (!match) {
+    return fail(
+      id,
+      name,
+      `missing or unparsable visible autopilot-suitability line immediately preceding the marker (value ${suitability.value})`,
+    );
+  }
+  const visibleValue = Number.parseInt(match[1], 10);
+  if (visibleValue !== suitability.value) {
+    return fail(
+      id,
+      name,
+      `visible line says ${visibleValue} but the marker says ${suitability.value}`,
+    );
+  }
+  return pass(
+    id,
+    name,
+    `visible line agrees with marker value ${suitability.value}`,
+  );
+}
+function checkEffortVisibleLineAgreement(text, markerPrefix) {
+  const id = 'effort-visible-line-agreement';
+  const name = 'Visible effort line agrees with the hidden marker';
+  // parseEffortMarker requires a value token ([^\s>]+ after the colon), so
+  // a value-less marker like `<!-- {prefix}-effort: -->` reads as
+  // `present: false` — indistinguishable, by that field alone, from no
+  // marker at all. Since effort is optional, treating that as "not
+  // applicable" would let a clearly malformed footer silently pass. Use
+  // the loose shape-only count to tell "genuinely absent" (0) apart from
+  // "present but valueless/malformed" (>0 but not a coherent value).
+  //
+  // Requiring rawCount === 1 (not just > 0) also closes a second gap: a
+  // body with one well-formed marker plus a second, valueless one would
+  // otherwise still resolve a coherent value (parseEffortMarker's regex
+  // silently ignores the valueless occurrence) and could pass by
+  // coincidence of which occurrence lastParagraphBeforeMarker lands on.
+  // An extra malformed occurrence must fail the check even when a
+  // well-formed one is also present.
+  const rawCount = countMarkerOccurrences(text, markerPrefix, 'effort');
+  if (rawCount === 0) {
+    return pass(id, name, 'not applicable: no effort footer (optional)');
+  }
+  if (rawCount > 1) {
+    return fail(
+      id,
+      name,
+      `expected at most one effort marker, found ${rawCount}`,
+    );
+  }
+  const effort = parseEffortMarker(text, markerPrefix);
+  if (!effort.present || effort.malformed || effort.value === null) {
+    return fail(
+      id,
+      name,
+      'effort marker is present but its value is not a single coherent S/M/L hint',
+    );
+  }
+  const scope = lastParagraphBeforeMarker(text, markerPrefix, 'effort');
+  const match = /_Effort:\s*([A-Za-z]+)/.exec(scope);
+  if (!match) {
+    return fail(
+      id,
+      name,
+      `missing or unparsable visible effort line immediately preceding the marker (value ${effort.value})`,
+    );
+  }
+  const visibleValue = match[1].toUpperCase();
+  if (visibleValue !== effort.value) {
+    return fail(
+      id,
+      name,
+      `visible line says ${visibleValue} but the marker says ${effort.value}`,
+    );
+  }
+  return pass(
+    id,
+    name,
+    `visible line agrees with marker value ${effort.value}`,
+  );
+}
+// An empty or whitespace-only currentRepo (reachable via an explicit
+// `--current-repo ''`, or an environment where `$GITHUB_REPOSITORY`
+// resolves to an empty string) must be treated the same as it being
+// unset. Without this, `currentRepo !== undefined` is true for `''`, but
+// `${owner}/${repo}` built from a regex match is never empty, so it can
+// never equal `''` — every full-URL/cross-repo-shorthand match would then
+// be silently treated as "known and different" (cross-repo) and excluded,
+// even when the reference is actually local. Returning the *trimmed*
+// value (not the original) when it is non-empty is a free, strictly more
+// correct bonus: a currentRepo with stray leading/trailing whitespace
+// would otherwise never case-insensitively equal a match's own untrimmed
+// `owner/repo` either.
+function normalizeCurrentRepo(currentRepo) {
+  if (currentRepo === undefined) {
+    return undefined;
+  }
+  const trimmed = currentRepo.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+function checkProseOnlyDependency(text, currentRepo) {
+  const id = 'prose-dependency';
+  const name =
+    'Advisory: issue/PR references near coordination language should use a dependency marker';
+  // Numbers already covered by a real machine-readable dependency encoding
+  // (Blocked by / Depends on / task-list) are never flagged, regardless of
+  // nearby prose — the whole point of this check is to catch references
+  // that carry *no* such encoding.
+  const encoded = new Set([
+    ...extractBlockedByIssueNumbers(text),
+    ...extractDependencyIssueNumbers(text),
+  ]);
+  const keywordPattern = new RegExp(
+    `\\b(?:${PROSE_DEPENDENCY_KEYWORDS.map(escapeRegex).join('|')})\\b`,
+    'i',
+  );
+  const flagged = new Set();
+  // Resolve reference-style Markdown links (`[text][ref]` + a separate
+  // `[ref]: target` definition elsewhere in the body) to the equivalent
+  // inline-link shape before splitting into paragraphs/sentences, so the
+  // existing Markdown-link alternative below — and its currentRepo /
+  // trailing-content handling — recognizes it with no duplicated matching
+  // logic. Scoped to this check only; other checks keep using `text`.
+  const resolvedText = resolveReferenceStyleLinks(text);
+  for (const paragraph of splitIntoParagraphs(resolvedText)) {
+    for (const sentence of splitIntoSentences(paragraph)) {
+      // Scope proximity to one sentence, not the whole paragraph: a long
+      // paragraph can legitimately combine an unrelated coordination word
+      // with a pure breadcrumb reference (e.g. "Part of roadmap (#1386)."
+      // followed by an unrelated "... before it correctly held ..." later
+      // in the same paragraph). Paragraph-level scoping would falsely flag
+      // the breadcrumb; sentence-level scoping does not.
+      if (!keywordPattern.test(sentence)) {
+        continue;
+      }
+      for (const match of sentence.matchAll(ISSUE_OR_PR_REFERENCE_PATTERN)) {
+        const [
+          ,
+          linkOwner,
+          linkRepo,
+          linkNumber,
+          bareNumber,
+          urlOwner,
+          urlRepo,
+          urlNumber,
+          shorthandOwner,
+          shorthandRepo,
+          shorthandNumber,
+        ] = match;
+        // Whichever of the two URL-bearing alternatives matched (a
+        // Markdown-link target or a bare URL) supplies the owner/repo/number
+        // trio; only one of the two can be present for a given match. A URL
+        // match with a known currentRepo that points elsewhere is a
+        // cross-repo reference: the Blocked by / Depends on markers this
+        // check recommends are inherently local, so flagging it here would
+        // be actively misleading rather than merely a nuisance false
+        // positive. Skip it entirely — for the Markdown-link alternative,
+        // this also discards any bare `#N` the link's own label repeated,
+        // since that label text was consumed as part of this same match and
+        // never separately visited by the bare-`#` alternative. When
+        // currentRepo is unknown, keep the prior behavior of flagging a
+        // full-URL match by default rather than guessing — though, like
+        // any match, it is still suppressed below if its number coincides
+        // with one already captured by a local Blocked-by/Depends-on/
+        // task-list marker elsewhere in the body.
+        const owner = linkOwner ?? urlOwner;
+        const repo = linkRepo ?? urlRepo;
+        if (
+          owner !== undefined &&
+          currentRepo !== undefined &&
+          `${owner}/${repo}`.toLowerCase() !== currentRepo.toLowerCase()
+        ) {
+          continue;
+        }
+        // The owner/repo#N shorthand alternative uses the *opposite*
+        // default from the URL-bearing alternatives above: it is excluded
+        // unless currentRepo is both known and a case-insensitive match.
+        // Unlike a full URL (which was always flaggable pre-#1399), this
+        // shorthand was never recognized at all before this alternative
+        // existed, so there is no prior "flag by default" behavior to
+        // preserve when locality can't be confirmed — see the
+        // `currentRepo` JSDoc on `AuditOptions`.
+        if (
+          shorthandOwner !== undefined &&
+          (currentRepo === undefined ||
+            `${shorthandOwner}/${shorthandRepo}`.toLowerCase() !==
+              currentRepo.toLowerCase())
+        ) {
+          continue;
+        }
+        const numberText =
+          bareNumber ?? linkNumber ?? urlNumber ?? shorthandNumber;
+        const number = Number.parseInt(numberText, 10);
+        if (!encoded.has(number)) {
+          flagged.add(number);
+        }
+      }
+    }
+  }
+  if (flagged.size === 0) {
+    return pass(
+      id,
+      name,
+      'no unencoded issue/PR reference found near coordination language',
+    );
+  }
+  const refs = [...flagged]
+    .sort((left, right) => left - right)
+    .map((number) => `#${number}`)
+    .join(', ');
+  return {
+    id,
+    name,
+    result: 'pass',
+    severity: 'warning',
+    detail:
+      `possible prose-only dependency on ${refs} — convert to a Blocked ` +
+      'by / Depends on marker, or confirm this is a breadcrumb reference ' +
+      'only',
+  };
+}
+// CommonMark reference labels are compared case-insensitively after
+// collapsing internal whitespace and trimming, so `[Upstream PR]` and
+// `[upstream  pr]` refer to the same definition.
+function normalizeLinkReferenceLabel(label) {
+  return label.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+// CommonMark §6.6 allows a reference definition's destination to be
+// wrapped in angle brackets (`[ref]: <https://...>`), captured verbatim
+// (brackets included) by LINK_REFERENCE_DEFINITION_PATTERN's `\S+`.
+// Without unwrapping, resolveReferenceStyleLinks would rewrite a usage to
+// `[text](<https://...>)`, which ISSUE_OR_PR_REFERENCE_PATTERN's
+// Markdown-link alternative does not recognize (it expects the URL
+// immediately after the opening paren, no angle brackets) — silently
+// leaving the reference-style link unresolved and re-leaking the label's
+// bare `#N` to the bare-`#` alternative, the same failure mode item 1
+// exists to prevent.
+function unwrapAngleBracketDestination(target) {
+  return target.startsWith('<') && target.endsWith('>')
+    ? target.slice(1, -1)
+    : target;
+}
+/**
+ * Resolves every `[text][ref]` reference-style link usage in `text`
+ * against its `[ref]: target` definition — which may appear anywhere else
+ * in the document, commonly far from the usage — by rewriting the usage
+ * to the equivalent inline-link shape `[text](target)`. A usage whose ref
+ * does not resolve to any definition is left unchanged: it falls through
+ * to the bare-`#` alternative like any other unrecognized bracket shape,
+ * the same fallback that already applies today. Duplicate labels keep the
+ * first definition, matching CommonMark's rule for duplicate link
+ * reference definitions.
+ */
+function resolveReferenceStyleLinks(text) {
+  const definitions = new Map();
+  for (const match of text.matchAll(LINK_REFERENCE_DEFINITION_PATTERN)) {
+    const key = normalizeLinkReferenceLabel(match[1]);
+    if (!definitions.has(key)) {
+      definitions.set(key, unwrapAngleBracketDestination(match[2]));
+    }
+  }
+  if (definitions.size === 0) {
+    return text;
+  }
+  return text.replace(
+    REFERENCE_STYLE_LINK_USAGE_PATTERN,
+    (whole, label, ref) => {
+      const target = definitions.get(normalizeLinkReferenceLabel(ref));
+      return target === undefined ? whole : `[${label}](${target})`;
+    },
+  );
+}
+// Exactly one blank line between two lines of content is two newline
+// characters (the left line's own terminator, then the blank line's
+// own terminator). Two or more blank lines means three or more, which
+// splitIntoParagraphs deliberately treats as a harder break -- see its
+// own doc comment.
+function isSingleBlankLine(separator) {
+  return (separator.match(/\n/g)?.length ?? 0) === 2;
+}
+// Once any list-item marker line appears in a blank-line-free run of
+// text, only a *later* marker line can close its node in
+// splitIntoListItemBlocks's own stack bookkeeping (a continuation line
+// never does). So, structurally, the *last* marker line anywhere in such
+// a run is necessarily still open at the run's end, and that marker's
+// own indentation is a cheap proxy for "the indentation of whatever node
+// is still open right before the blank line" -- without re-running the
+// full ancestry-stack simulation just to find out.
+//
+// That structural fact is not the same as the list still being open in
+// the Markdown a human reader sees, though (found on this PR's own
+// review, Codex): a marker followed by unindented plain prose --
+// `- Before merging\n  - child\nIndependent prose` -- reads as the list
+// having ended before the blank line, even though the algorithm's stack
+// still shows a node open (the trailing prose is a continuation line
+// attached via the ancestry walk, not a marker, so nothing closes it).
+// CommonMark's own lazy-continuation rule technically disagrees --
+// "Independent prose" is absorbed into "child"'s own paragraph rather
+// than ending the list -- but that is a well-known surprising edge case
+// that misleads readers (this PR's own Codex review included) far more
+// often than it helps them, so this heuristic follows the visual
+// reading over the stricter spec rule. Bridging across the blank line
+// in that shape would scope "Before" onto a reference in the next chunk
+// that a human author would not expect it to reach. Rather than trying
+// to fully re-derive CommonMark's real list-termination semantics,
+// require the last marker line to *be* the run's last line -- any
+// trailing continuation line makes "is this list still open" ambiguous
+// enough that refusing to bridge (a missed advisory, not a false one)
+// is the safer default, matching the same
+// prefer-a-miss-over-a-false-positive stance the indentation guard below
+// already takes for a too-deep right-hand marker.
+//
+// Returns undefined when `text` has no marker line at all, or when a
+// continuation line follows the last marker line.
+function lastListItemMarkerIndent(text) {
+  const lines = text.split('\n');
+  let lastMarkerIndex = -1;
+  let lastMarkerIndent;
+  for (let index = 0; index < lines.length; index += 1) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(lines[index]);
+    if (marker !== null) {
+      lastMarkerIndex = index;
+      lastMarkerIndent = indentColumnWidth(marker[1]);
+    }
+  }
+  return lastMarkerIndex === lines.length - 1 ? lastMarkerIndent : undefined;
+}
+// Two adjacent blank-line-delimited chunks bridge into one loose-list
+// paragraph only when the right chunk's first marker is no deeper than
+// whatever is still open at the end of the left chunk -- a same-depth
+// sibling continuation, or a resumption at a shallower ancestor's own
+// level, both legitimate loose-list shapes that splitIntoListItemBlocks's
+// existing same-or-shallower sibling-closing logic already re-separates
+// correctly when they are not actually related. A *strictly deeper*
+// right-hand marker is refused: bridging it would invent a parent/child
+// relationship across a blank line the source never expressed -- for
+// example a punctuation-free, keyword-bearing checklist item directly
+// followed by an unrelated, more-indented bullet, which would otherwise
+// flatten into one false-positive "sentence" (see #1476).
+function isBridgeableLooseListBoundary(left, separator, right) {
+  if (!isSingleBlankLine(separator)) {
+    return false;
+  }
+  const leftTailIndent = lastListItemMarkerIndent(left);
+  if (leftTailIndent === undefined) {
+    return false;
+  }
+  const rightMarker = LIST_ITEM_MARKER_PATTERN.exec(right.split('\n')[0] ?? '');
+  return (
+    rightMarker !== null && indentColumnWidth(rightMarker[1]) <= leftTailIndent
+  );
+}
+/**
+ * Splits `text` into paragraphs the same way as `text.split(/\n\s*\n/)`,
+ * except that two adjacent blank-line-delimited chunks are re-joined
+ * into one paragraph when the blank line between them sits inside what
+ * reads as a single loose Markdown list (see `isBridgeableLooseListBoundary`
+ * and #1476). Without this, a loose list -- its sibling items separated
+ * by a blank line, which is ordinary, valid CommonMark -- silently loses
+ * every earlier sibling's ancestor-scoped coordination language the
+ * moment `splitIntoListItemBlocks` runs on each paragraph independently.
+ *
+ * The blank line itself is preserved verbatim in the merged text rather
+ * than dropped: `splitIntoListItemBlocks` treats it like any other
+ * continuation line (no marker of its own), which never closes a node,
+ * so it is inert other than contributing a single collapsed space once
+ * `splitIntoSentences` later flattens the block.
+ *
+ * Merge decisions fold left-to-right against the *running accumulator*,
+ * not the original first chunk, so a loose list of three or more sibling
+ * items (blank line before the second, blank line before the third, and
+ * so on) keeps bridging correctly -- each decision re-derives the
+ * accumulator's own trailing indentation from whatever has already been
+ * merged in.
+ */
+function splitIntoParagraphs(text) {
+  const parts = text.split(/(\n\s*\n)/);
+  const paragraphs = [];
+  let current = parts[0] ?? '';
+  for (let index = 1; index < parts.length; index += 2) {
+    const separator = parts[index] ?? '';
+    const next = parts[index + 1] ?? '';
+    if (isBridgeableLooseListBoundary(current, separator, next)) {
+      current += separator + next;
+    } else {
+      paragraphs.push(current);
+      current = next;
+    }
+  }
+  paragraphs.push(current);
+  return paragraphs;
+}
+/**
+ * Split a paragraph into sentences on `.`/`!`/`?` followed by whitespace,
+ * after collapsing internal newlines to spaces (so a sentence that wraps
+ * across a Markdown soft line break is still scoped as one sentence). This
+ * is intentionally simple — good enough to separate two independent
+ * clauses sharing one paragraph, not a full natural-language sentence
+ * boundary detector.
+ *
+ * Markdown list items are treated as hard sentence boundaries first,
+ * *before* that whitespace-collapsing step: a tight list (items with no
+ * blank line between them) is one `\n\s*\n`-delimited "paragraph" to the
+ * caller, so collapsing every newline to a space would otherwise merge
+ * separate bullets that lack terminal punctuation into a single
+ * "sentence" — reintroducing exactly the false-positive risk this
+ * sentence-level scoping exists to avoid (e.g. a pure breadcrumb bullet
+ * conflated with a sibling bullet's unrelated coordination language).
+ */
+function splitIntoSentences(paragraph) {
+  return splitIntoListItemBlocks(paragraph).flatMap((block) => {
+    const flattened = block.replace(/\s+/g, ' ').trim();
+    return flattened.length === 0 ? [] : flattened.split(/(?<=[.!?])\s+/);
+  });
+}
+// CommonMark expands a tab to the next column that is a multiple of 4
+// when it participates in block structure (e.g. list-item indentation),
+// rather than counting as a single character. Comparing raw
+// `.length` would undercount a tab-indented marker's effective depth,
+// wrongly treating a tab-indented nested child as shallower than (or
+// equal to) a same-or-deeper space-indented parent and starting a new
+// block instead of keeping the child scoped with its parent — the same
+// loss-of-parent-scope splitIntoListItemBlocks exists to prevent, just
+// triggered by mixed tab/space indentation instead of an indentation
+// depth mismatch.
+function indentColumnWidth(indent) {
+  let column = 0;
+  for (const char of indent) {
+    column = char === '\t' ? (Math.floor(column / 4) + 1) * 4 : column + 1;
+  }
+  return column;
+}
+function lineIndentColumn(line) {
+  return indentColumnWidth(LEADING_WHITESPACE_PATTERN.exec(line)?.[0] ?? '');
+}
+/**
+ * Split a paragraph into blocks at each Markdown list item boundary, while
+ * still joining a soft-wrapped continuation line (one with no list marker
+ * of its own) onto the item it continues. A paragraph with no list items
+ * at all yields exactly one block spanning every line, preserving prior
+ * behavior for plain prose.
+ *
+ * Tracks a full indentation-ancestry stack of open `ListItemNode`s rather
+ * than a single most-recently-seen marker indentation (see issue #1474):
+ * a marker line strictly *deeper* than the stack's top is pushed as a new
+ * child node, nested under it. A marker at the *same or shallower*
+ * indentation pops nodes off the stack — closing each one — until the top
+ * is strictly shallower (or the stack empties), then pushes the new
+ * marker as a fresh node at that level.
+ *
+ * Closing a node emits it as its own block *only when it never acquired a
+ * child* (a leaf): the block is that leaf's still-open ancestors' own
+ * lines (root through parent, in document order) followed by the leaf's
+ * own lines. A node that did acquire a child is never emitted standalone
+ * — its own lines already appear as the ancestor prefix of every one of
+ * its descendant leaf blocks, so nothing is lost. Net effect: every
+ * root-to-leaf path down the tree emits exactly one block containing
+ * every node on that path, and every node lies on at least one such path.
+ * That scopes a parent bullet's coordination language together with
+ * *every* nested child's reference at any depth — not only the first
+ * child under a given parent, fixing the residual gap #1472 left behind
+ * — while same-depth sibling bullets never share a leaf block with each
+ * other, preserving the original tight-list sentence-conflation fix this
+ * function exists for.
+ *
+ * Lines seen before any node has opened (a plain-prose preamble, or an
+ * entire paragraph with no markers at all) accumulate in a separate
+ * `preamble` buffer rather than the stack — there is no ancestor above
+ * pre-first-marker prose to scope it with. `preamble` is flushed as its
+ * own standalone block as soon as the first marker line opens a node
+ * (preserving the existing behavior that leading prose never merges with
+ * the first list item), or as the paragraph's sole block if no marker
+ * ever appears.
+ *
+ * Two further gaps in the same area, both distinct from the
+ * marker-ancestry scoping above, were closed by #1476: a continuation
+ * line resuming at an ancestor's own indentation after a deeper child
+ * has already opened is now attributed to that ancestor rather than the
+ * deepest open child (see the ancestry walk in the continuation-line
+ * branch below, using `lineIndentColumn`), and a loose list — sibling
+ * items separated by a blank line — no longer resets scope at the
+ * paragraph boundary, because its caller (`checkProseOnlyDependency`)
+ * now bridges a single blank line between two loose-list chunks via
+ * `splitIntoParagraphs` before this function ever runs.
+ */
+function splitIntoListItemBlocks(paragraph) {
+  const blocks = [];
+  const stack = [];
+  let preamble = [];
+  const closeNode = (node) => {
+    if (node.hasChild) {
+      return;
+    }
+    const ancestorLines = stack.flatMap((ancestor) => ancestor.lines);
+    blocks.push([...ancestorLines, ...node.lines].join('\n'));
+  };
+  for (const line of paragraph.split('\n')) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    const indent = marker === null ? null : indentColumnWidth(marker[1]);
+    if (indent === null) {
+      // Continuation line: attach to the deepest open node whose own
+      // indentation is strictly less than this line's own indentation --
+      // the innermost node this line still reads as nested inside of. A
+      // continuation at or above an already-open child's own marker
+      // indentation is not deep enough to be that child's content; walk
+      // up the ancestry until a strictly shallower owner is found,
+      // falling back to the shallowest (root) node when none is
+      // strictly shallower (#1476: this is what lets a continuation
+      // that resumes at an ancestor's own indentation, after a deeper
+      // child already opened, land on that ancestor instead of
+      // unconditionally on the deepest open child). A continuation
+      // genuinely deeper than every open node still resolves at the
+      // first (deepest) comparison, so the normal, unambiguous case is
+      // unchanged. When no node is open yet, keep attaching to the
+      // pre-first-marker preamble.
+      const top = stack.at(-1);
+      if (top === undefined) {
+        preamble.push(line);
+        continue;
+      }
+      const ownIndent = lineIndentColumn(line);
+      const owner =
+        stack.findLast((node) => node.indent < ownIndent) ?? stack[0];
+      owner.lines.push(line);
+      continue;
+    }
+    // A same-or-shallower marker closes every open node at this depth or
+    // deeper — one level at a time — before the new marker starts its own
+    // node, mirroring the original single-value comparison per stack
+    // level instead of once against a single flattened scalar.
+    for (
+      let top = stack.at(-1);
+      top !== undefined && indent <= top.indent;
+      top = stack.at(-1)
+    ) {
+      stack.pop();
+      closeNode(top);
+    }
+    const parent = stack.at(-1);
+    if (parent !== undefined) {
+      parent.hasChild = true;
+    } else if (preamble.length > 0) {
+      blocks.push(preamble.join('\n'));
+      preamble = [];
+    }
+    stack.push({ indent, lines: [line], hasChild: false });
+  }
+  for (let top = stack.at(-1); top !== undefined; top = stack.at(-1)) {
+    stack.pop();
+    closeNode(top);
+  }
+  if (preamble.length > 0) {
+    blocks.push(preamble.join('\n'));
+  }
+  return blocks;
+}
+function countMarkerOccurrences(text, markerPrefix, suffix) {
+  const base = createMarkerRegex(markerPrefix, suffix);
+  const global = new RegExp(base.source, `${base.flags}g`);
+  return [...text.matchAll(global)].length;
+}
+/**
+ * The text of the last paragraph (block separated by a blank line) that
+ * appears before the LAST occurrence of the `{markerPrefix}-{suffix}`
+ * marker in `text`. Used to scope the visible-line/hidden-marker
+ * agreement checks to the footer's own paragraph, per the contract's
+ * "visible line + hidden marker, paired as one footer" shape — so a
+ * visible-line-shaped string elsewhere in the body (e.g. inside a pasted
+ * template/example snippet) cannot satisfy the check for a footer whose
+ * real visible line is missing or different. Returns '' when the marker
+ * is not found.
+ */
+function lastParagraphBeforeMarker(text, markerPrefix, suffix) {
+  const base = createMarkerRegex(markerPrefix, suffix);
+  const global = new RegExp(base.source, `${base.flags}g`);
+  let lastIndex = -1;
+  for (const match of text.matchAll(global)) {
+    lastIndex = match.index;
+  }
+  if (lastIndex < 0) {
+    return '';
+  }
+  // Trim trailing whitespace first: `before` ends exactly at the blank-line
+  // separator that precedes the marker, so an untrimmed split would yield
+  // an empty trailing paragraph instead of the visible-line paragraph.
+  const before = text.slice(0, lastIndex).replace(/\s+$/, '');
+  const paragraphs = before.split(/\n\s*\n/);
+  return paragraphs.at(-1) ?? '';
+}
+function extractHeadings(text) {
+  const headings = new Set();
+  // CommonMark/GitHub Markdown allow up to 3 leading spaces before an ATX
+  // heading (the same tolerance stripMarkdownCodeRegions already applies to
+  // fence openers), so a slightly-indented "   ## Background" must still
+  // count as a real heading.
+  for (const match of text.matchAll(/^ {0,3}##\s+(.+?)\s*$/gm)) {
+    headings.add(match[1].trim());
+  }
+  return headings;
+}
+function normalizeMarkerPrefix(prefix) {
+  // Trim first: a config value or CLI input with accidental leading/
+  // trailing whitespace (e.g. "idd-skill ") would otherwise become a
+  // distinct prefix that never matches any real marker, producing
+  // confusing false failures across every check.
+  const trimmed = typeof prefix === 'string' ? prefix.trim() : '';
+  return trimmed.length > 0 ? trimmed : DEFAULT_MARKER_PREFIX;
+}
+function pass(id, name, detail) {
+  return { id, name, result: 'pass', detail };
+}
+function fail(id, name, detail) {
+  return { id, name, result: 'fail', detail };
+}
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (!args.shape || !isIssueShape(args.shape)) {
+    fail_(`--shape is required and must be one of orphan|roadmap|child`);
+  }
+  if (!args.bodyFile && !args.stdin) {
+    fail_('either --body-file <path> or --stdin is required');
+  }
+  if (args.bodyFile && args.stdin) {
+    fail_('choose only one of --body-file or --stdin');
+  }
+  const bodyText = args.stdin
+    ? readFileSync(0, 'utf8')
+    : readFileSync(resolve(process.cwd(), args.bodyFile), 'utf8');
+  const policy = loadPolicy(args.configPath);
+  const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
+  const report = auditAuthoredIssue(bodyText, {
+    shape: args.shape,
+    markerPrefix,
+    labels: args.labels,
+    blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    // Explicit --current-repo wins; otherwise fall back to the
+    // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
+    // usage narrows cross-repo URL false positives with no extra flag.
+    // undefined (neither present) keeps the pre-#1399-fix default of
+    // flagging every full-URL reference.
+    currentRepo: args.currentRepo ?? process.env.GITHUB_REPOSITORY,
+  });
+  writeReport(report, args.format);
+  process.exit(report.passed ? 0 : 1);
+}
+function isIssueShape(value) {
+  return value === 'orphan' || value === 'roadmap' || value === 'child';
+}
+/**
+ * Deliberate exception (#1721): every sibling `*.mts` `loadPolicy()` throws
+ * on an explicit path that cannot be read or parsed (converged through
+ * idd-config.mts's `loadPolicyConfig`). This one does not: `main()` may
+ * still apply `--marker-prefix` on top of the value this returns, so an
+ * unreadable `--config` here does not necessarily mean the invocation is
+ * under-specified — hard-failing would reject an invocation that is
+ * actually fully specified. This function still calls the same shared
+ * `loadPolicyConfig()` reader every sibling routes through for the
+ * read-and-parse step, and catches its throw itself right here to keep
+ * this warn-and-continue contract instead of propagating it.
+ */
+function loadPolicy(configPath) {
+  // Default path: reuse the shared loadIddConfig() (idd-config.mts) rather
+  // than a second "readFileSync + JSON.parse, null on error" copy of the
+  // exact pattern it was extracted from (see that module's header, #1208).
+  // loadIddConfig() always reads '.github/idd/config.json' relative to cwd
+  // and has no path parameter, so an explicit --config override instead
+  // goes through loadPolicyConfig() below (caught locally, see doc comment
+  // above).
+  let config;
+  if (configPath) {
+    try {
+      config = loadPolicyConfig(configPath).config;
+    } catch (error) {
+      // Stay fail-safe (never hard-crash on a bad config, unlike every
+      // sibling *.mts loadPolicy()), but surface an explicit --config that
+      // could not be read/parsed: silently validating against the wrong
+      // policy would be a confusing, hard-to-notice false pass/fail.
+      //
+      // Describe this as loadPolicy's own fallback, not the audit's final
+      // effective markerPrefix: main() still applies --marker-prefix on
+      // top of this return value when the operator passed it, so naming a
+      // specific value here (e.g. DEFAULT_MARKER_PREFIX) could mislead
+      // when that flag is also present. The report's own markerPrefix
+      // field is the authoritative source for the value actually used.
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        `warning: could not read or parse --config ${configPath}; falling back to default policy unless overridden by --marker-prefix (see the report's markerPrefix field for the effective value): ${message}`,
+      );
+      config = null;
+    }
+  } else {
+    config = loadIddConfig();
+  }
+  if (!config) {
+    return {
+      markerPrefix: DEFAULT_MARKER_PREFIX,
+      blockedByHumanLabelName: POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    };
+  }
+  return {
+    markerPrefix: normalizeMarkerPrefix(config.markerPrefix),
+    blockedByHumanLabelName:
+      normalizePolicyConfig(config).labels.blockedByHumanLabelName,
+  };
+}
+function writeReport(report, format) {
+  if (format === 'table') {
+    console.log(
+      `shape=${report.shape} markerPrefix=${report.markerPrefix} passed=${report.passed}`,
+    );
+    console.log(['id', 'result', 'severity', 'detail'].join('\t'));
+    for (const finding of report.findings) {
+      console.log(
+        [
+          finding.id,
+          finding.result,
+          finding.severity ?? '',
+          finding.detail,
+        ].join('\t'),
+      );
+    }
+    return;
+  }
+  console.log(`${JSON.stringify(report, null, 2)}\n`);
+}
+function parseArgs(argv) {
+  // No test in this file asserts the pre-migration message text or the
+  // no-colon "unknown argument X" / "X requires a value" spelling (see
+  // #1451's PR description), so a parse failure adopts the wrapper's
+  // uniform message. The exit-code-2 contract IS preserved: catch the
+  // wrapper's thrown Error here and route it through this file's own
+  // fail_() exactly as every other malformed-input path already does.
+  let parsed;
+  try {
+    parsed = parseCliArgs(argv, AUDIT_AUTHORED_ISSUE_FLAG_SPEC);
+  } catch (error) {
+    fail_(error.message);
+  }
+  const { values, help } = parsed;
+  const format = values.format;
+  if (!['json', 'table'].includes(format)) {
+    fail_('--format must be json or table');
+  }
+  return {
+    help,
+    shape: values.shape,
+    bodyFile: values['body-file'],
+    stdin: values.stdin,
+    markerPrefix: values['marker-prefix'],
+    configPath: values.config,
+    currentRepo: values['current-repo'],
+    labels: values.label ?? [],
+    format,
+  };
+}
+function printUsage() {
+  console.log(`usage: node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> (--body-file <path> | --stdin) [options]
+
+Mechanically audits a drafted GitHub issue body against the issue-authoring
+contract's structural expectations (skills/issue-authoring/references/
+contract.md): the autopilot-suitability marker, its cross-field
+status:blocked-by-human agreement, markerPrefix consistency, required
+section headings for the declared shape, the roadmap-id/blocked-by
+dependency-marker rules, visible/hidden suitability+effort line
+agreement, and an advisory (warning-severity only) check that flags an
+issue/PR reference used near coordination language with no corresponding
+dependency marker. Exits 0 when every check passes, 1 when any check
+fails, 2 on a usage error; the advisory check never affects the exit
+code.
+
+Options:
+  --shape <orphan|roadmap|child>   declared issue shape (required)
+  --body-file <path>               read the drafted issue body from a file
+  --stdin                          read the drafted issue body from stdin
+  --marker-prefix <prefix>         override the resolved markerPrefix
+  --config <path>                  policy config path (default: .github/idd/config.json)
+  --label <name>                   a label currently applied/proposed on the issue
+                                    (repeatable; used for the suitability=1
+                                    cross-field check)
+  --current-repo <owner/repo>      this repository, for the prose-dependency check
+                                    to recognize a full-URL issue/PR reference as
+                                    cross-repo (default: $GITHUB_REPOSITORY)
+  --format <json|table>            output format (default: json)
+  --help                           show this help
+`);
+}
+function fail_(message) {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}

--- a/scripts/audit-pr-cleanup-summary.mjs
+++ b/scripts/audit-pr-cleanup-summary.mjs
@@ -1,0 +1,56 @@
+// idd-generated-from: src/scripts/audit-pr-cleanup-summary.mts
+//
+// The scripts/audit-pr-cleanup-summary.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+export function computeReportSummary(report) {
+  const alreadyMinimized = report.skipped.filter(
+    (skip) => skip.isMinimized,
+  ).length;
+  const viewerCanMinimize =
+    report.candidates.length +
+    report.skipped.filter((skip) => skip.viewerCanMinimize).length;
+  const viewerCannotMinimize = report.skipped.filter(
+    (skip) => !skip.isMinimized && !skip.viewerCanMinimize,
+  ).length;
+  report.summary = {
+    candidate: report.candidates.length,
+    skipped: report.skipped.length,
+    applied: report.applied.length,
+    failed: report.failed.length,
+    'already-minimized': alreadyMinimized,
+    'viewer-can-minimize': viewerCanMinimize,
+    'viewer-cannot-minimize': viewerCannotMinimize,
+  };
+  if (report.mode === 'dry-run') {
+    if (report.candidates.length > 0) {
+      report.status = 'needs-apply';
+    } else if (viewerCannotMinimize > 0) {
+      report.status = 'permission-blocked';
+    } else {
+      report.status = 'clean';
+    }
+    return;
+  }
+  if (report.mode === 'apply') {
+    if (report.failed.length > 0) {
+      report.status = 'failed';
+      return;
+    }
+    // A candidate that ended up minimized is done — whether this run minimized
+    // it (`applied`) or it was already / cascade-minimized (an
+    // already-minimized skip; minimizing a parent collapses its child threads,
+    // so a single apply converges more comments than it counts into `applied`).
+    // The only genuine unfinished work is a permission-blocked remainder
+    // (`viewer-cannot-minimize`); a real per-call failure is already handled
+    // above. So `incomplete` is reserved for that remainder, and a converged
+    // run reports `applied` (work done) or `clean` (nothing left). This stops a
+    // converged multi-candidate apply from spuriously reporting `incomplete`
+    // and drawing a false cleanup-failure comment on a merged PR (#1039).
+    if (viewerCannotMinimize > 0) {
+      report.status = 'incomplete';
+      return;
+    }
+    report.status = report.applied.length > 0 ? 'applied' : 'clean';
+  }
+}

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -1,0 +1,1188 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/audit-pr-cleanup.mts
+//
+// The scripts/audit-pr-cleanup.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { computeReportSummary } from './audit-pr-cleanup-summary.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import { ghText } from './gh-exec.mjs';
+import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
+import {
+  classifyRegularBotComment,
+  hasFreshDisposition,
+  indexLatestGatingReviewsByAuthor,
+  indexThreadsByReview,
+  isDispositionComment,
+  isKnownReviewBot,
+  normalizeTrustedMarkerLogins,
+  operationalMarkerPrefix,
+  summarizeClaimValidation,
+  unionTrustedMarkerActorSources,
+  unsafeTextReason,
+} from './protocol-helpers.mjs';
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant.
+const AUDIT_PR_CLEANUP_FLAG_SPEC = {
+  '--help': { type: 'boolean', short: 'h', default: false },
+  '--pr': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--dry-run': { type: 'boolean', default: false },
+  '--apply': { type: 'boolean', default: false },
+  '--format': { type: 'string', default: 'json' },
+  '--claim-issue': { type: 'string' },
+  '--claim-id': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--skip-claim-check': { type: 'boolean', default: false },
+};
+const TRUSTED_MARKER_PERMISSIONS = new Set(['admin', 'maintain', 'write']);
+const trustedMarkerAuthorCache = new Map();
+const collaboratorPermissionCache = new Map();
+let cachedConfiguredTrustedMarkerActorSources = null;
+let cachedCurrentViewerLogin = null;
+if (import.meta.main) {
+  await main();
+}
+// The CLI body. Guarded behind `import.meta.main` so importing this
+// module (for unit tests) does not parse process.argv, fail, or make a
+// `gh` call. This one stays async
+// because it retains a pre-existing await (buildReport) from before the
+// guard was added.
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (!args.pr) {
+    fail('missing required --pr <number>');
+  }
+  if (args.apply && args.dryRun) {
+    fail('choose only one of --dry-run or --apply');
+  }
+  if (!args.apply) {
+    args.dryRun = true;
+  }
+  if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+    fail(
+      '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+    );
+  }
+  if (
+    args.apply &&
+    !args.skipClaimCheck &&
+    (!args.claimIssue || !args.claimId)
+  ) {
+    fail(
+      '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
+    );
+  }
+  const repository = args.repo ?? detectRepository();
+  const [owner, repo] = parseRepository(repository);
+  const prNumber = parsePositiveInteger(args.pr, '--pr');
+  const claimContext = {
+    expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
+    // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+    // a legitimate issue-only handoff that predates the PR is honored even
+    // against this PR-backed claim. Resolve it once for both claim asserts.
+    prFirstCommitAt: args.apply
+      ? fetchPrFirstCommitAt(owner, repo, prNumber)
+      : null,
+  };
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+  const report = await buildReport(owner, repo, prNumber);
+  if (args.apply) {
+    report.mode = 'apply';
+    for (const candidate of report.candidates) {
+      if (!args.skipClaimCheck) {
+        try {
+          assertActiveClaim(
+            owner,
+            repo,
+            args.claimIssue,
+            args.agentId,
+            args.claimId,
+            claimContext,
+          );
+        } catch (error) {
+          report.failed.push({
+            ...candidate,
+            error: error.message,
+          });
+          break;
+        }
+      }
+      try {
+        const freshCandidate = await revalidateCandidate(
+          owner,
+          repo,
+          prNumber,
+          candidate,
+          report,
+        );
+        if (!freshCandidate) {
+          continue;
+        }
+        if (!args.skipClaimCheck) {
+          try {
+            assertActiveClaim(
+              owner,
+              repo,
+              args.claimIssue,
+              args.agentId,
+              args.claimId,
+              claimContext,
+            );
+          } catch (error) {
+            report.failed.push({
+              ...freshCandidate,
+              error: error.message,
+            });
+            break;
+          }
+        }
+        const minimized = minimizeComment(
+          freshCandidate.subjectId,
+          freshCandidate.classifier,
+        );
+        report.applied.push({
+          ...freshCandidate,
+          isMinimized: minimized.isMinimized,
+          minimizedReason: minimized.minimizedReason,
+        });
+      } catch (error) {
+        report.failed.push({
+          ...candidate,
+          error: error.message,
+        });
+      }
+    }
+    computeReportSummary(report);
+    if (report.failed.length > 0) {
+      writeReport(report, args.format);
+      process.exit(1);
+    }
+  }
+  computeReportSummary(report);
+  writeReport(report, args.format);
+}
+// Build an IDD-scoped disposition-author predicate from the resolved
+// trusted-marker actors (the accounts the IDD agent posts dispositions under).
+// The non-gate `hasFreshDisposition` callers must use this so a human
+// reviewer's `**Accepted**`/`**Rejected**` is not mistaken for a completed IDD
+// disposition.
+function makeIddDispositionAuthorPredicate(iddLogins) {
+  const set = new Set(iddLogins);
+  return (login) =>
+    set.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+async function buildReport(owner, repo, prNumber, options = {}) {
+  const pr = fetchPullRequest(owner, repo, prNumber, options);
+  const comments = fetchIssueComments(owner, repo, prNumber, options);
+  const reviews = fetchReviews(owner, repo, prNumber, options);
+  const threads = fetchReviewThreads(owner, repo, prNumber, options);
+  const configuredTrust = configuredTrustedMarkerActorSources();
+  const iddAgentLogins = normalizeTrustedMarkerLogins([
+    currentViewerLogin(),
+    ...configuredTrust.actors,
+  ]);
+  const threadIndex = indexThreadsByReview(threads, {
+    isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
+  });
+  const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
+  const report = {
+    repository: `${owner}/${repo}`,
+    pr: prNumber,
+    prUrl: pr.url,
+    merged: pr.merged,
+    mode: 'dry-run',
+    trustedMarkerActors: iddAgentLogins,
+    trustedMarkerActorsSources: [
+      ...(currentViewerLogin() ? ['viewer'] : []),
+      ...configuredTrust.sources,
+    ],
+    collaboratorTrustEnabled: trustCollaboratorMarkers(),
+    candidates: [],
+    skipped: [],
+    applied: [],
+    failed: [],
+    summary: null,
+    status: null,
+  };
+  for (const comment of comments) {
+    if (evaluateOperationalComment(comment, pr, report, owner, repo)) {
+      continue;
+    }
+    evaluateRegularBotComment(comment, comments, threads, pr, report);
+  }
+  for (const thread of threads) {
+    evaluateReviewComments(thread, pr, latestGatingReviews, report);
+  }
+  for (const review of reviews) {
+    evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, report);
+  }
+  // Collaborator trust is evaluated lazily per author; record it in the
+  // source mix only when the collaborator path actually trusted someone
+  // during this report's evaluation.
+  if (
+    report.collaboratorTrustEnabled &&
+    [...trustedMarkerAuthorCache.values()].some(Boolean)
+  ) {
+    report.trustedMarkerActorsSources.push('collaborators');
+  }
+  return report;
+}
+function evaluateOperationalComment(comment, pr, report, owner, repo) {
+  const prefix = operationalMarkerPrefix(comment.body);
+  if (!prefix) {
+    return false;
+  }
+  const subject = subjectFromNode(comment, 'IssueComment', 'OUTDATED');
+  const author = comment.author?.login ?? '';
+  if (!isTrustedMarkerAuthor(owner, repo, author)) {
+    addSkipped(report, subject, 'operational marker author is not trusted');
+    return true;
+  }
+  if (prefix === '<!-- forced-handoff:') {
+    addSkipped(report, subject, 'forced-handoff markers remain audit evidence');
+    return true;
+  }
+  if (!pr.merged) {
+    addSkipped(report, subject, 'PR is not merged');
+    return true;
+  }
+  const unsafeReason = unsafeTextReason(comment.body);
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return true;
+  }
+  if (comment.isMinimized) {
+    addSkipped(report, subject, 'already minimized');
+    return true;
+  }
+  if (!comment.viewerCanMinimize) {
+    addSkipped(report, subject, 'viewer cannot minimize this comment');
+    return true;
+  }
+  report.candidates.push({
+    ...subject,
+    markerPrefix: prefix,
+    reason: 'stale IDD operational marker on a merged PR',
+  });
+  return true;
+}
+function evaluateRegularBotComment(comment, comments, threads, pr, report) {
+  const author = comment.author?.login ?? '';
+  if (!isKnownReviewBot(author)) {
+    return;
+  }
+  const classification = classifyRegularBotComment(comment, comments, threads, {
+    isDispositionAuthor: makeIddDispositionAuthorPredicate(
+      report.trustedMarkerActors,
+    ),
+  });
+  const subject = subjectFromNode(
+    comment,
+    'IssueComment',
+    classification?.classifier ?? 'RESOLVED',
+  );
+  if (!pr.merged) {
+    addSkipped(report, subject, 'PR is not merged');
+    return;
+  }
+  const unsafeReason = unsafeTextReason(comment.body ?? '');
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return;
+  }
+  if (comment.isMinimized) {
+    addSkipped(report, subject, 'already minimized');
+    return;
+  }
+  if (!comment.viewerCanMinimize) {
+    addSkipped(report, subject, 'viewer cannot minimize this comment');
+    return;
+  }
+  if (!classification) {
+    addSkipped(
+      report,
+      subject,
+      'known review-bot regular comment lacks a completed-review signal',
+    );
+    return;
+  }
+  report.candidates.push({
+    ...subject,
+    author,
+    reason: classification.reason,
+  });
+}
+function evaluateReviewParent(
+  review,
+  pr,
+  threadIndex,
+  latestGatingReviews,
+  report,
+) {
+  const author = review.author?.login ?? '';
+  if (!isKnownReviewBot(author)) {
+    return;
+  }
+  const subject = subjectFromNode(review, 'PullRequestReview', 'RESOLVED');
+  const associated = threadIndex.get(review.id) ?? {
+    total: 0,
+    unresolved: 0,
+    threadIds: [],
+  };
+  const latestGatingReview = latestGatingReviews.get(author.toLowerCase());
+  if (!pr.merged) {
+    addSkipped(report, subject, 'PR is not merged');
+    return;
+  }
+  const unsafeReason = unsafeTextReason(review.body ?? '');
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return;
+  }
+  if (review.isMinimized) {
+    addSkipped(report, subject, 'already minimized');
+    return;
+  }
+  if (!review.viewerCanMinimize) {
+    addSkipped(report, subject, 'viewer cannot minimize this review');
+    return;
+  }
+  if (
+    review.state === 'CHANGES_REQUESTED' ||
+    latestGatingReview?.state === 'CHANGES_REQUESTED'
+  ) {
+    addSkipped(
+      report,
+      subject,
+      'review author still has an active changes-requested state',
+    );
+    return;
+  }
+  if (associated.total === 0) {
+    addSkipped(report, subject, 'review has no associated review threads');
+    return;
+  }
+  if (associated.incomplete) {
+    addSkipped(
+      report,
+      {
+        ...subject,
+        associatedThreads: associated.total,
+        unresolvedThreads: associated.unresolved,
+        missingDispositionThreads: associated.missingDisposition,
+      },
+      'associated review threads have truncated comment data',
+    );
+    return;
+  }
+  if (associated.unresolved > 0) {
+    addSkipped(
+      report,
+      {
+        ...subject,
+        associatedThreads: associated.total,
+        unresolvedThreads: associated.unresolved,
+        missingDispositionThreads: associated.missingDisposition,
+      },
+      'review has unresolved associated review threads',
+    );
+    return;
+  }
+  if (associated.missingDisposition > 0) {
+    addSkipped(
+      report,
+      {
+        ...subject,
+        associatedThreads: associated.total,
+        unresolvedThreads: 0,
+        missingDispositionThreads: associated.missingDisposition,
+      },
+      'associated review threads are missing IDD accept/reject dispositions',
+    );
+    return;
+  }
+  report.candidates.push({
+    ...subject,
+    author,
+    associatedThreads: associated.total,
+    unresolvedThreads: 0,
+    missingDispositionThreads: 0,
+    reason:
+      'known bot review parent with all associated review threads resolved',
+  });
+}
+function evaluateReviewComments(thread, pr, latestGatingReviews, report) {
+  for (const comment of thread.comments?.nodes ?? []) {
+    evaluateReviewComment(comment, thread, pr, latestGatingReviews, report);
+  }
+}
+function evaluateReviewComment(
+  comment,
+  thread,
+  pr,
+  latestGatingReviews,
+  report,
+) {
+  const author = comment.author?.login ?? '';
+  if (!isKnownReviewBot(author) || isDispositionComment(comment)) {
+    return;
+  }
+  const subject = subjectFromNode(
+    comment,
+    'PullRequestReviewComment',
+    'RESOLVED',
+  );
+  const latestGatingReview = latestGatingReviews.get(author.toLowerCase());
+  if (!pr.merged) {
+    addSkipped(report, subject, 'PR is not merged');
+    return;
+  }
+  const unsafeReason = unsafeTextReason(comment.body ?? '');
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return;
+  }
+  if (comment.isMinimized) {
+    addSkipped(report, subject, 'already minimized');
+    return;
+  }
+  if (!comment.viewerCanMinimize) {
+    addSkipped(report, subject, 'viewer cannot minimize this review comment');
+    return;
+  }
+  if (latestGatingReview?.state === 'CHANGES_REQUESTED') {
+    addSkipped(
+      report,
+      subject,
+      'review author still has an active changes-requested state',
+    );
+    return;
+  }
+  if (!thread.isResolved) {
+    addSkipped(
+      report,
+      { ...subject, threadId: thread.id },
+      'review thread is unresolved',
+    );
+    return;
+  }
+  if (thread.comments?.pageInfo?.hasNextPage) {
+    addSkipped(
+      report,
+      { ...subject, threadId: thread.id },
+      'review thread comment data is truncated',
+    );
+    return;
+  }
+  if (
+    !hasFreshDisposition(thread, {
+      isDispositionAuthor: makeIddDispositionAuthorPredicate(
+        report.trustedMarkerActors,
+      ),
+    })
+  ) {
+    addSkipped(
+      report,
+      { ...subject, threadId: thread.id },
+      'review thread is missing an IDD accept/reject disposition',
+    );
+    return;
+  }
+  report.candidates.push({
+    ...subject,
+    author,
+    threadId: thread.id,
+    reason: 'known bot feedback comment in a resolved review thread',
+  });
+}
+function subjectFromNode(node, type, classifier) {
+  return {
+    subjectId: node.id,
+    url: node.url,
+    type,
+    classifier,
+    viewerCanMinimize: Boolean(node.viewerCanMinimize),
+    isMinimized: Boolean(node.isMinimized),
+    minimizedReason: node.minimizedReason || null,
+  };
+}
+function addSkipped(report, subject, reason) {
+  report.skipped.push({
+    ...subject,
+    skipReason: reason,
+  });
+}
+function fetchPullRequest(owner, repo, number, options = {}) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        number
+        url
+        merged
+      }
+    }
+  }`;
+  const result = ghGraphql(query, { owner, repo, number }, options);
+  const pr = result.data?.repository?.pullRequest;
+  if (!pr) {
+    handleGraphqlFailure(`PR #${number} was not found`, options);
+  }
+  return pr;
+}
+/**
+ * Resolve the PR's first-commit time as an ISO string for the Part B
+ * forced-handoff rule (#1058): the minimum committed date (falling back to
+ * authored date) across the PR's commits. Returns `null` when no commit
+ * carries a parseable date — which makes the Part B gate fail closed
+ * (issue-only handoffs against a PR-backed claim stay rejected). Fails safe to
+ * `null` on any lookup error rather than aborting the claim assertion.
+ */
+function fetchPrFirstCommitAt(owner, repo, number) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        commits(first:100,after:$after){
+          nodes{commit{committedDate authoredDate}}
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  let earliestMs = null;
+  let earliestIso = null;
+  let after = null;
+  try {
+    for (;;) {
+      const result = ghGraphql(
+        query,
+        { owner, repo, number, after },
+        // Fail safe: a lookup error throws (caught below) instead of aborting
+        // the whole claim assertion via the default process-exit path.
+        { throwOnError: true },
+      );
+      const connection = result?.data?.repository?.pullRequest?.commits;
+      if (!connection) {
+        break;
+      }
+      for (const node of connection.nodes ?? []) {
+        const date =
+          String(node?.commit?.committedDate ?? '').trim() ||
+          String(node?.commit?.authoredDate ?? '').trim();
+        if (!date) {
+          continue;
+        }
+        const ms = Date.parse(date);
+        if (!Number.isFinite(ms)) {
+          continue;
+        }
+        if (earliestMs === null || ms < earliestMs) {
+          earliestMs = ms;
+          earliestIso = date;
+        }
+      }
+      if (!connection.pageInfo?.hasNextPage) {
+        break;
+      }
+      after = connection.pageInfo.endCursor ?? null;
+      if (!after) {
+        break;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return earliestIso;
+}
+function fetchIssueComments(owner, repo, number, options = {}) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        comments(first:100,after:$after){
+          nodes{
+            id
+            url
+            body
+            createdAt
+            updatedAt
+            isMinimized
+            minimizedReason
+            viewerCanMinimize
+            author{login}
+          }
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  return fetchConnection(
+    query,
+    { owner, repo, number },
+    (data) => {
+      return data.repository.pullRequest.comments;
+    },
+    options,
+  );
+}
+function fetchReviews(owner, repo, number, options = {}) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        reviews(first:100,after:$after){
+          nodes{
+            id
+            url
+            body
+            state
+            submittedAt
+            isMinimized
+            minimizedReason
+            viewerCanMinimize
+            author{login}
+          }
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  return fetchConnection(
+    query,
+    { owner, repo, number },
+    (data) => {
+      return data.repository.pullRequest.reviews;
+    },
+    options,
+  );
+}
+function fetchReviewThreads(owner, repo, number, options = {}) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        reviewThreads(first:100,after:$after){
+          nodes{
+            id
+            isResolved
+            comments(first:100){
+              pageInfo{hasNextPage}
+              nodes{
+                id
+                url
+                body
+                createdAt
+                isMinimized
+                minimizedReason
+                viewerCanMinimize
+                author{login}
+                pullRequestReview{id}
+              }
+            }
+          }
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  return fetchConnection(
+    query,
+    { owner, repo, number },
+    (data) => {
+      return data.repository.pullRequest.reviewThreads;
+    },
+    options,
+  );
+}
+function fetchConnection(query, baseVariables, pickConnection, options = {}) {
+  const nodes = [];
+  let after = null;
+  do {
+    const variables = { ...baseVariables };
+    if (after) {
+      variables.after = after;
+    }
+    const result = ghGraphql(query, variables, options);
+    if (result.errors?.length) {
+      handleGraphqlFailure(
+        `GraphQL connection query failed: ${formatGraphqlErrors(result.errors)}; ${formatGraphqlContext(query, variables)}`,
+        options,
+      );
+    }
+    if (!result.data) {
+      handleGraphqlFailure(
+        `GraphQL connection query returned no data; ${formatGraphqlContext(query, variables)}`,
+        options,
+      );
+    }
+    const connection = pickConnection(result.data);
+    if (!connection) {
+      handleGraphqlFailure(
+        `GraphQL connection query returned no connection; ${formatGraphqlContext(query, variables)}`,
+        options,
+      );
+    }
+    nodes.push(...(connection.nodes ?? []));
+    after = connection.pageInfo?.hasNextPage
+      ? connection.pageInfo.endCursor
+      : null;
+  } while (after);
+  return nodes;
+}
+function formatGraphqlErrors(errors) {
+  return errors
+    .map((error) => error.message ?? JSON.stringify(error))
+    .join('; ');
+}
+function formatGraphqlContext(query, variables) {
+  const compactQuery = query.replace(/\s+/g, ' ').trim();
+  const queryPreview =
+    compactQuery.length > 240
+      ? `${compactQuery.slice(0, 237)}...`
+      : compactQuery;
+  return `query=${queryPreview}; variables=${JSON.stringify(variables)}`;
+}
+function minimizeComment(subjectId, classifier) {
+  const query = `mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+    minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+      minimizedComment{
+        __typename
+        ... on IssueComment{id url isMinimized minimizedReason}
+        ... on PullRequestReview{id url isMinimized minimizedReason}
+        ... on PullRequestReviewComment{id url isMinimized minimizedReason}
+      }
+    }
+  }`;
+  const result = ghGraphql(
+    query,
+    { id: subjectId, classifier },
+    { throwOnError: true },
+  );
+  if (result.errors?.length) {
+    throw new Error(
+      `GraphQL mutation failed: ${formatGraphqlErrors(result.errors)}; ${formatGraphqlContext(query, { id: subjectId, classifier })}`,
+    );
+  }
+  const minimized = result.data?.minimizeComment?.minimizedComment;
+  if (!minimized) {
+    throw new Error(
+      `GraphQL mutation returned no minimized comment; ${formatGraphqlContext(query, { id: subjectId, classifier })}`,
+    );
+  }
+  return minimized;
+}
+async function revalidateCandidate(owner, repo, prNumber, candidate, report) {
+  const freshReport = await buildReport(owner, repo, prNumber, {
+    throwOnError: true,
+  });
+  const freshCandidate = freshReport.candidates.find((current) => {
+    return (
+      current.subjectId === candidate.subjectId &&
+      current.classifier === candidate.classifier
+    );
+  });
+  if (freshCandidate) {
+    return freshCandidate;
+  }
+  const skipped = freshReport.skipped.find((current) => {
+    return (
+      current.subjectId === candidate.subjectId &&
+      current.classifier === candidate.classifier
+    );
+  });
+  // Carry the FRESH state of the candidate (not the stale scan row) so the
+  // summary classifies it correctly: a candidate that was minimized between the
+  // scan and this apply — typically a cascade when its parent was minimized
+  // earlier in the same run — now has `isMinimized: true` and is counted as an
+  // already-minimized (converged) skip, while a candidate that became
+  // permission-blocked keeps `viewerCanMinimize: false` and is counted as a
+  // genuine remainder. Without this, a cascade-minimized child kept the stale
+  // `isMinimized: false`, so the run looked `incomplete` even though it
+  // converged (#1039).
+  addSkipped(
+    report,
+    skipped ?? candidate,
+    `pre-minimize revalidation failed: ${skipped?.skipReason ?? 'candidate is no longer eligible'}`,
+  );
+  return null;
+}
+function assertActiveClaim(
+  owner,
+  repo,
+  issueNumber,
+  agentId,
+  claimId,
+  options = {},
+) {
+  const active = readActiveClaim(owner, repo, issueNumber, options);
+  if (
+    !active ||
+    active.claimId !== claimId ||
+    (agentId && active.agentId !== agentId)
+  ) {
+    const activeLabel = active ? `${active.agentId} ${active.claimId}` : 'none';
+    throw new Error(
+      `claim check failed for #${issueNumber}: active claim is ${activeLabel}`,
+    );
+  }
+}
+function readActiveClaim(owner, repo, issueNumber, options = {}) {
+  const result = JSON.parse(
+    ghText([
+      'issue',
+      'view',
+      String(issueNumber),
+      '--repo',
+      `${owner}/${repo}`,
+      '--json',
+      'comments',
+    ]),
+  );
+  const comments = (result.comments ?? []).map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.createdAt ?? '',
+    author: { login: comment.author?.login ?? '' },
+  }));
+  // Read the authority policy once per call; the
+  // isAuthorizedForcedHandoff callback may fire multiple times during
+  // claim parsing and re-reading .github/idd/config.json on each call
+  // would be a needless I/O hot path.
+  const forcedHandoffAuthorityPolicyValue = readForcedHandoffAuthorityPolicy();
+  const summary = summarizeClaimValidation(comments, {
+    trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
+    forcedHandoffEnabled: readForcedHandoffMode() === 'human-gated',
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicyValue,
+        collaboratorPermissionCache,
+      ),
+  });
+  return summary.activeClaimPresent ? summary.activeClaim : null;
+}
+function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
+  const normalized = String(prNumber ?? '').trim();
+  if (!normalized) {
+    return [];
+  }
+  return [
+    normalized,
+    `#${normalized}`,
+    `https://github.com/${owner}/${repo}/pull/${normalized}`,
+  ];
+}
+function resolveTrustedMarkerLogins(owner, repo, comments) {
+  return normalizeTrustedMarkerLogins(
+    comments
+      .map((comment) => comment.author?.login ?? '')
+      .filter(Boolean)
+      .filter((login) => isTrustedMarkerAuthor(owner, repo, login)),
+  );
+}
+function isTrustedMarkerAuthor(owner, repo, login) {
+  if (!login) {
+    return false;
+  }
+  const normalized = login.toLowerCase();
+  if (normalized === currentViewerLogin()) {
+    return true;
+  }
+  if (configuredTrustedMarkerAuthors().has(normalized)) {
+    return true;
+  }
+  if (!trustCollaboratorMarkers()) {
+    return false;
+  }
+  const cacheKey = `${owner}/${repo}:${normalized}`;
+  if (trustedMarkerAuthorCache.has(cacheKey)) {
+    return trustedMarkerAuthorCache.get(cacheKey) ?? false;
+  }
+  let trusted = false;
+  try {
+    const permission = ghText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    ).toLowerCase();
+    trusted = TRUSTED_MARKER_PERMISSIONS.has(permission);
+  } catch {
+    trusted = false;
+  }
+  trustedMarkerAuthorCache.set(cacheKey, trusted);
+  return trusted;
+}
+function currentViewerLogin() {
+  if (cachedCurrentViewerLogin !== null) {
+    return cachedCurrentViewerLogin;
+  }
+  try {
+    cachedCurrentViewerLogin = ghText(['api', 'user', '--jq', '.login'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toLowerCase();
+  } catch {
+    cachedCurrentViewerLogin = '';
+  }
+  return cachedCurrentViewerLogin;
+}
+function configuredTrustedMarkerActorSources() {
+  if (cachedConfiguredTrustedMarkerActorSources) {
+    return cachedConfiguredTrustedMarkerActorSources;
+  }
+  let config = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    config = null;
+  }
+  const { actors, sources } = unionTrustedMarkerActorSources({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  cachedConfiguredTrustedMarkerActorSources = {
+    actors: new Set(actors),
+    sources,
+  };
+  return cachedConfiguredTrustedMarkerActorSources;
+}
+function configuredTrustedMarkerAuthors() {
+  return configuredTrustedMarkerActorSources().actors;
+}
+function trustCollaboratorMarkers() {
+  try {
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
+  } catch {
+    // Fall through to env-var fallback.
+  }
+  return /^(1|true|yes)$/i.test(
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? '',
+  );
+}
+function ghGraphql(query, variables, options = {}) {
+  const commandArgs = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (Number.isInteger(value)) {
+      commandArgs.push('-F', `${key}=${value}`);
+    } else {
+      commandArgs.push('-f', `${key}=${value}`);
+    }
+  }
+  try {
+    return JSON.parse(ghText(commandArgs));
+  } catch (error) {
+    const e = error;
+    const stdout = String(e.stdout ?? '').trim();
+    const stderr = String(e.stderr ?? '').trim();
+    const response = parseJsonOrNull(stdout);
+    if (response?.errors?.length) {
+      handleGraphqlFailure(
+        `GraphQL request failed: ${formatGraphqlErrors(response.errors)}; ${formatGraphqlContext(query, variables)}`,
+        options,
+      );
+    }
+    handleGraphqlFailure(
+      `gh api graphql failed: ${stderr || e.message}; ${formatGraphqlContext(query, variables)}`,
+      options,
+    );
+  }
+}
+function handleGraphqlFailure(message, options) {
+  if (options.throwOnError) {
+    throw new Error(message);
+  }
+  fail(message);
+}
+function parseJsonOrNull(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+function detectRepository() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+  return ghText([
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner',
+  ]);
+}
+function parseRepository(value) {
+  const parts = value.split('/');
+  if (
+    parts.length !== 2 ||
+    parts.some((part) => part.length === 0 || /\s/.test(part))
+  ) {
+    fail(`invalid repository ${value}; expected owner/name`);
+  }
+  return parts;
+}
+function writeReport(report, format) {
+  if (format === 'json') {
+    console.log(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  // Print summary header
+  if (report.summary) {
+    console.log(
+      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}`,
+    );
+    console.log('');
+  }
+  printRows('candidates', report.candidates);
+  printRows('skipped', report.skipped);
+  if (report.applied.length > 0) {
+    printRows('applied', report.applied);
+  }
+  if (report.failed.length > 0) {
+    printRows('failed', report.failed);
+  }
+}
+function printRows(label, rows) {
+  console.log(`${label}: ${rows.length}`);
+  if (rows.length === 0) {
+    return;
+  }
+  console.log(
+    [
+      'subjectId',
+      'type',
+      'classifier',
+      'viewerCanMinimize',
+      'isMinimized',
+      'minimizedReason',
+      'reason',
+      'url',
+    ].join('\t'),
+  );
+  for (const row of rows) {
+    console.log(
+      [
+        row.subjectId,
+        row.type,
+        row.classifier,
+        row.viewerCanMinimize,
+        row.isMinimized,
+        row.minimizedReason ?? '',
+        row.error ?? row.skipReason ?? row.reason ?? '',
+        row.url,
+      ].join('\t'),
+    );
+  }
+}
+function parseArgs(argv) {
+  // No test in this file asserts the pre-migration message text or the
+  // no-colon "unknown argument X" / "X requires a value" spelling (see
+  // #1451's PR description), so a parse failure adopts the wrapper's
+  // uniform message. The exit-code-2 contract IS preserved: catch the
+  // wrapper's thrown Error here and route it through this file's own
+  // fail() exactly as every other malformed-input path already does.
+  let parsed;
+  try {
+    parsed = parseCliArgs(argv, AUDIT_PR_CLEANUP_FLAG_SPEC);
+  } catch (error) {
+    fail(error.message);
+  }
+  const { values, help } = parsed;
+  // The pre-migration readValue() used `!value` (not `=== undefined`), so
+  // an explicit empty-string value was rejected the same as an omitted
+  // flag for EVERY flag in this file. parseCliArgs accepts an empty
+  // string (matching bare node:util parseArgs), so this check restores
+  // that exact uniform pre-migration behavior. The message matches
+  // parseCliArgs' own "missing value for argument: <flag>" phrasing
+  // (Copilot review finding on PR #1467) so an empty-string value and an
+  // omitted/flag-shaped value report the same failure style.
+  const requireNonEmpty = (token, flag) => {
+    if (token === '') {
+      fail(`missing value for argument: ${flag}`);
+    }
+    return token;
+  };
+  const pr = requireNonEmpty(values.pr, '--pr');
+  const repo = requireNonEmpty(values.repo, '--repo');
+  const format = requireNonEmpty(values.format, '--format');
+  if (!['json', 'table'].includes(format)) {
+    fail('--format must be json or table');
+  }
+  const claimIssue = requireNonEmpty(values['claim-issue'], '--claim-issue');
+  const claimId = requireNonEmpty(values['claim-id'], '--claim-id');
+  const agentId = requireNonEmpty(values['agent-id'], '--agent-id');
+  return {
+    format,
+    help,
+    pr,
+    repo,
+    dryRun: values['dry-run'],
+    apply: values.apply,
+    claimIssue,
+    claimId,
+    agentId,
+    skipClaimCheck: values['skip-claim-check'],
+  };
+}
+function parsePositiveInteger(value, flag) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    fail(`${flag} must be a positive integer`);
+  }
+  return Number.parseInt(value, 10);
+}
+function printUsage() {
+  console.log(`usage: node scripts/audit-pr-cleanup.mjs --pr <number> [options]
+
+Options:
+  --dry-run                         list candidates without mutating (default)
+  --apply                           minimize safe candidates
+  --claim-issue <number>            issue whose active claim protects apply mode
+  --claim-id <id>                   active claim id required for apply mode
+  --agent-id <id>                   optionally require this claim agent id
+  --skip-claim-check                explicit maintainer override for apply mode
+  --repo <owner/name>               repository override
+  --format <json|table>             output format (default: json)
+  --help                            show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS         comma-separated trusted bot/app logins
+                                    (combined with config.json trustedMarkerActors)
+  IDD_TRUST_COLLABORATOR_MARKERS    set true to trust Write/Maintain/Admin collaborators
+`);
+}
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}

--- a/scripts/authoring-label-guard.mjs
+++ b/scripts/authoring-label-guard.mjs
@@ -1,0 +1,112 @@
+// idd-generated-from: src/scripts/authoring-label-guard.mts
+//
+// The scripts/authoring-label-guard.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import {
+  normalizePolicyConfig,
+  POLICY_DEFAULTS,
+  parseIsoDurationToMs,
+} from './policy-helpers.mjs';
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+export function resolveAuthoringGuardPolicy(config) {
+  const normalized = normalizePolicyConfig(config);
+  const fallbackMs =
+    parseIsoDurationToMs(POLICY_DEFAULTS.issueAuthoring.authoringStaleAge) ?? 0;
+  return {
+    labelName: normalized.issueAuthoring.authoringLabelName,
+    staleAge: normalized.issueAuthoring.authoringStaleAge,
+    staleAgeMs:
+      parseIsoDurationToMs(normalized.issueAuthoring.authoringStaleAge) ??
+      fallbackMs,
+  };
+}
+export function buildAuthoringLabelWarning({
+  issueNumber,
+  labelName,
+  labelEvents,
+  now = new Date(),
+  staleAgeMs,
+}) {
+  const labeledAt = findLatestLabeledAt(labelEvents, labelName);
+  if (!labeledAt) {
+    return {
+      issueNumber,
+      labelName,
+      status: 'timestamp_unavailable',
+      labeledAt: null,
+      ageMs: null,
+      staleAgeMs,
+      message:
+        `Warning: Issue #${issueNumber} carries the authoring label, ` +
+        'but the labeled event timestamp could not be resolved; ' +
+        'the stale-authoring age could not be checked.',
+    };
+  }
+  const labeledAtMs = Date.parse(labeledAt);
+  const nowMs = now instanceof Date ? now.getTime() : Date.parse(String(now));
+  const ageMs = nowMs - labeledAtMs;
+  if (!Number.isFinite(ageMs) || ageMs < staleAgeMs) {
+    return null;
+  }
+  return {
+    issueNumber,
+    labelName,
+    status: 'stale',
+    labeledAt,
+    ageMs,
+    staleAgeMs,
+    message:
+      `Warning: Issue #${issueNumber} has carried the authoring label for ` +
+      `${formatElapsedDuration(ageMs)}; the authoring session may be stalled.`,
+  };
+}
+export function findLatestLabeledAt(events, labelName) {
+  let latest = '';
+  for (const event of events ?? []) {
+    if (!isMatchingLabeledEvent(event, labelName)) {
+      continue;
+    }
+    const createdAt = String(event.created_at ?? event.createdAt ?? '');
+    if (!createdAt || Number.isNaN(Date.parse(createdAt))) {
+      continue;
+    }
+    if (!latest || Date.parse(createdAt) > Date.parse(latest)) {
+      latest = createdAt;
+    }
+  }
+  return latest;
+}
+export function formatElapsedDuration(durationMs) {
+  const clamped = Math.max(0, Math.floor(durationMs));
+  const days = Math.floor(clamped / DAY_MS);
+  const hours = Math.floor((clamped % DAY_MS) / HOUR_MS);
+  const minutes = Math.floor((clamped % HOUR_MS) / MINUTE_MS);
+  const parts = [];
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0 || parts.length === 0) {
+    parts.push(`${minutes}m`);
+  }
+  return parts.join(' ');
+}
+function isMatchingLabeledEvent(event, labelName) {
+  if (event?.event !== 'labeled') {
+    return false;
+  }
+  const eventLabel =
+    typeof event.label === 'string' ? event.label : event.label?.name;
+  if (typeof eventLabel !== 'string') {
+    return false;
+  }
+  // Match case-insensitively and trimmed so a label differing only in case
+  // or surrounding whitespace (e.g. " Status:Authoring ") still registers.
+  return eventLabel.trim().toLowerCase() === labelName.trim().toLowerCase();
+}

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -1,0 +1,206 @@
+// idd-generated-from: src/scripts/autopilot-suitability.mts
+//
+// The scripts/autopilot-suitability.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared autopilot-suitability score parsing and discovery
+// ranking/routing. Consumed by:
+//
+// - scripts/discover-orphan-filter.mjs (A0-O candidate list)
+// - scripts/discover-roadmap-graph.mjs (A1.5/A2 node enumeration)
+//
+// The score is the authored 1-5 autopilot-suitability marker defined
+// in skills/issue-authoring/references/contract.md. It is an
+// advisory ranking/routing hint only — it never replaces the A4.5
+// suitability gate or the A5 claim safety checks, which still run on
+// whatever candidate is selected.
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+export const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+/**
+ * Canonical parser for the authored
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker.
+ *
+ * Returns `{ present, value, malformed }`:
+ * - `present` is false only when no marker appears in the body.
+ * - `value` is the single coherent integer 1-5, or null (fail-safe =
+ *   "no score") when the marker is absent, non-integer, out of the 1-5
+ *   range, or repeated with disagreeing values.
+ * - `malformed` is true when a marker is present but its value is not a
+ *   single coherent 1-5 score.
+ *
+ * `parseAutopilotSuitability` and `idd-doctor` both parse the marker
+ * through this one implementation so the regex and fail-safe rules never
+ * drift between the discovery rankers and the doctor consistency check.
+ *
+ * The body is masked with {@link stripMarkdownCodeRegions} before the
+ * scan, so a marker merely *quoted* in prose (inside backticks or a
+ * fenced block — for example an issue describing this marker's own
+ * syntax) cannot be mistaken for a real one and poison an otherwise
+ * valid footer marker elsewhere in the body (#1614, mirroring #1121's
+ * identical fix for the `roadmap-id` marker).
+ */
+export function parseAutopilotSuitabilityMarker(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  const prefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  const text = stripMarkdownCodeRegions(String(body ?? ''));
+  // Stream matches with regex.exec instead of matchAll so an untrusted,
+  // marker-heavy body avoids per-match array allocation, and fail fast
+  // on the first invalid token or first value that conflicts with an
+  // earlier one.
+  let present = false;
+  let value = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = match[1];
+    const parsed = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN;
+    // Fail-safe: any invalid token, or a value disagreeing with an
+    // earlier coherent one, yields no score.
+    if (
+      !isAutopilotSuitabilityScore(parsed) ||
+      (value !== null && parsed !== value)
+    ) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = parsed;
+    match = regex.exec(text);
+  }
+  if (!present) {
+    return { present: false, value: null, malformed: false };
+  }
+  return { present: true, value, malformed: false };
+}
+/**
+ * Parse the authored autopilot-suitability score from an issue body.
+ *
+ * Returns an integer 1-5 when the body carries a single coherent
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker. Returns null
+ * (fail-safe = "no score") when the marker is absent, non-integer,
+ * out of the 1-5 range, or present more than once with disagreeing
+ * values. A null score must never cause an issue to be skipped; the
+ * caller evaluates it the normal way. Thin value-only view over
+ * {@link parseAutopilotSuitabilityMarker}.
+ */
+export function parseAutopilotSuitability(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  return parseAutopilotSuitabilityMarker(body, markerPrefix).value;
+}
+/**
+ * Normalize a configured floor to an integer 1-5, falling back to the
+ * default (3) for anything out of range or non-integer.
+ */
+export function normalizeAutopilotSuitabilityFloor(floor) {
+  if (
+    typeof floor === 'number' &&
+    Number.isInteger(floor) &&
+    floor >= 1 &&
+    floor <= 5
+  ) {
+    return floor;
+  }
+  return DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+}
+/**
+ * Rank a candidate list by autopilot-suitability score and route
+ * below-floor candidates out to a human bucket.
+ *
+ * - `enabled: false` is a kill-switch: the items are returned
+ *   unchanged with an empty routedToHuman bucket.
+ * - Ranking always runs (when enabled): items are stable-sorted by
+ *   effective score descending, where a missing score uses the floor as
+ *   a neutral baseline so unscored (e.g. pre-existing) issues are never
+ *   buried. At a tied effective score, a genuinely-scored candidate
+ *   always ranks above an unscored one defaulted to the floor (the
+ *   written A4 Step 2 "scored-vs-unscored floor tie-breaker" rule,
+ *   matching `compareUnionLeaves` in discover-roadmap-graph.mts). Beyond
+ *   that scored-vs-unscored split, ties keep input order, so callers
+ *   that need a domain tie-break (e.g. effort hint, lowest issue number)
+ *   pre-sort the input by that key.
+ * - Routing is **opt-in** via `routeBelowFloor` (the autopilot-run
+ *   behavior). When true, candidates whose score is present and
+ *   `< floor` are moved to `routedToHuman` (kept visible, never
+ *   discarded). When false (the attended-safe default), below-floor
+ *   candidates stay in `ranked` — they simply sort to the bottom by
+ *   their real score — so attended discovery never loses a selectable
+ *   issue.
+ */
+export function rankAndRouteBySuitability(items, options = {}) {
+  const list = Array.isArray(items) ? [...items] : [];
+  const getScore =
+    typeof options.getScore === 'function' ? options.getScore : () => null;
+  if (options.enabled === false) {
+    return { ranked: list, routedToHuman: [] };
+  }
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor);
+  const routeBelowFloor = options.routeBelowFloor === true;
+  // Compute each item's score exactly once and reuse it for both routing
+  // and ranking, so a non-trivial or non-deterministic getScore cannot
+  // produce inconsistent decisions. Defensively normalize here too:
+  // anything that is not an integer 1-5 (null, NaN, 0, 6, 2.5, …) is
+  // treated as "no score", upholding the fail-safe rule regardless of
+  // what the caller's getScore returns.
+  const scored = list.map((item, index) => {
+    const raw = getScore(item);
+    return {
+      item,
+      index,
+      score: isAutopilotSuitabilityScore(raw) ? raw : null,
+    };
+  });
+  const routedToHuman = [];
+  const eligible = [];
+  for (const entry of scored) {
+    if (routeBelowFloor && entry.score !== null && entry.score < floor) {
+      routedToHuman.push(entry);
+    } else {
+      eligible.push(entry);
+    }
+  }
+  const ranked = eligible
+    .sort(
+      (left, right) =>
+        (right.score ?? floor) - (left.score ?? floor) ||
+        // Scored-before-unscored at a tie (written A4 Step 2 rule): a
+        // genuinely-scored candidate never ranks below an unscored one
+        // defaulted to the floor. `entry.score` is already normalized to
+        // "coherent 1-5 or null" above, so `!== null` is the same
+        // "genuinely scored" notion `compareUnionLeaves` derives from
+        // `isAutopilotSuitabilityScore`, reused rather than reimplemented.
+        // Applied before the caller's pre-sorted index order (which
+        // carries the effort-hint / issue-number tie-breakers), so those
+        // softer tie-breakers never outrank a real score.
+        Number(right.score !== null) - Number(left.score !== null) ||
+        left.index - right.index,
+    )
+    .map((entry) => entry.item);
+  return { ranked, routedToHuman: routedToHuman.map((entry) => entry.item) };
+}
+/**
+ * True when `value` is a valid authored autopilot-suitability score:
+ * an integer in the inclusive range 1-5.
+ */
+export function isAutopilotSuitabilityScore(value) {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 5
+  );
+}
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -1,0 +1,807 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/branch-conflict-state.mts
+//
+// The scripts/branch-conflict-state.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { execFileSync, spawnSync } from 'node:child_process';
+import { parseCliArgs } from './cli-args.mjs';
+import { ghText } from './gh-exec.mjs';
+
+/** One-line advisory attached to `notes` alongside a `true` result. */
+const BASE_ADVANCED_BLIND_SPOT_NOTE =
+  'Base has advanced since the merge-base for this branch ' +
+  '(baseAdvancedSinceMergeBase); a textually clean/mergeable verdict is ' +
+  'conflict-freeness only, not whole-tree CI-invariant freedom (e.g. ' +
+  'line-count budgets, generated-file drift, lockfile consistency) against ' +
+  'the current base tip, and a pull_request-triggered CI result may be ' +
+  'pinned to a merge-ref computed at an earlier trigger time. Consider ' +
+  're-validating against current base before relying on a pre-existing ' +
+  'green check.';
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant.
+const BRANCH_CONFLICT_STATE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+/**
+ * Bounded fetch-depth escalation steps tried by {@link computeMergeBase}'s
+ * retry loop, in order. The first step (`--depth=1`) matches the
+ * pre-existing single-shallow-fetch behavior byte-for-byte, so a checkout
+ * that already resolves after one shallow fetch performs exactly the same
+ * single extra fetch call as before this retry loop existed (#1519's "no
+ * regression for the common case" requirement). Each later step widens
+ * local history via `git fetch --deepen=<n>` -- relative to the current
+ * shallow boundary, so repeated calls compose instead of re-fetching the
+ * same fixed `--depth=N` -- instead of retrying forever. Three total
+ * attempts mirrors the bounded-retry shape F1's `computing` re-poll budget
+ * already uses elsewhere in this codebase (`idd-pre-merge.instructions.md`).
+ *
+ * Exported so tests can fetch with these exact args against a hermetic
+ * local fixture remote (see `tests/branch-conflict-state.test.mts`'s
+ * shallow-checkout fixture) instead of a hand-copied duplicate that could
+ * silently drift from what `tryFetchBase` actually runs in production.
+ *
+ * Declared here, above the CLI entry block below, rather than next to
+ * {@link computeMergeBase} that actually uses it: the entry block's
+ * top-level `await` parks module evaluation there on the CLI path, so a
+ * module-level `const` declared textually after it would still be in its
+ * temporal dead zone the first time a helper reads it (see
+ * `tests/cli-entry-smoke.test.mts`'s module-eval-order guard, #1447).
+ */
+export const MERGE_BASE_FETCH_STEPS = [
+  ['--depth=1'],
+  ['--deepen=20'],
+  ['--deepen=200'],
+];
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const result = await classifyBranchConflictState(args.prNumber, {
+    owner,
+    repo,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+export async function classifyBranchConflictState(prNumber, options = {}) {
+  const { owner, repo, _testPrData, _skipGitProbe } = options;
+  const notes = [];
+  const prData = _testPrData ?? fetchPrData(owner, repo, prNumber);
+  const prHeadSha = String(prData.headRefOid ?? '');
+  const prBaseSha = String(prData.baseRefOid ?? '');
+  const prHeadRef = String(prData.headRefName ?? '');
+  const prBaseRef = String(prData.baseRefName ?? '');
+  const mergeable = prData.mergeable ?? null;
+  const mergeStateStatus = prData.mergeStateStatus ?? null;
+  const published = Boolean(prHeadSha);
+  if (!prHeadSha || !prBaseSha) {
+    return {
+      protocolVersion: '1',
+      prNumber: Number(prNumber),
+      prHeadSha: prHeadSha || '',
+      prBaseSha: prBaseSha || '',
+      published,
+      mergeable: null,
+      mergeStateStatus: null,
+      branchState: 'unknown',
+      syncRecommendation: 'hold-unknown',
+      baseAdvancedSinceMergeBase: false,
+      readOnly: true,
+      worktreeUnchanged: true,
+      diagnostics: {
+        mergeableSource: 'none',
+        conflictFiles: [],
+        notes: [
+          'PR head or base SHA unavailable; cannot classify branch state.',
+        ],
+      },
+    };
+  }
+  const {
+    branchState,
+    syncRecommendation,
+    conflictFiles,
+    mergeableSource,
+    baseAdvancedSinceMergeBase,
+  } = deriveBranchState({
+    prHeadSha,
+    prBaseSha,
+    prHeadRef,
+    prBaseRef,
+    prNumber,
+    mergeable,
+    mergeStateStatus,
+    notes,
+    owner,
+    repo,
+    skipGitProbe: Boolean(_skipGitProbe),
+  });
+  return {
+    protocolVersion: '1',
+    prNumber: Number(prNumber),
+    prHeadSha,
+    prBaseSha,
+    published,
+    mergeable: normalizeNullable(mergeable),
+    mergeStateStatus: normalizeNullable(mergeStateStatus),
+    branchState,
+    syncRecommendation,
+    baseAdvancedSinceMergeBase,
+    readOnly: true,
+    worktreeUnchanged: true,
+    diagnostics: {
+      mergeableSource,
+      conflictFiles,
+      notes,
+    },
+  };
+}
+function deriveBranchState({
+  prHeadSha,
+  prBaseSha,
+  prBaseRef,
+  prNumber,
+  mergeable,
+  mergeStateStatus,
+  notes,
+  owner,
+  repo,
+  skipGitProbe,
+}) {
+  const mergeableNorm = String(mergeable ?? '').toUpperCase();
+  const mergeStateNorm = String(mergeStateStatus ?? '').toUpperCase();
+  if (mergeableNorm === 'CONFLICTING') {
+    const probeResult = skipGitProbe
+      ? []
+      : probeConflictFilesReadOnly(
+          prHeadSha,
+          prBaseSha,
+          prBaseRef,
+          prNumber,
+          owner,
+          repo,
+          notes,
+        );
+    return {
+      branchState: 'content-conflict',
+      syncRecommendation: 'hold-unknown',
+      conflictFiles: probeResult ?? [],
+      mergeableSource: 'github-mergeable',
+      // A real textual conflict already forces a hold; whether base also
+      // advanced past the merge-base is not an independently useful signal
+      // here, so this is not computed for this branch.
+      baseAdvancedSinceMergeBase: false,
+    };
+  }
+  if (mergeStateNorm === 'DIRTY') {
+    return {
+      branchState: 'dirty',
+      syncRecommendation: 'hold-unknown',
+      conflictFiles: [],
+      mergeableSource: 'github-merge-state',
+      baseAdvancedSinceMergeBase: false,
+    };
+  }
+  if (mergeableNorm === 'MERGEABLE' && mergeStateNorm === 'CLEAN') {
+    const baseAdvancedSinceMergeBase = computeBaseAdvanced(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      prNumber,
+      owner,
+      repo,
+      notes,
+      skipGitProbe,
+    );
+    if (baseAdvancedSinceMergeBase) {
+      notes.push(BASE_ADVANCED_BLIND_SPOT_NOTE);
+    }
+    return {
+      branchState: 'clean',
+      syncRecommendation: 'none',
+      conflictFiles: [],
+      mergeableSource: 'github-mergeable',
+      baseAdvancedSinceMergeBase,
+    };
+  }
+  if (mergeStateNorm === 'BEHIND') {
+    // GitHub's BEHIND state is definitional: the base has already advanced
+    // past this branch's merge-base (that is what "behind" means), so this
+    // is known for free without an extra git probe, for every return below.
+    const baseAdvancedSinceMergeBase = true;
+    if (skipGitProbe) {
+      return {
+        branchState: 'behind-no-conflict',
+        syncRecommendation: 'merge-main',
+        conflictFiles: [],
+        mergeableSource: 'github-merge-state',
+        baseAdvancedSinceMergeBase,
+      };
+    }
+    const probeResult = probeConflictFilesReadOnly(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      prNumber,
+      owner,
+      repo,
+      notes,
+    );
+    if (probeResult === null) {
+      return {
+        branchState: 'unknown',
+        syncRecommendation: 'hold-unknown',
+        conflictFiles: [],
+        mergeableSource: 'git-merge-tree',
+        baseAdvancedSinceMergeBase,
+      };
+    }
+    if (probeResult.length > 0) {
+      return {
+        branchState: 'content-conflict',
+        syncRecommendation: 'hold-unknown',
+        conflictFiles: probeResult,
+        mergeableSource: 'git-merge-tree',
+        baseAdvancedSinceMergeBase,
+      };
+    }
+    return {
+      branchState: 'behind-no-conflict',
+      syncRecommendation: 'merge-main',
+      conflictFiles: [],
+      mergeableSource: 'git-merge-tree',
+      baseAdvancedSinceMergeBase,
+    };
+  }
+  if (mergeableNorm === 'MERGEABLE') {
+    const baseAdvancedSinceMergeBase = computeBaseAdvanced(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      prNumber,
+      owner,
+      repo,
+      notes,
+      skipGitProbe,
+    );
+    if (baseAdvancedSinceMergeBase) {
+      notes.push(BASE_ADVANCED_BLIND_SPOT_NOTE);
+    }
+    return {
+      branchState: 'clean',
+      syncRecommendation: 'none',
+      conflictFiles: [],
+      mergeableSource: 'github-mergeable',
+      baseAdvancedSinceMergeBase,
+    };
+  }
+  if (mergeableNorm === 'UNKNOWN' || !mergeableNorm) {
+    notes.push(
+      `Mergeable status is ${mergeable ?? 'null'}; GitHub computes mergeability asynchronously, so this is most likely still computing. Re-poll before treating it as terminal.`,
+    );
+    return {
+      branchState: 'computing',
+      syncRecommendation: 'recheck',
+      conflictFiles: [],
+      mergeableSource: 'none',
+      baseAdvancedSinceMergeBase: false,
+    };
+  }
+  notes.push(
+    `Unrecognized mergeable=${mergeable} / mergeStateStatus=${mergeStateStatus}.`,
+  );
+  return {
+    branchState: 'unknown',
+    syncRecommendation: 'hold-unknown',
+    conflictFiles: [],
+    mergeableSource: 'none',
+    baseAdvancedSinceMergeBase: false,
+  };
+}
+/**
+ * Bounded merge-base resolution retry used by {@link computeMergeBase}: call
+ * `lookupMergeBase()`, and on an empty result, call `widenHistory(stepIndex)`
+ * before each subsequent lookup -- stopping as soon as a merge-base
+ * resolves, `widenHistory` reports it could not widen history (e.g. no
+ * fetchable base ref, or the fetch itself failed, so a deeper attempt would
+ * not plausibly help either), or `stepCount` attempts are exhausted.
+ *
+ * Exported so the retry-loop and attempt-cap shape itself stays directly
+ * unit-testable (both the deepened-success and still-undetermined paths)
+ * independent of `tryFetchBase`'s own remote-URL assembly and real `git
+ * fetch` call, which stay deliberately untested at their call site (see
+ * `tryFetchBase`'s doc comment) -- matching this file's existing
+ * hermetic-test convention of never letting a test reach a live network
+ * fetch.
+ */
+export function resolveMergeBaseWithRetry(
+  lookupMergeBase,
+  widenHistory,
+  stepCount,
+) {
+  let mergeBase = lookupMergeBase();
+  for (let step = 0; !mergeBase && step < stepCount; step += 1) {
+    if (!widenHistory(step)) break;
+    mergeBase = lookupMergeBase();
+  }
+  return mergeBase || null;
+}
+/**
+ * Read-only local `git merge-base` lookup, falling back to a bounded,
+ * progressively deeper fetch of the base ref **and** the PR head ref when
+ * the merge-base is not yet resolvable locally. Two genuinely different
+ * shallow-history gaps can block `git merge-base` here, and #1535 added the
+ * second one alongside #1519's original base-ref fix:
+ *
+ * - The base commit is missing (e.g. an agent worktree that has not fetched
+ *   recent base history) -- {@link tryFetchBase} handles this, unchanged
+ *   since #1519.
+ * - The PR **head**'s own ancestry is missing (e.g. a shallow CI checkout of
+ *   just the PR head, or a fork PR whose head commits were never fetched at
+ *   all) -- {@link tryFetchHead} handles this by fetching/deepening
+ *   `refs/pull/<prNumber>/head` from the same base-repository remote
+ *   {@link tryFetchBase} already targets. GitHub mirrors every PR head onto
+ *   the base repository under that ref (confirmed empirically against real
+ *   GitHub-hosted repos, including a genuine fork PR, for #1535 -- see the
+ *   PR description), so no separate fork remote URL is needed even when the
+ *   head lives in a fork: `classifyBranchConflictState`'s existing
+ *   `owner`/`repo` (the base repository) plus `prNumber` are sufficient.
+ *
+ * Each retry step attempts **both** fetches at the same escalating
+ * depth/deepen args and widens history if **either** succeeds, so a
+ * structural block on one side (e.g. a missing `prBaseRef`) does not stop
+ * the other side's retries, and the loop only gives up early when neither
+ * side can plausibly help.
+ *
+ * Returns `null` when the merge-base still cannot be resolved after
+ * exhausting {@link MERGE_BASE_FETCH_STEPS}; callers decide how to report
+ * that indeterminate outcome, since "conflict probe" and "base-advancement"
+ * callers need different diagnostics wording for the same underlying null.
+ */
+function computeMergeBase(
+  prHeadSha,
+  prBaseSha,
+  prBaseRef,
+  prNumber,
+  owner,
+  repo,
+  notes,
+) {
+  return resolveMergeBaseWithRetry(
+    () => gitText(['merge-base', prHeadSha, prBaseSha]),
+    (step) => {
+      const fetchArgs = MERGE_BASE_FETCH_STEPS[step];
+      const baseFetched = tryFetchBase(
+        prBaseRef,
+        owner,
+        repo,
+        notes,
+        fetchArgs,
+      );
+      const headFetched = tryFetchHead(prNumber, owner, repo, notes, fetchArgs);
+      return baseFetched || headFetched;
+    },
+    MERGE_BASE_FETCH_STEPS.length,
+  );
+}
+/**
+ * True when the base ref has moved past this PR's merge-base, independent of
+ * `syncRecommendation` -- the blind spot this field exists to close. Returns
+ * `false` both when base genuinely has not advanced and when the merge-base
+ * could not be resolved at all; the latter, indeterminate case is
+ * distinguished only via a `notes` entry, never silently reported as a
+ * confirmed "no" (see the `computeMergeBase` doc comment above).
+ */
+function computeBaseAdvanced(
+  prHeadSha,
+  prBaseSha,
+  prBaseRef,
+  prNumber,
+  owner,
+  repo,
+  notes,
+  skipGitProbe,
+) {
+  if (skipGitProbe) return false;
+  try {
+    const mergeBase = computeMergeBase(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      prNumber,
+      owner,
+      repo,
+      notes,
+    );
+    if (!mergeBase) {
+      notes.push(
+        'merge-base not found; base-advancement since merge-base is undetermined (reported as false).',
+      );
+      return false;
+    }
+    return mergeBase !== prBaseSha;
+  } catch {
+    notes.push(
+      'git merge-base unavailable; base-advancement since merge-base is undetermined (reported as false).',
+    );
+    return false;
+  }
+}
+function probeConflictFilesReadOnly(
+  prHeadSha,
+  prBaseSha,
+  prBaseRef,
+  prNumber,
+  owner,
+  repo,
+  notes,
+) {
+  try {
+    const mergeBase = computeMergeBase(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      prNumber,
+      owner,
+      repo,
+      notes,
+    );
+    if (!mergeBase) {
+      notes.push(
+        'merge-base not found; cannot prove conflict-free; holding unknown.',
+      );
+      return null;
+    }
+    const result = spawnSync(
+      'git',
+      ['merge-tree', `--merge-base=${mergeBase}`, prHeadSha, prBaseSha],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    if (result.status !== 0 && result.status !== 1) {
+      notes.push(
+        `git merge-tree exited with status ${result.status}; cannot probe conflicts.`,
+      );
+      return null;
+    }
+    const conflictFiles = parseConflictFiles(result.stdout ?? '');
+    if (result.status === 1 && conflictFiles.length === 0) {
+      notes.push(
+        'git merge-tree exited 1 but no conflict files were parsed; treating as unknown.',
+      );
+      return null;
+    }
+    return conflictFiles;
+  } catch {
+    notes.push(
+      'git merge-tree unavailable; falling back to GitHub mergeability signal only.',
+    );
+    return null;
+  }
+}
+/** Default `origin` URL reader: `git remote get-url origin` in the current
+ * working directory (this file's other git probes are likewise un-scoped
+ * to a `-C <dir>`, since they always run from inside the target checkout).
+ * `gitText` already swallows any git failure and returns `''`. */
+function readOriginRemoteUrl() {
+  return gitText(['remote', 'get-url', 'origin']);
+}
+/**
+ * Parse the scheme and host (hostname, plus `:port` when meaningful) from
+ * a git remote URL. Supports the `http://` / `https://` URL-scheme forms
+ * (parseable by the WHATWG URL parser) and the scp-like SSH shorthand
+ * (`[user@]host:path`, which has no `://` scheme and is not
+ * `URL`-parseable; per git's own URL syntax the `user@` prefix is
+ * optional, e.g. a bare `ghes.example.com:owner/repo.git` is valid).
+ *
+ * The returned `scheme` always matches an `http://` or `https://` origin's
+ * own scheme — an `http://`-only GHES instance (no TLS, e.g. behind a
+ * private network boundary) must stay `http`, since silently upgrading to
+ * `https` on the same port would target a port that is not serving TLS
+ * and the fetch would fail; that origin's port is preserved too, since it
+ * is directly reusable here.
+ *
+ * An `ssh://` URL-scheme origin (or any other non-`http(s)` scheme)
+ * deliberately returns `null` rather than reusing its hostname: an SSH
+ * hostname is sometimes an alias with no HTTPS service of its own —
+ * GitHub's own documented `ssh.github.com` (used for SSH-over-443
+ * firewall traversal) accepts SSH, not HTTPS, on that hostname, and a
+ * local `~/.ssh/config` `Host` alias may not resolve via DNS at all.
+ * Guessing wrong here would regress a previously-working `github.com`
+ * fallback into a broken fetch, so this signal is treated as unusable
+ * rather than guessed at. The scp-like shorthand keeps reusing its host,
+ * since that syntax has no port field of its own and is therefore not
+ * used for GitHub's SSH-over-443 workaround in practice — the same
+ * hostname is the overwhelmingly common real-world case for a GHES
+ * remote's SSH and HTTPS endpoints.
+ *
+ * Returns `null` for empty, unparseable, or host-less input (e.g. a
+ * `file://` URL, whose `hostname` is `''`) so callers fall back to
+ * another signal. The host is lowercased for consistent comparison —
+ * DNS/HTTP hosts are case-insensitive.
+ */
+export function parseGitFetchOrigin(url) {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('://')) {
+    try {
+      const parsed = new URL(trimmed);
+      if (!parsed.hostname) return null;
+      if (parsed.protocol === 'http:') {
+        return { scheme: 'http', host: parsed.host.toLowerCase() };
+      }
+      if (parsed.protocol === 'https:') {
+        return { scheme: 'https', host: parsed.host.toLowerCase() };
+      }
+      // ssh:// (or any other scheme): no reusable host -- see the doc
+      // comment above.
+      return null;
+    } catch {
+      return null;
+    }
+  }
+  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse
+  // it). A single-character "host" is excluded rather than requiring
+  // `user@`: git's own scp-like syntax makes the username optional (a
+  // real GHES remote can validly omit it), but no real git host is a
+  // single letter, so this is almost always a Windows drive-letter path
+  // (`C:\Users\...`, `C:repo.git`) rather than a real host.
+  //
+  // A bracketed IPv6 literal host (`[2001:db8::1]`) is matched before the
+  // generic host pattern: IPv6 literals contain colons of their own, so
+  // the generic `[^:/\s]+` alternative would otherwise stop at the first
+  // one and capture only a truncated fragment (e.g. `[2001`).
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?(\[[^\]\s]+\]|[^:/\s]+):/);
+  const host = scpMatch?.[1];
+  return host && host.length > 1
+    ? { scheme: 'https', host: host.toLowerCase() }
+    : null;
+}
+/**
+ * Resolve the scheme + host to use for the read-only base-ref fetch
+ * fallback in {@link tryFetchBase}, instead of hardcoding
+ * `https://github.com` (#1454) — a GitHub Enterprise Server (GHES)
+ * checkout must fetch from its own host, or the fallback silently targets
+ * an unrelated github.com repo of the same owner/repo name (or just
+ * fails outright). Preference order:
+ *
+ * 1. The `GH_HOST` environment variable — the same override `gh` itself
+ *    honors — when set and non-blank. `GH_HOST` never carries a scheme,
+ *    so this always resolves to `https` (the same assumption `gh` itself
+ *    makes for its own HTTPS operations).
+ * 2. The scheme and host parsed from the local checkout's `origin`
+ *    remote URL. This assumes the fetch-worthy remote is named `origin`,
+ *    the conventional default for a single-remote checkout; an unusual
+ *    multi-remote checkout that names its GHES remote something else
+ *    falls through to (3).
+ * 3. `https://github.com`, the pre-existing default, when neither signal
+ *    resolves.
+ */
+export function resolveFetchOrigin(env = process.env, readers = {}) {
+  const ghHost = env.GH_HOST?.trim();
+  // Lowercased for consistency with the origin-derived path below (DNS/HTTP
+  // hosts are case-insensitive either way, so this does not change fetch
+  // behavior -- only comparison/display consistency).
+  if (ghHost) return { scheme: 'https', host: ghHost.toLowerCase() };
+  const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
+  return (
+    parseGitFetchOrigin(readOriginUrl()) ?? {
+      scheme: 'https',
+      host: 'github.com',
+    }
+  );
+}
+/**
+ * Attempt one fetch of the base ref at the given depth/deepen args, for
+ * {@link computeMergeBase}'s bounded retry loop (via {@link
+ * resolveMergeBaseWithRetry}). Returns `true` when the `git fetch` call
+ * itself succeeded, so the caller's retry loop knows a deeper next step
+ * could plausibly still help; returns `false` when preconditions
+ * (`prBaseRef`, `owner`, `repo`) are missing, or when the fetch itself
+ * failed (network, auth, unknown ref, etc.) -- in either case a further
+ * attempt against the same unreachable/absent target would not change the
+ * outcome, so the caller should stop immediately rather than repeat the
+ * same failure (and its `notes` entry) across every remaining step.
+ */
+function tryFetchBase(prBaseRef, owner, repo, notes, fetchArgs) {
+  if (!prBaseRef) return false;
+  if (!owner || !repo) {
+    notes.push(
+      'Skipped base-ref fetch fallback: owner/repo not provided; merge-base probe may be incomplete.',
+    );
+    return false;
+  }
+  try {
+    // resolveFetchOrigin()'s own branching (GH_HOST / origin-remote /
+    // default) is unit-tested directly; this URL-assembly line and the
+    // real `git fetch` below stay deliberately untested at this call
+    // site, matching this file's existing test-suite convention of never
+    // letting a test reach a live network fetch (see the "unresolvable
+    // merge-base" test's `baseRefName: ''` short-circuit).
+    const { scheme, host } = resolveFetchOrigin();
+    const remote = `${scheme}://${host}/${owner}/${repo}.git`;
+    execFileSync(
+      'git',
+      ['fetch', '--no-tags', ...fetchArgs, remote, prBaseRef],
+      {
+        stdio: 'ignore',
+        encoding: 'utf8',
+      },
+    );
+    return true;
+  } catch {
+    notes.push(
+      `Could not fetch base ref ${prBaseRef} (git fetch ${fetchArgs.join(' ')}); merge-base probe may be incomplete.`,
+    );
+    return false;
+  }
+}
+/**
+ * Attempt one fetch of the PR **head** side at the given depth/deepen args,
+ * for {@link computeMergeBase}'s bounded retry loop (via {@link
+ * resolveMergeBaseWithRetry}) -- the #1535 sibling of {@link tryFetchBase}.
+ *
+ * Fetches `refs/pull/<prNumber>/head` from the same base-repository remote
+ * `tryFetchBase` already targets, rather than the PR's own `headRefName` or
+ * a fork's own remote URL. GitHub creates and keeps this ref updated on the
+ * **base** repository for every pull request -- including from a fork, and
+ * even when the fork remote has since been renamed, made private, or
+ * deleted -- so it is fetchable with the exact same remote URL, the exact
+ * same (anonymous, credential-helper-backed) auth, and the exact same
+ * escalating depth/deepen args as the base-ref fetch, with no separate
+ * fork-remote resolution required. Confirmed empirically for #1535 against
+ * real GitHub-hosted repos (both a same-repository PR and a genuine
+ * cross-repository/fork PR): `git ls-remote <repo> refs/pull/<n>/head`
+ * matches `gh pr view --json headRefOid` exactly, and fetching that ref
+ * (progressively deepened, mirroring {@link MERGE_BASE_FETCH_STEPS}) lets a
+ * shallow clone that never had the PR head's ancestry at all resolve
+ * `git merge-base` against it -- see the PR description for the full
+ * experiment. Because this always fetches a normally-advertised ref (never
+ * a bare, unadvertised SHA), it needs no server-side
+ * `uploadpack.allow*SHA1InWant` support either.
+ *
+ * Returns `true` when the `git fetch` call itself succeeded, so the
+ * caller's retry loop knows a deeper next step could plausibly still help;
+ * returns `false` when preconditions (`prNumber`, `owner`, `repo`) are
+ * missing or malformed, or when the fetch itself failed (network, auth,
+ * unknown ref, etc.) -- in either case a further attempt against the same
+ * unreachable/absent target would not change the outcome.
+ */
+function tryFetchHead(prNumber, owner, repo, notes, fetchArgs) {
+  // Mirrors parseArgs's own canonical-positive-integer check: a malformed or
+  // missing PR number is a structural skip, not an error -- callers that
+  // never had a resolvable PR number (e.g. this file's own hermetic tests)
+  // must not reach the real `git fetch` below.
+  const prNumberText = String(prNumber ?? '');
+  if (!/^[1-9]\d*$/.test(prNumberText)) return false;
+  if (!owner || !repo) {
+    notes.push(
+      'Skipped head-ref fetch fallback: owner/repo not provided; merge-base probe may be incomplete.',
+    );
+    return false;
+  }
+  const headRef = `refs/pull/${prNumberText}/head`;
+  try {
+    // Deliberately untested at this call site -- see tryFetchBase's own
+    // doc comment for why (this file's hermetic-test convention never lets
+    // a test reach a live network fetch); the retry-loop shape this feeds
+    // is covered directly via resolveMergeBaseWithRetry against a real
+    // local shallow-clone fixture instead (see
+    // tests/branch-conflict-state.test.mts's head-side-shallow test).
+    const { scheme, host } = resolveFetchOrigin();
+    const remote = `${scheme}://${host}/${owner}/${repo}.git`;
+    execFileSync('git', ['fetch', '--no-tags', ...fetchArgs, remote, headRef], {
+      stdio: 'ignore',
+      encoding: 'utf8',
+    });
+    return true;
+  } catch {
+    notes.push(
+      `Could not fetch head ref ${headRef} (git fetch ${fetchArgs.join(' ')}); merge-base probe may be incomplete.`,
+    );
+    return false;
+  }
+}
+export function parseConflictFiles(mergeTreeOutput) {
+  const files = new Set();
+  for (const line of mergeTreeOutput.split('\n')) {
+    // "CONFLICT (content): Merge conflict in path/to/file"
+    // "CONFLICT (add/add): Merge conflict in path/to/file"
+    // Any conflict type whose message ends with "Merge conflict in <path>"
+    const mergeConflictMatch = line.match(
+      /^CONFLICT\s+\([^)]+\):\s+Merge conflict in\s+(.+?)\s*$/i,
+    );
+    if (mergeConflictMatch) {
+      files.add(mergeConflictMatch[1].trim());
+      continue;
+    }
+    // "CONFLICT (modify/delete): <path> deleted in ... and modified in ..."
+    // "CONFLICT (rename/delete): <old> renamed to <new> in ..."
+    // "CONFLICT (rename/rename): <path> renamed to <a> in X and to <b> in Y"
+    // First token after "TYPE): " is the conflicted original path
+    const firstTokenMatch = line.match(
+      /^CONFLICT\s+\([^)]+\):\s+(.+?)\s+(?:deleted|renamed|added|modified)\s+/i,
+    );
+    if (firstTokenMatch) {
+      files.add(firstTokenMatch[1].trim());
+    }
+  }
+  return [...files];
+}
+function fetchPrData(owner, repo, prNumber) {
+  const raw = ghText([
+    'pr',
+    'view',
+    String(prNumber),
+    '-R',
+    `${owner}/${repo}`,
+    '--json',
+    'number,headRefOid,baseRefOid,headRefName,baseRefName,mergeable,mergeStateStatus,headRepository',
+    '--jq',
+    '.',
+  ]);
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`Failed to parse PR data for PR #${prNumber}`);
+  }
+}
+function normalizeNullable(value) {
+  if (value === null || value === undefined) return null;
+  const s = String(value);
+  return s === '' || s === 'null' || s === 'undefined' ? null : s;
+}
+function gitText(args) {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, BRANCH_CONFLICT_STATE_FLAG_SPEC);
+  // --pr stays a canonical-positive-integer STRING (not a parsed number):
+  // the caller passes it straight through to classifyBranchConflictState /
+  // gh invocations as text, and tests/branch-conflict-state.test.mts
+  // asserts this exact string-typed contract. Kept as a manual regex check
+  // (not the canonical-integer helper) so the return type stays a string.
+  const rawPr = values.pr;
+  let prNumber = null;
+  if (rawPr !== undefined) {
+    if (!/^[1-9]\d*$/.test(rawPr)) {
+      throw new Error(`invalid --pr value: ${rawPr}`);
+    }
+    prNumber = rawPr;
+  }
+  return {
+    help,
+    prNumber,
+    owner: values.owner ?? null,
+    repo: values.repo ?? null,
+  };
+}
+function printUsage() {
+  process.stdout.write(
+    `Usage:\n  node scripts/branch-conflict-state.mjs --pr <number> [--owner <owner>] [--repo <repo>]\n`,
+  );
+}

--- a/scripts/branch-name.mjs
+++ b/scripts/branch-name.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/branch-name.mts
+//
+// The scripts/branch-name.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Deterministic, network-free helper for the canonical IDD branch name.
+//
+// It implements the `issue/<number>-<slug>` slug algorithm defined in
+// `.github/instructions/idd-claim.instructions.md` pre-check (e) exactly,
+// so parallel sessions converge on a byte-identical branch name and the
+// pre-check (e) collision detection can recognize two sessions as working
+// the same issue. The written algorithm remains the canonical spec and
+// fallback; this helper only removes the hand-tracing error surface.
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
+
+// The fixed stop-word set from pre-check (e). Whole-token matches only.
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'in',
+  'for',
+  'to',
+  'with',
+  'from',
+]);
+const MAX_SLUG_LENGTH = 40;
+const FALLBACK_SLUG = 'task';
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `number:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --number spec key
+// below. See cli-args.mts's module header for the full invariant.
+// (Deliberately not written inside matching quote marks in this comment --
+// see advisory-convergence.mts's identical note for why.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see #1177's entry-order TDZ hardening for the same class
+// of bug in this file).
+const BRANCH_NAME_FLAG_SPEC = {
+  '--number': { type: 'string' },
+  '--title': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * Compute the deterministic slug for an issue title per pre-check (e):
+ *
+ * 1. lowercase the title;
+ * 2. replace every character outside ASCII `a-z`/`0-9` with `-`;
+ * 3. split on `-`, drop empty tokens, drop whole-token stop-words;
+ * 4. rejoin with single `-`;
+ * 5. if longer than 40 chars, cut to 40 — when that cut lands mid-token
+ *    and a `-` exists before char 40, trim back to that `-`, else keep
+ *    the hard 40-char cut — then strip any trailing `-`;
+ * 6. if empty, fall back to `task`.
+ *
+ * The algorithm is defined over an issue *title string*. Non-string
+ * inputs (including `null`/`undefined`) are out of that domain and are
+ * treated as empty, so they fall back to `task` rather than producing a
+ * coerced slug such as `object-object` or `123`.
+ */
+export function computeBranchSlug(title) {
+  const normalized = (typeof title === 'string' ? title : '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-');
+  const tokens = normalized
+    .split('-')
+    .filter((token) => token.length > 0 && !STOP_WORDS.has(token));
+  let slug = tokens.join('-');
+  if (slug.length > MAX_SLUG_LENGTH) {
+    const cut = slug.slice(0, MAX_SLUG_LENGTH);
+    // The cut lands mid-token only when the character at the cut boundary
+    // and the last kept character are both token characters (not `-`).
+    const boundaryChar = slug.charAt(MAX_SLUG_LENGTH);
+    const endsMidToken =
+      boundaryChar !== '' && boundaryChar !== '-' && !cut.endsWith('-');
+    if (endsMidToken) {
+      const lastHyphen = cut.lastIndexOf('-');
+      slug = lastHyphen >= 0 ? cut.slice(0, lastHyphen) : cut;
+    } else {
+      slug = cut;
+    }
+  }
+  slug = slug.replace(/-+$/, '');
+  return slug.length > 0 ? slug : FALLBACK_SLUG;
+}
+/**
+ * Compute the canonical `issue/<number>-<slug>` branch name. The caller is
+ * responsible for passing a positive integer issue number; the CLI
+ * validates this before calling.
+ */
+export function computeBranchName(issueNumber, title) {
+  return `issue/${issueNumber}-${computeBranchSlug(title)}`;
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.number === null) {
+    throw new Error('--number is required and must be a positive integer');
+  }
+  if (args.title === null) {
+    throw new Error('--title is required');
+  }
+  process.stdout.write(`${computeBranchName(args.number, args.title)}\n`);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, BRANCH_NAME_FLAG_SPEC);
+  return {
+    number: parseCanonicalIntegerOrNull(values.number),
+    title: typeof values.title === 'string' ? values.title : null,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+
+Prints the canonical IDD branch name \`issue/<number>-<slug>\` for the given
+issue number and title, applying the deterministic slug algorithm from
+idd-claim.instructions.md pre-check (e). Deterministic and network-free.
+
+Example:
+  node scripts/branch-name.mjs --number 42 --title "Add the OAuth login flow"
+  => issue/42-add-oauth-login-flow
+`);
+}

--- a/scripts/ci-wait-policy.mjs
+++ b/scripts/ci-wait-policy.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/ci-wait-policy.mts
+//
+// The scripts/ci-wait-policy.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mjs';
+import { loadJson, validateConfigSection } from './validate-schemas.mjs';
+
+const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
+const DEFAULT_GENERATION_TIMEOUT = 'PT10M';
+const DEFAULT_RERUN_POLICY = 'rerun-once';
+const DEFAULT_POLICY_PATH = '.github/idd/config.json';
+const RERUN_POLICIES = new Set(['rerun-once', 'hold']);
+const ISO_DURATION_PATTERN =
+  /^P(?=\d|T\d)(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/;
+const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+export const DEFAULT_CI_WAIT_POLICY = Object.freeze({
+  runningTimeout: DEFAULT_RUNNING_TIMEOUT,
+  runningTimeoutMs: 30 * 60 * 1000,
+  generationTimeout: DEFAULT_GENERATION_TIMEOUT,
+  generationTimeoutMs: 10 * 60 * 1000,
+  rerunPolicy: DEFAULT_RERUN_POLICY,
+});
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `policy:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --rerun-count spec
+// key below. See cli-args.mts's module header for the full invariant.
+// (Deliberately not written inside matching quote marks in this comment --
+// see advisory-convergence.mts's identical note for why.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see #1177's entry-order TDZ hardening for the same class
+// of bug in this file).
+const CI_WAIT_POLICY_FLAG_SPEC = {
+  '--policy': { type: 'string', default: DEFAULT_POLICY_PATH },
+  '--rerun-count': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+export function parseDurationToMs(value) {
+  const text = String(value ?? '').trim();
+  if (!text) return null;
+  const match = ISO_DURATION_PATTERN.exec(text);
+  if (!match) return null;
+  const days = Number.parseInt(match[1] ?? '0', 10);
+  const hours = Number.parseInt(match[2] ?? '0', 10);
+  const minutes = Number.parseInt(match[3] ?? '0', 10);
+  const seconds = Number.parseInt(match[4] ?? '0', 10);
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+}
+export function normalizeCiWaitPolicy(ciWait = {}) {
+  const c = ciWait ?? {};
+  const runningTimeout = normalizeDuration(
+    c.runningTimeout,
+    DEFAULT_RUNNING_TIMEOUT,
+  );
+  const generationTimeout = normalizeDuration(
+    c.generationTimeout,
+    DEFAULT_GENERATION_TIMEOUT,
+  );
+  const rerunPolicy = normalizeRerunPolicy(c.rerunPolicy);
+  return {
+    runningTimeout,
+    runningTimeoutMs: parseDurationToMs(runningTimeout),
+    generationTimeout,
+    generationTimeoutMs: parseDurationToMs(generationTimeout),
+    rerunPolicy,
+  };
+}
+export function readCiWaitPolicy(policyPath = DEFAULT_POLICY_PATH) {
+  const source = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), DEFAULT_POLICY_PATH);
+  try {
+    const config = JSON.parse(readFileSync(source, 'utf8'));
+    // Scoped to the ciWait subtree (#1359): an unrelated invalid field
+    // elsewhere in the document (an unknown top-level key, a typo'd enum in
+    // a sibling section, ...) must not zero out an otherwise-valid ciWait
+    // section.
+    if (validateConfigSection(config, POLICY_SCHEMA, 'ciWait').length > 0) {
+      return { ...DEFAULT_CI_WAIT_POLICY };
+    }
+    return normalizeCiWaitPolicy(config?.ciWait);
+  } catch {
+    return { ...DEFAULT_CI_WAIT_POLICY };
+  }
+}
+export function resolveCiRerunDecision({
+  rerunPolicy = DEFAULT_RERUN_POLICY,
+  rerunCount = 0,
+} = {}) {
+  const normalizedPolicy = normalizeRerunPolicy(rerunPolicy);
+  const normalizedCount =
+    typeof rerunCount === 'number' &&
+    Number.isInteger(rerunCount) &&
+    rerunCount > 0
+      ? rerunCount
+      : 0;
+  if (normalizedPolicy === 'hold') {
+    return {
+      action: 'hold',
+      reason: 'policy-hold',
+      rerunPolicy: normalizedPolicy,
+      rerunCount: normalizedCount,
+    };
+  }
+  if (normalizedCount === 0) {
+    return {
+      action: 'rerun',
+      reason: 'rerun-budget-available',
+      rerunPolicy: normalizedPolicy,
+      rerunCount: normalizedCount,
+    };
+  }
+  return {
+    action: 'hold',
+    reason: 'rerun-budget-exhausted',
+    rerunPolicy: normalizedPolicy,
+    rerunCount: normalizedCount,
+  };
+}
+function normalizeDuration(value, fallback) {
+  if (parseDurationToMs(value) === null) {
+    return fallback;
+  }
+  return String(value).trim();
+}
+function normalizeRerunPolicy(value) {
+  const text = String(value ?? '').trim();
+  return RERUN_POLICIES.has(text) ? text : DEFAULT_RERUN_POLICY;
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const policy = readCiWaitPolicy(args.policy);
+  const output = {
+    policy,
+  };
+  if (args.rerunCount !== null) {
+    output.rerunDecision = resolveCiRerunDecision({
+      rerunPolicy: policy.rerunPolicy,
+      rerunCount: args.rerunCount,
+    });
+  }
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, CI_WAIT_POLICY_FLAG_SPEC);
+  const rerunCountToken = values['rerun-count'];
+  return {
+    policy: values.policy,
+    // `min: 0`: --rerun-count is a non-negative counter (0 is a valid
+    // "no reruns yet" value), unlike the positive-integer contracts
+    // elsewhere in this file's siblings. Throws (rather than resolving to
+    // null) on violation, preserving this flag's existing fail-fast
+    // contract -- see tests/ci-wait-policy.test.mts.
+    rerunCount:
+      rerunCountToken === undefined
+        ? null
+        : parseCanonicalIntegerOrThrow(rerunCountToken, '--rerun-count', 0),
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/ci-wait-policy.mjs [--policy <path>] [--rerun-count <count>]
+
+Resolves the shared ciWait policy defaults from .github/idd/config.json.
+Optionally emits the deterministic rerun decision for a current rerun count.
+`);
+}

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -1,0 +1,532 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/ci-wait-state.mts
+//
+// The scripts/ci-wait-state.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Single-shot, read-only D-phase CI snapshot helper (#1317). Unlike the
+// E/F review-state steps, which each have a committed evidence-snapshot
+// helper (advisory-wait-state, pre-merge-readiness, review-activity-snapshot),
+// the D-phase CI wait has historically had no committed polling/snapshot
+// helper: callers re-derive check status from raw `statusCheckRollup` JSON
+// by hand every wait. Two concrete traps this helper closes:
+//
+// - Duplicate check names across triggering workflows: a single PR can carry
+//   two check runs with the identical display `name` (e.g. the same job name
+//   once under a "push as feature branch" workflow and again under a "merge
+//   as main branch" workflow). This helper keys every check entry by
+//   `(checkName, workflowName)` so a naive "first match by name" read never
+//   silently picks the wrong workflow's status.
+// - HEAD drift mid-wait: this helper always reports the live `headRefOid` at
+//   read time, so a caller polling in a loop can detect the branch moving
+//   out from under an in-flight wait.
+import { parseCliArgs } from './cli-args.mjs';
+import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { normalizePolicyConfig } from './policy-helpers.mjs';
+import {
+  CI_FAILURE_CONCLUSION_STATES,
+  parsePaginatedGhNdjson,
+  selectLatestCheckInstance,
+  summarizeBranchReviewRequirements,
+} from './protocol-helpers.mjs';
+
+// Interpretation table this bucketing is based on: idd-ci.instructions.md's
+// "Interpretation" section. Keep these three sets in sync with that table's
+// normalized states, with one deliberate addition: FAILURE_STATES also
+// includes StatusContext-only `ERROR` (see below), which that table does not
+// list because it predates this StatusContext-specific case.
+const SUCCESS_STATES = new Set([
+  'SUCCESS',
+  'NEUTRAL',
+  'SKIPPED',
+  'NOT_APPLICABLE',
+]);
+const PENDING_STATES = new Set([
+  'QUEUED',
+  'IN_PROGRESS',
+  'WAITING',
+  'PENDING',
+  'EXPECTED',
+  'REQUESTED',
+]);
+// Derived from the shared `CI_FAILURE_CONCLUSION_STATES` (protocol-helpers.mts)
+// plus `CANCELLED`, rather than an independently hand-maintained literal
+// (#1688): `CI_FAILURE_CONCLUSION_STATES` already carries `TIMED_OUT`,
+// `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and the commit-status-only
+// `ERROR` (a StatusContext `error` state distinct from `failure`; bucket it
+// as failure too, or a clearly failing required check would misleadingly
+// read as "unknown"). `CANCELLED` is added locally because this file's own
+// required-checks *bucketing* treats a cancelled run as failing for wait-gate
+// purposes, even though `ciStateTieRank`'s same-instant tie-break (in
+// `protocol-helpers.mts`) deliberately keeps `CANCELLED` at a lower rank
+// than every other member here -- a cancelled run reached no real verdict,
+// so it still loses a tie against a genuine success, but it must not be
+// treated as passing outright once it is the sole/latest instance for a
+// required check name. Deriving from the shared set (instead of maintaining
+// a second, separately-updated literal) is what keeps this file's wider
+// vocabulary from silently drifting away from `classifyCiChecks`'s again,
+// which is exactly how #1504's local-only fix diverged from the shared
+// `ciStateTieRank` in the first place.
+const FAILURE_STATES = new Set([...CI_FAILURE_CONCLUSION_STATES, 'CANCELLED']);
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls main() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see ci-wait-policy.mts's identical note).
+const CI_WAIT_STATE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  main();
+}
+// The CLI body. Guarded behind `import.meta.main` so importing this
+// module (for unit tests) does not parse process.argv, fail, or make a
+// `gh` call.
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.prNumber) {
+    // parseArgs normalizes both an absent --pr and an invalid one (e.g.
+    // `--pr 0` or `--pr foo`) to null, so "missing" alone would misreport an
+    // invalid value as absent.
+    throw new Error('missing or invalid --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,baseRefName,statusCheckRollup',
+    ]),
+  );
+  const encodedBaseRefName = encodeURIComponent(String(pr.baseRefName ?? ''));
+  const branchRules = ghApiJsonOr404Empty(
+    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
+    true,
+  );
+  const branchProtection = ghApiJsonOr404Empty(
+    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
+    false,
+  );
+  const branchReviewRequirements = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  );
+  // #1689: `ciGate.trustSourcePinnedRequiredChecks` -- see
+  // `buildRequiredChecksRollup`'s doc comment for the full rationale.
+  const trustSourcePinnedRequiredChecks =
+    normalizePolicyConfig(loadIddConfig()).ciGate
+      .trustSourcePinnedRequiredChecks === true;
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: pr.headRefOid ?? '',
+      statusCheckRollup: pr.statusCheckRollup ?? [],
+    },
+    {
+      requiredCheckNames: branchReviewRequirements.requiredCheckNames,
+      requiredCheckSourcePinned:
+        branchReviewRequirements.requiredCheckSourcePinned,
+      requiredCheckSourcePinnedUnresolved:
+        branchReviewRequirements.requiredCheckSourcePinnedUnresolved,
+      trustSourcePinnedRequiredChecks,
+    },
+  );
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+/**
+ * Build the read-only D-phase CI snapshot: every current check keyed by
+ * `(checkName, workflowName)`, the live `headRefOid`, and the top-level
+ * required-checks rollup. Pure and side-effect-free so it is directly unit
+ * testable without a live `gh` call.
+ */
+export function buildCiWaitStateSummary(input, options = {}) {
+  const requiredCheckNameSet = new Set(
+    (options.requiredCheckNames ?? [])
+      .map((name) => String(name ?? '').trim())
+      .filter(Boolean),
+  );
+  const checks = (input.statusCheckRollup ?? [])
+    .map((entry) => normalizeCheckEntry(entry, requiredCheckNameSet))
+    .filter((entry) => entry.checkName);
+  const requiredChecks = buildRequiredChecksRollup(
+    checks,
+    requiredCheckNameSet,
+    options.requiredCheckSourcePinned === true,
+    options.requiredCheckSourcePinnedUnresolved === true,
+    options.trustSourcePinnedRequiredChecks === true,
+  );
+  return {
+    headRefOid: String(input.headRefOid ?? ''),
+    checks,
+    requiredChecks,
+  };
+}
+function normalizeCheckEntry(entry, requiredCheckNameSet) {
+  if (entry?.__typename === 'StatusContext') {
+    const checkName = String(entry.context ?? '').trim();
+    const state = String(entry.state ?? '')
+      .trim()
+      .toUpperCase();
+    return {
+      checkName,
+      workflowName: '',
+      type: 'status-context',
+      state,
+      status: bucketState(state),
+      required: requiredCheckNameSet.has(checkName),
+      url: String(entry.targetUrl ?? ''),
+      startedAt: String(entry.startedAt ?? ''),
+      completedAt: String(entry.completedAt ?? ''),
+    };
+  }
+  const checkName = String(entry?.name ?? '').trim();
+  const status = String(entry?.status ?? '')
+    .trim()
+    .toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '')
+    .trim()
+    .toUpperCase();
+  const state =
+    status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN';
+  return {
+    checkName,
+    // Trimmed like checkName: workflowName is part of the
+    // (checkName, workflowName) disambiguation key, so untrimmed
+    // whitespace-only differences could otherwise produce unstable keys
+    // or spuriously "distinct" workflow entries.
+    workflowName: String(entry?.workflowName ?? '').trim(),
+    type: 'check-run',
+    state,
+    status: bucketState(state),
+    required: requiredCheckNameSet.has(checkName),
+    url: String(entry?.detailsUrl ?? ''),
+    startedAt: String(entry?.startedAt ?? ''),
+    completedAt: String(entry?.completedAt ?? ''),
+  };
+}
+function bucketState(state) {
+  if (FAILURE_STATES.has(state)) return 'failure';
+  if (PENDING_STATES.has(state)) return 'pending';
+  if (SUCCESS_STATES.has(state)) return 'success';
+  return 'unknown';
+}
+/**
+ * Reduce `entries` to one representative per `checkName`, matching the
+ * per-name dedup #1471 added to `classifyCiChecks` in
+ * `protocol-helpers.mts`: GitHub can report several check-run instances
+ * sharing one required check name (a manual or automatic rerun leaves the
+ * earlier instance in the fetched rollup alongside the new one), and only
+ * the latest instance per name should govern pass/fail/pending (#1478).
+ * Reuses the exported `selectLatestCheckInstance` for the actual
+ * same-name reduction (still-incomplete wins over completed; else latest
+ * `completedAt` wins; a same-instant tie prefers any
+ * `CI_FAILURE_CONCLUSION_STATES` member, then non-`CANCELLED`) so this file
+ * does not maintain a second, independently-drifting copy of that
+ * tie-break logic. Only the
+ * name-keyed grouping below is local to this file, because
+ * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
+ * `CheckLike` uses `name`.
+ *
+ * `selectLatestCheckInstance`'s shared `ciStateTieRank` originally
+ * special-cased only the two literal strings `'FAILURE'` and `'CANCELLED'`;
+ * every other raw state -- including this file's own wider `FAILURE_STATES`
+ * additions `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and
+ * `ERROR` -- fell into the shared tie-break's generic rank-1 bucket, where a
+ * same-instant tie against a success-family state resolved by raw
+ * lexicographic string comparison instead of "the failure should win"
+ * (#1504). That was fixed locally only, in this file, at the time (a
+ * tie-break-only state normalization applied by `selectLatestCheckEntry`
+ * before calling `selectLatestCheckInstance`) -- widening `ciStateTieRank`
+ * itself was left out of scope as "shared, upstream of `classifyCiChecks`".
+ * #1688 closed that shared corner: `ciStateTieRank` now ranks every
+ * `CI_FAILURE_CONCLUSION_STATES` member (which this file's `FAILURE_STATES`
+ * is derived from) at 0 directly, so `selectLatestCheckEntry` no longer
+ * needs a local normalization step at all -- see that function.
+ *
+ * Deliberately keyed by `checkName` alone, not the `(checkName,
+ * workflowName)` pair this file otherwise disambiguates entries by (see
+ * the module header): GitHub's own required-status-check gate matches by
+ * check name alone, independent of which workflow produced a given
+ * instance, so any rerun whose `workflowName` happens to differ from the
+ * instance it supersedes would not be deduped under a workflow-qualified
+ * key, leaving the defect only partially fixed. (The live PR #1434
+ * reproduction this fix targets happens to share one `workflowName`
+ * across every instance, so a composite key would also fix that specific
+ * case -- but not the general one, and not as directly as matching
+ * GitHub's own name-only semantics.) `required` itself is already
+ * computed by `checkName` alone (see `normalizeCheckEntry`), so this
+ * does not newly conflate anything the required-checks rollup did not
+ * already conflate. Two genuinely independent, same-named required
+ * checks that happen to complete in the same instant remain an accepted
+ * limitation shared with `classifyCiChecks` (tracked in #1483).
+ *
+ * `entries` itself may be empty (e.g. no required check has been
+ * reported yet), in which case `groups` simply ends up with zero
+ * entries. What is guaranteed is that every group `selectLatestCheckEntry`
+ * receives has at least one member: a group is only ever created by
+ * pushing the entry that introduced its key (see the `Map` construction
+ * below), so the seedless `reduce` inside `selectLatestCheckInstance`
+ * never runs on an empty array.
+ */
+function selectLatestCheckEntryPerName(entries) {
+  const groups = new Map();
+  for (const entry of entries) {
+    const group = groups.get(entry.checkName);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(entry.checkName, [entry]);
+    }
+  }
+  return [...groups.values()].map((group) => selectLatestCheckEntry(group));
+}
+/**
+ * Reduce one name-keyed group to its representative instance via the
+ * shared `selectLatestCheckInstance`, comparing each entry's own real
+ * `state` directly -- no local tie-break-only normalization needed
+ * (#1688; pre-#1688 this wrapped every entry through a *tie-break-only*
+ * normalized state before calling `selectLatestCheckInstance`, since the
+ * shared `ciStateTieRank` only recognized the literal `'FAILURE'` string;
+ * now that `ciStateTieRank` itself ranks every `CI_FAILURE_CONCLUSION_STATES`
+ * member -- which is exactly this file's `FAILURE_STATES` minus `CANCELLED`
+ * -- at 0, this file's own wider vocabulary already wins a same-instant tie
+ * against a success-family state with no local help).
+ *
+ * A same-instant tie between two *distinct* raw failure states (e.g.
+ * `TIMED_OUT` and `STARTUP_FAILURE`, both now rank 0) still resolves
+ * deterministically regardless of input order, because
+ * `isNewerCheckInstance`'s residual same-rank fallback
+ * (`candidate.state !== current.state && candidate.state < current.state`)
+ * is a genuine lexicographic argmin over the two *distinct* raw state
+ * strings -- symmetric and order-independent by construction, unlike the
+ * pre-#1688 wrapped comparison (which needed an explicit pre-sort, Copilot
+ * review PR #1530, because two distinct raw states could normalize to the
+ * *same* wrapped string and make the residual comparison see a false tie).
+ * With no normalization step left, that failure mode no longer exists, so
+ * the pre-sort is gone too.
+ *
+ * Exported (like `protocol-helpers.mts`'s own `selectLatestCheckInstance`)
+ * so the determinism property above is directly unit-testable: the winning
+ * *raw* instance's identity is not observable through
+ * `buildCiWaitStateSummary`'s public return shape at all -- `checks` there
+ * is the raw, not-deduped list, and `requiredChecks` only exposes aggregate
+ * pass/fail booleans that stay identical regardless of which same-rank
+ * instance wins a tie.
+ */
+export function selectLatestCheckEntry(group) {
+  const winner = selectLatestCheckInstance(
+    group.map((entry) => ({
+      entry,
+      state: entry.state,
+      completedAt: entry.completedAt,
+    })),
+  );
+  return winner.entry;
+}
+function buildRequiredChecksRollup(
+  checks,
+  requiredCheckNameSet,
+  requiredCheckSourcePinned,
+  // #1689: true when at least one pinned source has no resolved check name
+  // (a `workflows` rule, or a pinned classic entry with no `context`/
+  // `name`/`check`) -- see `CiWaitRequiredChecksRollup`'s doc comment. The
+  // opt-in below must never bypass the downgrade while this is true, even
+  // when a separate, named-and-pinned check on the same required-check set
+  // would itself qualify.
+  requiredCheckSourcePinnedUnresolved,
+  // #1689: `ciGate.trustSourcePinnedRequiredChecks` opt-in, mirroring
+  // `summarizeRequiredChecks`'s option of the same name in
+  // protocol-helpers.mts -- see that function's doc comment for the full
+  // rationale. Only widens the named/present/passing mixed case below;
+  // the fully-unnamed case above (`names.length === 0`) stays
+  // unconditionally conservative regardless of this flag, since there is
+  // no check name to correlate with a live run at all in that case.
+  trustSourcePinnedRequiredChecks,
+) {
+  const names = [...requiredCheckNameSet].sort();
+  if (names.length === 0) {
+    return {
+      names,
+      missingNames: [],
+      // A source-pinned required check (ruleset `workflows` rule, or an
+      // app/integration-pinned classic check with no enumerable context)
+      // is still gating the branch even though it cannot be resolved by
+      // name here — fail closed (`allRequiredPresent: false`) instead of
+      // reporting the vacuous "no required checks" pass.
+      allRequiredPresent: !requiredCheckSourcePinned,
+      allRequiredPassing: false,
+      anyRequiredPending: false,
+      anyRequiredFailing: false,
+      anyRequiredUnknown: false,
+      requiredCheckSourcePinned,
+      requiredCheckSourcePinnedUnresolved,
+      status: requiredCheckSourcePinned
+        ? 'source-pinned'
+        : 'no-required-checks',
+    };
+  }
+  const requiredEntries = checks.filter((check) => check.required);
+  const presentNames = new Set(requiredEntries.map((check) => check.checkName));
+  const missingNames = names.filter((name) => !presentNames.has(name));
+  const allRequiredPresent = missingNames.length === 0;
+  // #1478: dedupe multiple check-run instances sharing one required check
+  // name down to the latest instance before classifying, so a stale
+  // CANCELLED/FAILURE instance never outvotes a later SUCCESS for the
+  // same name (the identical defect shape #1471 fixed in
+  // classifyCiChecks). presentNames/missingNames/allRequiredPresent above
+  // are unaffected: they only test *presence* by name via a Set, which is
+  // already naturally deduped.
+  const dedupedRequiredEntries = selectLatestCheckEntryPerName(requiredEntries);
+  const anyRequiredFailing = dedupedRequiredEntries.some(
+    (check) => check.status === 'failure',
+  );
+  const anyRequiredPending = dedupedRequiredEntries.some(
+    (check) => check.status === 'pending',
+  );
+  const anyRequiredUnknown = dedupedRequiredEntries.some(
+    (check) => check.status === 'unknown',
+  );
+  const namedChecksPassing =
+    allRequiredPresent &&
+    dedupedRequiredEntries.every((check) => check.status === 'success');
+  let status;
+  if (!allRequiredPresent) {
+    status = 'missing';
+  } else if (anyRequiredFailing) {
+    status = 'failing';
+  } else if (anyRequiredPending || anyRequiredUnknown) {
+    status = 'pending';
+  } else if (
+    requiredCheckSourcePinned &&
+    (!trustSourcePinnedRequiredChecks || requiredCheckSourcePinnedUnresolved)
+  ) {
+    // Mixed case: enumerable required checks all pass, but a ruleset
+    // `workflows` rule or an app-pinned classic check is ALSO in force and
+    // not name-enumerable, so it is not covered by requiredEntries at all.
+    // Mirrors summarizeRequiredChecks in protocol-helpers.mts, which
+    // downgrades an otherwise-"success" classification (absent the #1689
+    // `trustSourcePinnedRequiredChecks` opt-in checked above) under the
+    // same condition — never report a vacuous success while an unverified
+    // source-pinned requirement could still be gating the branch. The
+    // opt-in itself never overrides an unresolved pinned source (no check
+    // name to correlate with a live run at all), even when a separate,
+    // named-and-pinned check on the same required-check set would itself
+    // qualify.
+    status = 'source-pinned';
+  } else {
+    status = 'success';
+  }
+  const allRequiredPassing = namedChecksPassing && status === 'success';
+  return {
+    names,
+    missingNames,
+    allRequiredPresent,
+    allRequiredPassing,
+    anyRequiredPending,
+    anyRequiredFailing,
+    anyRequiredUnknown,
+    requiredCheckSourcePinned,
+    requiredCheckSourcePinnedUnresolved,
+    status,
+  };
+}
+/**
+ * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
+ * `Number.parseInt` accepts trailing-garbage ("42abc" -> 42) and
+ * leading-zero ("007" -> 7) tokens the same way the original hand-rolled
+ * `Number.parseInt(value ?? '', 10)` always did, then the original's own
+ * `!Number.isInteger(...) || (... ?? 0) < 1` post-check collapses an
+ * invalid or absent value to `null`. `cli-args.mts`'s
+ * `parseCanonicalIntegerOrNull` is a poor substitute: its canonical-pattern
+ * regex rejects those same permissive tokens outright, which is a real
+ * contract change a CodeRabbit review on PR #1466 caught -- #1450's
+ * acceptance criteria protect the post-parse integer contract as-is, only
+ * flag *syntax* (missing/flag-shaped values, unknown flags) is meant to
+ * tighten.
+ */
+function parseLenientPositiveIntegerOrNull(token) {
+  const value = Number.parseInt(token ?? '', 10);
+  return Number.isInteger(value) && value >= 1 ? value : null;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, CI_WAIT_STATE_FLAG_SPEC);
+  return {
+    prNumber: parseLenientPositiveIntegerOrNull(values.pr),
+    owner: values.owner,
+    repo: values.repo,
+    help,
+  };
+}
+/**
+ * `gh api <path>`, tolerating a genuine 404 (unprotected branch / no active
+ * rules) as an empty result. `gh` exits 1 for every HTTP error alike, so the
+ * real status is derived from the error text via the shared
+ * {@link deriveGhHttpStatus} rather than the useless process exit code —
+ * the same discrimination `pre-merge-readiness.mts` and the A3/A4 discovery
+ * helpers already rely on. Any other status (403, rate limit, transient
+ * failure) propagates so this snapshot fails closed instead of silently
+ * treating an auth/network failure as "no required checks configured".
+ */
+function ghApiJsonOr404Empty(path, paginate) {
+  // `--jq '.[]'` (NDJSON, one array element per line) is the repo-standard
+  // paginate form — see gh-exec.mts and protocol-helpers.mts's
+  // parsePaginatedGhNdjson, reused here rather than hand-rolling a second
+  // parser. Unlike `--jq '.'`, it does not depend on gh's jq implementation
+  // staying compact-per-page; `--slurp` (a single JSON array) landed in gh
+  // v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0 via apt, so NDJSON stays
+  // the compatible default.
+  const args = paginate
+    ? ['api', path, '--paginate', '--jq', '.[]']
+    : ['api', path];
+  try {
+    const raw = ghText(
+      args,
+      paginate ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS } : {},
+    );
+    if (!paginate) {
+      const trimmed = raw.trim();
+      return trimmed ? JSON.parse(trimmed) : {};
+    }
+    return parsePaginatedGhNdjson(raw);
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return paginate ? [] : {};
+    }
+    throw error;
+  }
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/ci-wait-state.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--help]
+
+Single-shot, read-only D-phase CI snapshot: per-check status keyed by
+(checkName, workflowName), the live headRefOid, and a top-level
+required-checks rollup. Performs no writes or reruns.
+`);
+}

--- a/scripts/claim-approval-gate.mjs
+++ b/scripts/claim-approval-gate.mjs
@@ -1,0 +1,794 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/claim-approval-gate.mts
+//
+// The scripts/claim-approval-gate.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+} from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { normalizePolicyConfig } from './policy-helpers.mjs';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+
+const APPROVAL_POLICIES = new Set([
+  'owners-and-maintainers-only',
+  'all-write-permission-actors',
+]);
+const APPROVAL_POLICY_DEFAULT = 'owners-and-maintainers-only';
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const CLAIM_APPROVAL_GATE_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--token': { type: 'string' },
+  '--generated-plan-updated-at': { type: 'string' },
+  '--verbose': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+export function evaluateClaimApprovalGate(input, options = {}) {
+  const issue = normalizeIssue(input.issue);
+  const comments = normalizeComments(input.comments);
+  const timelineState = normalizeTimeline(input.timeline);
+  const policyState = normalizePolicy(input.policy);
+  const generatedPlanState = detectGeneratedPlanUpdateAt({
+    comments,
+    override: input.generatedPlanUpdatedAt,
+  });
+  const resolvePermission =
+    typeof options.resolvePermission === 'function'
+      ? options.resolvePermission
+      : () => ({
+          known: false,
+          permission: '',
+          error: 'permission resolver missing',
+        });
+  const checks = [];
+  const gateEnabled = !policyState.skipIssueAuthorApprovalGate;
+  checks.push({
+    id: 'gate_enabled',
+    name: 'Issue-author gate enabled',
+    result: gateEnabled ? 'pass' : 'fail',
+    evidence: gateEnabled
+      ? 'skipIssueAuthorApprovalGate is not true.'
+      : 'skipIssueAuthorApprovalGate=true; gate bypassed.',
+  });
+  if (!gateEnabled) {
+    return {
+      approved: true,
+      reason: 'gate-disabled',
+      gateEnabled: false,
+      policy: {
+        skipIssueAuthorApprovalGate: true,
+        maintainerApprovalActorPolicy:
+          policyState.maintainerApprovalActorPolicy,
+        approvalSignals: policyState.approvalSignals,
+        source: policyState.source,
+      },
+      checks,
+    };
+  }
+  const ambiguity = [];
+  let permissionAmbiguity = false;
+  const issueAuthor = issue.authorLogin;
+  const authorPermission = issueAuthor
+    ? normalizePermissionResult(resolvePermission(issueAuthor))
+    : { known: false, permission: '', error: 'issue author missing' };
+  const authorSelfAuthorized = isAuthorizedByPolicy(
+    authorPermission.permission,
+    policyState.maintainerApprovalActorPolicy,
+  );
+  if (!authorPermission.known) {
+    ambiguity.push('issue-author-permission-unavailable');
+    permissionAmbiguity = true;
+  }
+  checks.push({
+    id: 'author_self_authorized',
+    name: 'Issue author self-authorized',
+    result: authorSelfAuthorized ? 'pass' : 'fail',
+    evidence: authorSelfAuthorized
+      ? `Issue author ${issueAuthor} satisfies policy ${policyState.maintainerApprovalActorPolicy}.`
+      : `Issue author ${issueAuthor || '(missing)'} does not satisfy policy ${policyState.maintainerApprovalActorPolicy}.`,
+  });
+  const latestSubstantiveEditAt = resolveLatestSubstantiveEditAt(
+    issue,
+    timelineState,
+  );
+  const freshnessAnchor = maxTimestamp(
+    latestSubstantiveEditAt,
+    generatedPlanState.updatedAt,
+  );
+  const freshnessDeterminable =
+    latestSubstantiveEditAt !== null && generatedPlanState.known;
+  const readyLabelState = resolveReadyLabelApproval({
+    issue,
+    timelineState,
+    policy: policyState,
+    freshnessAnchor,
+    freshnessDeterminable,
+  });
+  if (readyLabelState.freshnessUnknown) {
+    ambiguity.push('ready-label-freshness-unavailable');
+  }
+  checks.push({
+    id: 'ready_label_present',
+    name: 'Configured ready label approval',
+    result: readyLabelState.approved ? 'pass' : 'fail',
+    evidence: readyLabelState.evidence,
+  });
+  const approvalCommentState = findLatestReadyApprovalComment({
+    comments,
+    policy: policyState.maintainerApprovalActorPolicy,
+    resolvePermission,
+  });
+  if (approvalCommentState.permissionUnknown) {
+    ambiguity.push('approval-comment-permission-unavailable');
+    permissionAmbiguity = true;
+  }
+  let readyCommentFresh = false;
+  if (
+    approvalCommentState.comment &&
+    freshnessDeterminable &&
+    freshnessAnchor
+  ) {
+    readyCommentFresh =
+      compareIso(approvalCommentState.comment.createdAt, freshnessAnchor) > 0;
+  }
+  checks.push({
+    id: 'ready_comment_fresh',
+    name: 'Fresh maintainer approval comment',
+    result: readyCommentFresh ? 'pass' : 'fail',
+    evidence: buildReadyCommentEvidence({
+      approvalCommentState,
+      freshnessDeterminable,
+      freshnessAnchor,
+    }),
+  });
+  const timelineKnown = timelineState.known;
+  if (!timelineKnown) {
+    ambiguity.push('issue-timeline-unavailable');
+  }
+  if (!generatedPlanState.known) {
+    ambiguity.push('generated-plan-freshness-unavailable');
+  }
+  const ambiguityBlocking =
+    ambiguity.length > 0 &&
+    !authorSelfAuthorized &&
+    !readyLabelState.approved &&
+    !readyCommentFresh;
+  checks.push({
+    id: 'ambiguity_guard',
+    name: 'Fail-closed ambiguity guard',
+    result: ambiguityBlocking ? 'fail' : 'pass',
+    evidence: ambiguityBlocking
+      ? `Approval state is ambiguous: ${ambiguity.join(', ')}`
+      : ambiguity.length > 0
+        ? `Ambiguity present but bypassed by explicit/author approval: ${ambiguity.join(', ')}`
+        : 'No ambiguity detected.',
+  });
+  const approved =
+    authorSelfAuthorized ||
+    readyLabelState.approved ||
+    (readyCommentFresh && !ambiguityBlocking);
+  return {
+    approved,
+    reason: deriveReason({
+      approved,
+      authorSelfAuthorized,
+      readyLabelApproved: readyLabelState.approved,
+      readyLabelFreshnessUnknown: readyLabelState.freshnessUnknown,
+      readyCommentFresh,
+      hasAuthorizedReadyComment: Boolean(approvalCommentState.comment),
+      ambiguityBlocking,
+      permissionAmbiguity,
+      freshnessDeterminable,
+    }),
+    gateEnabled: true,
+    policy: {
+      skipIssueAuthorApprovalGate: false,
+      maintainerApprovalActorPolicy: policyState.maintainerApprovalActorPolicy,
+      approvalSignals: policyState.approvalSignals,
+      source: policyState.source,
+    },
+    checks,
+  };
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.token) {
+    process.env.GH_TOKEN = args.token;
+    process.env.GITHUB_TOKEN = args.token;
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repoRef = `${owner}/${repo}`;
+  const issue = ghJson(['api', `repos/${repoRef}/issues/${args.issue}`]);
+  const comments = ghApiJson(
+    `repos/${repoRef}/issues/${args.issue}/comments`,
+    true,
+  );
+  const timelineState = fetchIssueTimeline(repoRef, args.issue ?? 0);
+  const policy = loadPolicy(args.policy);
+  const permissionCache = new Map();
+  const resolvePermission = (login) =>
+    resolveCollaboratorPermission({
+      owner,
+      repo,
+      login,
+      cache: permissionCache,
+    });
+  const result = evaluateClaimApprovalGate(
+    {
+      issue,
+      comments,
+      timeline: timelineState.events,
+      policy: policy.config,
+      generatedPlanUpdatedAt: args.generatedPlanUpdatedAt,
+    },
+    { resolvePermission },
+  );
+  const output = {
+    repository: { owner, repo },
+    issue: {
+      number: Number.parseInt(String(issue.number), 10),
+      title: String(issue.title ?? ''),
+      state: String(issue.state ?? ''),
+      url: String(issue.html_url ?? issue.url ?? ''),
+      author: String(issue.user?.login ?? ''),
+    },
+    approved: result.approved,
+    reason: result.reason,
+    gateEnabled: result.gateEnabled,
+    policy: result.policy,
+    checks: args.verbose
+      ? result.checks
+      : result.checks.map((check) => ({
+          id: check.id,
+          name: check.name,
+          result: check.result,
+        })),
+    timelineAvailable: timelineState.known,
+    timelineParseError: timelineState.parseError,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, CLAIM_APPROVAL_GATE_FLAG_SPEC);
+  const issueToken = values.issue;
+  return {
+    // Kept as lenient Number.parseInt (not the canonical-integer helper),
+    // matching the pre-migration contract exactly: this file's own
+    // "!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0" post-check
+    // (in runCli, unchanged) already rejects a non-canonical result, so
+    // tightening at this layer would be an untested, out-of-scope
+    // behavior change for this behavior-preserving migration (see #1451).
+    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    policy: values.policy ?? '',
+    token: values.token ?? '',
+    generatedPlanUpdatedAt: values['generated-plan-updated-at'] ?? '',
+    verbose: values.verbose,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/claim-approval-gate.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--generated-plan-updated-at <ISO8601>] [--verbose]
+
+Output schema:
+{
+  "repository": {"owner": "...", "repo": "..."},
+  "issue": {"number": 393, "title": "...", "state": "OPEN", "url": "...", "author": "..."},
+  "approved": true,
+  "reason": "gate-disabled|author-self-authorized|ready-label-present|ready-comment-fresh|approval-missing|approval-ambiguous|approval-comment-stale|freshness-undetermined",
+  "gateEnabled": true,
+  "policy": {"skipIssueAuthorApprovalGate": false, "maintainerApprovalActorPolicy": "owners-and-maintainers-only", "approvalSignals": {"readyLabelName": "idd:ready", "labelFreshnessMode": "presence-only"}, "source": ".github/idd/config.json"},
+  "checks": [{"id":"gate_enabled","name":"Issue-author gate enabled","result":"pass|fail","evidence":"..."}],
+  "timelineAvailable": true
+}
+`);
+}
+function normalizeIssue(issue) {
+  const i = issue;
+  return {
+    authorLogin: String(i?.user?.login ?? '')
+      .trim()
+      .toLowerCase(),
+    labels: normalizeLabels(i?.labels),
+    createdAt: normalizeIso(i?.created_at),
+    updatedAt: normalizeIso(i?.updated_at),
+  };
+}
+function normalizeLabels(labels) {
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+  return labels
+    .map((label) => (typeof label === 'string' ? label : (label?.name ?? '')))
+    .map((label) => String(label).trim().toLowerCase())
+    .filter(Boolean);
+}
+function normalizeComments(comments) {
+  if (!Array.isArray(comments)) {
+    return [];
+  }
+  return comments
+    .map((comment) => ({
+      authorLogin: String(comment?.user?.login ?? '')
+        .trim()
+        .toLowerCase(),
+      body: String(comment?.body ?? ''),
+      createdAt: normalizeIso(comment?.created_at),
+    }))
+    .filter((comment) => comment.createdAt !== null);
+}
+function normalizeTimeline(timeline) {
+  if (!Array.isArray(timeline)) {
+    return { known: false, events: [] };
+  }
+  return { known: true, events: timeline };
+}
+function normalizePolicy(policy) {
+  const normalized = normalizePolicyConfig(policy);
+  return {
+    skipIssueAuthorApprovalGate: normalized.skipIssueAuthorApprovalGate,
+    maintainerApprovalActorPolicy: APPROVAL_POLICIES.has(
+      normalized.maintainerApprovalActorPolicy,
+    )
+      ? normalized.maintainerApprovalActorPolicy
+      : APPROVAL_POLICY_DEFAULT,
+    approvalSignals: {
+      readyLabelName: String(normalized.approvalSignals.readyLabelName ?? '')
+        .trim()
+        .toLowerCase(),
+      labelFreshnessMode: String(
+        normalized.approvalSignals.labelFreshnessMode ?? 'presence-only',
+      ),
+    },
+    source: String(policy?.source ?? '.github/idd/config.json'),
+  };
+}
+function resolveReadyLabelApproval({
+  issue,
+  timelineState,
+  policy,
+  freshnessAnchor,
+  freshnessDeterminable,
+}) {
+  const readyLabelName = policy.approvalSignals.readyLabelName;
+  const labelDisplayName = readyLabelName || 'idd:ready';
+  const hasReadyLabel = issue.labels.includes(readyLabelName);
+  if (!hasReadyLabel) {
+    return {
+      approved: false,
+      present: false,
+      freshnessUnknown: false,
+      evidence: `Configured ready label ${labelDisplayName} is absent.`,
+    };
+  }
+  if (policy.approvalSignals.labelFreshnessMode !== 'event-freshness') {
+    return {
+      approved: true,
+      present: true,
+      freshnessUnknown: false,
+      evidence: `Configured ready label ${labelDisplayName} is present; labelFreshnessMode=presence-only.`,
+    };
+  }
+  if (!timelineState.known) {
+    return {
+      approved: false,
+      present: true,
+      freshnessUnknown: true,
+      evidence: `Configured ready label ${labelDisplayName} is present, but the issue timeline is unavailable for label freshness checks.`,
+    };
+  }
+  if (!freshnessDeterminable || !freshnessAnchor) {
+    return {
+      approved: false,
+      present: true,
+      freshnessUnknown: true,
+      evidence: `Configured ready label ${labelDisplayName} is present, but the freshness anchor could not be determined.`,
+    };
+  }
+  const latestLabelEvent = findLatestReadyLabelEvent(
+    timelineState.events,
+    readyLabelName,
+  );
+  if (latestLabelEvent?.event !== 'labeled') {
+    return {
+      approved: false,
+      present: true,
+      freshnessUnknown: true,
+      evidence: `Configured ready label ${labelDisplayName} is present, but no matching label application event was found in the issue timeline.`,
+    };
+  }
+  const fresh = compareIso(latestLabelEvent.createdAt, freshnessAnchor) > 0;
+  return {
+    approved: fresh,
+    present: true,
+    freshnessUnknown: false,
+    evidence: `Configured ready label ${labelDisplayName} was last applied at ${latestLabelEvent.createdAt}; freshness anchor is ${freshnessAnchor}.`,
+  };
+}
+function detectGeneratedPlanUpdateAt({ comments, override }) {
+  const overrideIso = normalizeIso(override);
+  if (override && !overrideIso) {
+    return { known: false, updatedAt: null };
+  }
+  if (overrideIso) {
+    return { known: true, updatedAt: overrideIso };
+  }
+  if (!Array.isArray(comments)) {
+    return { known: false, updatedAt: null };
+  }
+  const generatedPlanComments = comments
+    .filter((comment) => /\bgenerated[- ]plan\b/i.test(comment.body))
+    .map((comment) => comment.createdAt)
+    .filter(Boolean);
+  return { known: true, updatedAt: maxTimestamp(...generatedPlanComments) };
+}
+function resolveLatestSubstantiveEditAt(issue, timelineState) {
+  if (!timelineState.known) {
+    return null;
+  }
+  const editedAt = timelineState.events
+    .filter((event) => String(event?.event ?? '') === 'edited')
+    .filter((event) => event?.changes?.title || event?.changes?.body)
+    .map((event) => normalizeIso(event?.created_at))
+    .filter(Boolean);
+  return maxTimestamp(issue.createdAt, ...editedAt);
+}
+function findLatestReadyLabelEvent(events, readyLabelName) {
+  if (!Array.isArray(events)) {
+    return null;
+  }
+  const relevant = events
+    .map((event) => ({
+      event: String(event?.event ?? '')
+        .trim()
+        .toLowerCase(),
+      labelName: normalizeLabelName(event?.label),
+      createdAt: normalizeIso(event?.created_at),
+    }))
+    .filter((event) => event.createdAt !== null)
+    .filter((event) => event.event === 'labeled' || event.event === 'unlabeled')
+    .filter((event) => event.labelName === readyLabelName)
+    .sort((left, right) => compareIso(left.createdAt, right.createdAt));
+  return relevant.length > 0 ? relevant[relevant.length - 1] : null;
+}
+function normalizeLabelName(value) {
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase();
+  }
+  return String(value?.name ?? '')
+    .trim()
+    .toLowerCase();
+}
+function findLatestReadyApprovalComment({
+  comments,
+  policy,
+  resolvePermission,
+}) {
+  const readyCandidates = comments.filter((comment) =>
+    hasReadySignal(comment.body),
+  );
+  let permissionUnknown = false;
+  const authorized = [];
+  for (const candidate of readyCandidates) {
+    const permission = normalizePermissionResult(
+      resolvePermission(candidate.authorLogin),
+    );
+    if (!permission.known) {
+      permissionUnknown = true;
+      continue;
+    }
+    if (isAuthorizedByPolicy(permission.permission, policy)) {
+      authorized.push(candidate);
+    }
+  }
+  authorized.sort((left, right) => compareIso(left.createdAt, right.createdAt));
+  return {
+    comment: authorized.length > 0 ? authorized[authorized.length - 1] : null,
+    permissionUnknown,
+    totalCandidates: readyCandidates.length,
+  };
+}
+function hasReadySignal(body) {
+  const trimmed = String(body ?? '').trim();
+  if (trimmed === 'IDD ready') {
+    return true;
+  }
+  return String(body ?? '')
+    .split(/\r?\n/)
+    .some((line) => line.trim() === 'IDD ready');
+}
+function buildReadyCommentEvidence({
+  approvalCommentState,
+  freshnessDeterminable,
+  freshnessAnchor,
+}) {
+  if (!approvalCommentState.comment) {
+    return approvalCommentState.totalCandidates > 0
+      ? 'Ready comments exist but none came from an authorized actor.'
+      : 'No standalone IDD ready comment found.';
+  }
+  if (!freshnessDeterminable || !freshnessAnchor) {
+    return 'Ready comment found, but freshness anchor could not be determined.';
+  }
+  return `Latest authorized ready comment at ${approvalCommentState.comment.createdAt}; freshness anchor is ${freshnessAnchor}.`;
+}
+function deriveReason(state) {
+  if (!state.approved) {
+    if (state.permissionAmbiguity) {
+      return 'approval-ambiguous';
+    }
+    if (state.readyLabelFreshnessUnknown) {
+      return 'freshness-undetermined';
+    }
+    if (!state.freshnessDeterminable) {
+      return 'freshness-undetermined';
+    }
+    if (state.ambiguityBlocking) {
+      return 'approval-ambiguous';
+    }
+    if (state.hasAuthorizedReadyComment && state.readyCommentFresh === false) {
+      return 'approval-comment-stale';
+    }
+    return 'approval-missing';
+  }
+  if (state.authorSelfAuthorized) {
+    return 'author-self-authorized';
+  }
+  if (state.readyLabelApproved) {
+    return 'ready-label-present';
+  }
+  if (state.readyCommentFresh) {
+    return 'ready-comment-fresh';
+  }
+  return 'gate-disabled';
+}
+function isAuthorizedByPolicy(permission, policy) {
+  if (policy === 'all-write-permission-actors') {
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  }
+  return permission === 'admin' || permission === 'maintain';
+}
+function normalizePermissionResult(value) {
+  if (!value || typeof value !== 'object') {
+    return { known: false, permission: '', error: 'invalid permission result' };
+  }
+  const v = value;
+  const permission = String(v.permission ?? '')
+    .trim()
+    .toLowerCase();
+  return {
+    known: Boolean(v.known),
+    permission,
+    error: String(v.error ?? ''),
+  };
+}
+function normalizeIso(value) {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+function compareIso(left, right) {
+  const leftTime = new Date(left).getTime();
+  const rightTime = new Date(right).getTime();
+  if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
+    return 0;
+  }
+  return leftTime - rightTime;
+}
+function maxTimestamp(...values) {
+  const normalized = values
+    .filter(Boolean)
+    .map((value) => normalizeIso(value))
+    .filter((value) => value !== null);
+  if (normalized.length === 0) {
+    return null;
+  }
+  normalized.sort(compareIso);
+  return normalized[normalized.length - 1];
+}
+function fetchIssueTimeline(repoRef, issueNumber) {
+  try {
+    const events = ghApiJson(
+      `repos/${repoRef}/issues/${issueNumber}/timeline`,
+      true,
+      ['-H', 'Accept: application/vnd.github+json'],
+    );
+    return { known: true, events, parseError: '' };
+  } catch (error) {
+    // #1692: a `SyntaxError` means the gh call itself succeeded but its
+    // output could not be parsed -- a bug, not a legitimate "timeline
+    // unavailable" case (missing issue, permission denial, network
+    // failure, all of which throw from `runGh` before parsing is ever
+    // reached). Surface it via `parseError` instead of silently
+    // collapsing into the same `known: false` shape a genuine absence
+    // produces, so it stays visible in the CLI's JSON output rather than
+    // being indistinguishable from "no timeline data".
+    const parseError = error instanceof SyntaxError ? error.message : '';
+    return { known: false, events: [], parseError };
+  }
+}
+function resolveCollaboratorPermission({ owner, repo, login, cache }) {
+  const normalized = String(login ?? '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) {
+    return { known: false, permission: '', error: 'empty login' };
+  }
+  const cached = cache.get(normalized);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = ghApiJsonWithStatus(
+    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalized)}/permission`,
+  );
+  if (result.status === 404) {
+    const notCollaborator = {
+      known: true,
+      permission: 'none',
+      error: '',
+    };
+    cache.set(normalized, notCollaborator);
+    return notCollaborator;
+  }
+  if (result.status !== 200) {
+    const unknownResult = {
+      known: false,
+      permission: '',
+      error: `permission lookup failed: ${result.status}`,
+    };
+    cache.set(normalized, unknownResult);
+    return unknownResult;
+  }
+  const permission = String(result.body?.permission ?? '')
+    .trim()
+    .toLowerCase();
+  const known = permission.length > 0;
+  const resolved = {
+    known,
+    permission,
+    error: known ? '' : 'permission missing in response',
+  };
+  cache.set(normalized, resolved);
+  return resolved;
+}
+// Read-and-parse failure semantics (explicit path throws; default path
+// silently falls back only on ENOENT) are converged in idd-config.mts's
+// loadPolicyConfig (#1721); this helper keeps its own shape normalization —
+// normalizePolicyConfig's full defaults on a missing/absent config, and the
+// `source` field embedded in `config` so normalizePolicy() (below) can read
+// it back out of the value evaluateClaimApprovalGate receives.
+function loadPolicy(policyPath) {
+  const { path: source, config: rawConfig } = loadPolicyConfig(policyPath);
+  const normalized = normalizePolicyConfig(rawConfig);
+  return {
+    source,
+    config: {
+      ...normalized,
+      source,
+    },
+  };
+}
+function ghApiJson(path, paginate = false, extraArgs = []) {
+  const args = ['api', path, ...extraArgs];
+  // #1692: `--jq '.[]'` (not a bare `--paginate`) makes gh emit one JSON
+  // value per line, guaranteed newline-separated, for every element across
+  // every page. Without it, a whole-stdout `JSON.parse` (the prior
+  // behavior here) broke on any multi-page response -- `--paginate` alone
+  // concatenates each page's whole-array response, with no separator
+  // guaranteed on gh 2.45.0 (this repo's documented compatibility floor).
+  // Matches the NDJSON convention `gh-exec.mts`'s shared `ghApiJson` uses.
+  if (paginate) {
+    args.push('--paginate', '--jq', '.[]');
+  }
+  const raw = runGh(args, paginate).trim();
+  if (paginate) {
+    return parsePaginatedGhNdjson(raw);
+  }
+  return JSON.parse(raw || '[]');
+}
+function ghApiJsonWithStatus(path) {
+  try {
+    const body = JSON.parse(runGh(['api', path]).trim() || '{}');
+    return { status: 200, body };
+  } catch (error) {
+    // #1693: derive the real HTTP status via the shared gh-http-status.mts
+    // helper instead of grepping stderr only with a bespoke `/HTTP\s+(\d+)/`
+    // pattern -- that missed the JSON-error-body-in-stdout fallback
+    // deriveGhHttpStatus already applies (stdout now survives runGh's error
+    // wrapping too; see wrapGhError below). `0` preserves this function's
+    // existing "status could not be determined" sentinel (unchanged
+    // downstream contract: callers already treat any non-200/404 status,
+    // including 0, as "permission lookup failed").
+    const status = deriveGhHttpStatus(error);
+    return { status: status ?? 0, body: null };
+  }
+}
+function ghJson(args) {
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+/**
+ * Pure wrap step for {@link runGh}'s catch branch, exported so tests can
+ * inject a raw execFileSync-shaped error directly instead of shelling out
+ * to a real `gh` invocation (matching the mock-free-subprocess convention
+ * documented in `tests/collaborator-permission.test.mts`).
+ *
+ * When stderr is present, wraps it into a fresh Error carrying both
+ * `.stderr` and `.stdout`. #1693: the previous wrap carried `.stderr` only,
+ * which silently dropped `.stdout` and defeated `deriveGhHttpStatus`'s
+ * JSON-error-body-in-stdout fallback for every caller downstream of
+ * `runGh` (this file's `ghApiJsonWithStatus`) -- `gh api` can print a JSON
+ * error body to stdout even as it writes its human-readable diagnostic to
+ * stderr. When stderr is empty, returns the original error unchanged: the
+ * raw execFileSync error already carries `.stdout`/`.stderr`/`.status`
+ * natively, so wrapping would only lose information.
+ */
+export function wrapGhError(error) {
+  const stderr = String(error?.stderr ?? '').trim();
+  if (!stderr) {
+    return error;
+  }
+  const stdout = String(error?.stdout ?? '').trim();
+  const wrapped = new Error(`gh command failed: ${stderr}`);
+  wrapped.stderr = stderr;
+  wrapped.stdout = stdout;
+  return wrapped;
+}
+function runGh(args, paginate = false) {
+  try {
+    return ghText(args, {
+      ...GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ...(paginate ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS } : {}),
+    });
+  } catch (error) {
+    throw wrapGhError(error);
+  }
+}

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/claim-lock.mts
+//
+// The scripts/claim-lock.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Worktree-local lock file: a same-machine fast path that complements the
+// cross-machine activation-nonce claim check (#1522). The lock never judges
+// staleness itself -- GitHub claim state stays the sole authority. A
+// different-claim-id lock is always a collision; only an explicit
+// `--takeover`, issued after the caller independently re-verifies live
+// GitHub claim state (`resume-claim-routing.mjs --fresh-claim-gate`), may
+// override it. This deliberately excludes any local liveness signal (e.g.
+// process PID): under this repository's execution model, the process
+// invoking this CLI is a one-shot child that exits the moment the call
+// returns, so a recorded PID would be a tombstone before any competing
+// session could ever observe it as "alive" -- checking it would silently
+// defeat the very collision this lock exists to catch. See `## Claim
+// revalidation gate` in idd-overview-core.instructions.md for the full
+// protocol this helper implements (#1523).
+//
+// Re-acquiring a matching claim-id is read-only (no write at all): a
+// same-claim-id "reacquire" only needs to confirm nobody else took over,
+// never to refresh anything on disk (`acquiredAt` is audit-only -- no code
+// path here reads it back to make a decision). An earlier revision deleted
+// and recreated the file on every reacquire, which opened a window where an
+// unrelated, unauthorized different-claim-id session could slip through a
+// fresh `wx` create as if nobody held the lock -- exactly the collision
+// this lock exists to catch. Making reacquire read-only removes that window
+// entirely on the common fast path. The only path that still writes over an
+// existing lock is an authorized `--takeover`, and it replaces the file via
+// a same-directory temp-write + `renameSync` rather than unlink-then-create.
+// POSIX replaces an existing regular file atomically; Windows requires that
+// regular file to be removed before the rename, so that platform-specific
+// fallback necessarily leaves a brief gap. A malformed directory at the lock
+// path is the other recovery exception: an authorized takeover removes that
+// exact directory before installing the replacement.
+//
+// This lock intentionally does not try to perfectly serialize two
+// concurrent authorized takeovers of the same worktree -- that is a much
+// narrower race than the collision above, and the claim revalidation gate
+// (re-reading the GitHub claim-id before every mutation, independent of this
+// lock) is the real authority there: GitHub claim parsing is deterministic,
+// so only one concurrent takeover's claim-id can actually be the active one,
+// regardless of what this local lock file happens to contain.
+import { execFileSync } from 'node:child_process';
+import {
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+
+const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
+const MAX_RETRY_ATTEMPTS = 5;
+const CLAIM_LOCK_FLAG_SPEC = {
+  '--acquire': { type: 'boolean' },
+  '--check': { type: 'boolean' },
+  '--worktree': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--claim-id': { type: 'string' },
+  '--takeover': { type: 'boolean' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * Keep repository discovery tied to the requested worktree rather than to
+ * ambient Git overrides inherited from a hook, wrapper, or parent process.
+ * Config override variables are cleared as well so a caller cannot redirect
+ * repository discovery through an injected config path or parameter. Git's
+ * normal system/global config remains available because it may contain a
+ * required `safe.directory` exception for shared or mounted worktrees.
+ */
+function sanitizedGitEnvironment() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  return env;
+}
+/**
+ * Resolve the lock file's path inside `worktree`'s own private git-admin
+ * directory (`git rev-parse --absolute-git-dir`), never a literal
+ * `.git/idd-claim.lock` — inside a linked worktree, `.git` is a *file*
+ * (a `gitdir:` pointer), not a directory, so that literal path would throw
+ * `ENOTDIR`. Using the worktree's own admin dir also means `git worktree
+ * remove` deletes the lock together with the worktree, with no separate
+ * cleanup step required.
+ */
+export function resolveClaimLockPath(worktree) {
+  const gitDir = execFileSync(
+    'git',
+    ['-C', worktree, 'rev-parse', '--absolute-git-dir'],
+    { encoding: 'utf8', env: sanitizedGitEnvironment() },
+  ).trim();
+  return join(gitDir, CLAIM_LOCK_FILE_NAME);
+}
+function isClaimLockBody(value) {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.agentId === 'string' &&
+    typeof value.claimId === 'string' &&
+    typeof value.acquiredAt === 'string'
+  );
+}
+function readLock(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { status: 'absent' };
+    }
+    // Any other read failure means the path cannot be trusted as absent or
+    // valid (for example EACCES/EPERM, EISDIR, or a transient filesystem
+    // error). Fail closed as malformed so callers take the collision path
+    // instead of silently bypassing a lock they cannot inspect.
+    return { status: 'malformed' };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: 'malformed' };
+  }
+  return isClaimLockBody(parsed)
+    ? { status: 'present', lock: parsed }
+    : { status: 'malformed' };
+}
+function renderLockBody(agentId, claimId) {
+  const body = {
+    agentId,
+    claimId,
+    acquiredAt: new Date().toISOString(),
+  };
+  return JSON.stringify(body);
+}
+/**
+ * Replace `path` with a freshly-rendered lock body. The temp file is written
+ * in the same directory as `path` (a cross-filesystem rename is not atomic),
+ * then renamed into place. POSIX `rename` onto an existing regular file is
+ * atomic, but Windows does not replace an existing destination, so a regular
+ * file must be removed before retrying the rename on that platform. A
+ * directory target is handled the same way for malformed-lock recovery.
+ * The `finally` cleans up the temp file if `renameSync` throws, so a failed
+ * replace never leaks it.
+ */
+function overwriteLockAtomically(path, agentId, claimId) {
+  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(tmpPath, renderLockBody(agentId, claimId), { flag: 'wx' });
+  try {
+    try {
+      renameSync(tmpPath, path);
+    } catch (error) {
+      let targetKind = 'unavailable';
+      try {
+        targetKind = statSync(path).isDirectory() ? 'directory' : 'other';
+      } catch {
+        // Preserve the original rename error when the target disappeared or
+        // cannot be inspected safely.
+      }
+      if (targetKind === 'unavailable') {
+        throw error;
+      }
+      if (targetKind === 'other') {
+        // Windows does not let rename replace an existing regular file. Keep
+        // the operation scoped to the exact target and retry the
+        // same-directory rename. The brief absence is unavoidable on that
+        // platform; the caller's GitHub claim gate remains authoritative.
+        rmSync(path, { force: true });
+        renameSync(tmpPath, path);
+        return;
+      }
+      rmSync(path, { recursive: true, force: true });
+      renameSync(tmpPath, path);
+    }
+  } finally {
+    // Best-effort cleanup only: a successful rename already moved tmpPath
+    // away (this is a no-op ENOENT), and a failed rename's own error is
+    // what the caller needs to see, so any cleanup failure here is
+    // deliberately swallowed rather than masking that original error.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+/**
+ * Acquire (or idempotently re-acquire) the worktree-local claim lock.
+ * Safe to call before every mutation, not just once at worktree creation.
+ *
+ * A matching `claimId` is a pure read: it confirms nobody else holds the
+ * lock and returns `acquired`/`reacquired` without writing anything (the
+ * fast path — no GitHub round-trip, and no window where the lock briefly
+ * disappears). A different `claimId` is always a `collision` unless
+ * `takeover` is set, regardless of how long the lock has existed: the
+ * configured GitHub `claim-stale-age` is the sole staleness authority, so the caller must
+ * independently re-verify live claim state (e.g.
+ * `resume-claim-routing.mjs --fresh-claim-gate`) before retrying with
+ * `takeover: true`.
+ */
+export function acquireClaimLock(worktree, agentId, claimId, takeover) {
+  const path = resolveClaimLockPath(worktree);
+  for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt += 1) {
+    const read = readLock(path);
+    if (read.status === 'present' && read.lock.claimId === claimId) {
+      return { mode: 'acquired', path, reacquired: true };
+    }
+    if (read.status === 'absent') {
+      try {
+        writeFileSync(path, renderLockBody(agentId, claimId), { flag: 'wx' });
+        return { mode: 'acquired', path };
+      } catch (error) {
+        if (error.code !== 'EEXIST') {
+          throw error;
+        }
+        // Raced with a concurrent fresh acquire between the read above and
+        // this create; loop around to re-read and re-decide.
+        continue;
+      }
+    }
+    // Either a different claim-id, or a malformed body whose holder can't
+    // be determined safely: always a same-machine collision either way.
+    // Local state (including how old the lock is) never authorizes an
+    // override — only an explicit, GitHub-reverified `takeover` may.
+    const holder = read.status === 'present' ? read.lock : undefined;
+    if (!takeover) {
+      return { mode: 'collision', path, holder };
+    }
+    overwriteLockAtomically(path, agentId, claimId);
+    return { mode: 'acquired', path, forcedTakeover: true, holder };
+  }
+  // Exhausted retries on the narrow absent-then-raced-create loop above.
+  // Re-read once after the final EEXIST so a well-formed winner is reported
+  // to the caller instead of being returned as an unexplained collision. If
+  // the winner disappeared before this read, make one last create attempt so
+  // a transiently absent lock is not reported as a false collision.
+  const finalRead = readLock(path);
+  if (finalRead.status === 'present' && finalRead.lock.claimId === claimId) {
+    return { mode: 'acquired', path, reacquired: true };
+  }
+  if (finalRead.status === 'absent') {
+    try {
+      writeFileSync(path, renderLockBody(agentId, claimId), { flag: 'wx' });
+      return { mode: 'acquired', path };
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error;
+      }
+      const racedRead = readLock(path);
+      if (
+        racedRead.status === 'present' &&
+        racedRead.lock.claimId === claimId
+      ) {
+        return { mode: 'acquired', path, reacquired: true };
+      }
+      return {
+        mode: 'collision',
+        path,
+        holder: racedRead.status === 'present' ? racedRead.lock : undefined,
+      };
+    }
+  }
+  return {
+    mode: 'collision',
+    path,
+    holder: finalRead.status === 'present' ? finalRead.lock : undefined,
+  };
+}
+/** Read-only lock inspection: never creates, mutates, or deletes the lock. */
+export function checkClaimLock(worktree) {
+  const path = resolveClaimLockPath(worktree);
+  const read = readLock(path);
+  if (read.status === 'absent') {
+    return { path, present: false };
+  }
+  if (read.status === 'malformed') {
+    return { path, present: true, malformed: true };
+  }
+  return { path, present: true, holder: read.lock };
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, CLAIM_LOCK_FLAG_SPEC);
+  return {
+    acquire: Boolean(values.acquire),
+    check: Boolean(values.check),
+    worktree: typeof values.worktree === 'string' ? values.worktree : null,
+    agentId: typeof values['agent-id'] === 'string' ? values['agent-id'] : null,
+    claimId: typeof values['claim-id'] === 'string' ? values['claim-id'] : null,
+    takeover: Boolean(values.takeover),
+    help,
+  };
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.acquire === args.check) {
+    throw new Error('exactly one of --acquire or --check is required');
+  }
+  if (args.worktree === null) {
+    throw new Error('--worktree is required');
+  }
+  if (args.check) {
+    process.stdout.write(`${JSON.stringify(checkClaimLock(args.worktree))}\n`);
+    return;
+  }
+  if (args.agentId === null) {
+    throw new Error('--agent-id is required for --acquire');
+  }
+  if (args.claimId === null) {
+    throw new Error('--claim-id is required for --acquire');
+  }
+  const outcome = acquireClaimLock(
+    args.worktree,
+    args.agentId,
+    args.claimId,
+    args.takeover,
+  );
+  process.stdout.write(`${JSON.stringify(outcome)}\n`);
+  if (outcome.mode === 'collision') {
+    process.exitCode = 2;
+  }
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id <id> --claim-id <id> [--takeover]
+  node scripts/claim-lock.mjs --check --worktree <path>
+
+Worktree-local lock file: a same-machine fast path that complements the
+cross-machine activation-nonce claim check. Resolves the lock file inside
+<path>'s own private git-admin directory (\`git rev-parse
+--absolute-git-dir\`), so \`git worktree remove\` deletes it together with
+the worktree -- no separate release step is needed.
+
+--acquire is idempotent for a matching --claim-id: it re-acquires
+(confirms nobody else holds it) as a pure read, with no write and no GitHub
+round-trip -- this is the fast path used before every mutation. A different
+--claim-id is always reported as a collision, regardless of how old the
+existing lock is: this helper never judges staleness locally. Pass
+--takeover only after independently re-verifying live GitHub claim state
+(e.g. via \`resume-claim-routing.mjs --fresh-claim-gate\` reporting
+\`claimable\` or \`stale-reclaimable\`) to override a collision; \`holder\`
+in the JSON output reports the previous occupant on both a plain collision
+and an authorized takeover.
+
+--check is read-only: it reports the current lock state without creating,
+mutating, or deleting anything. \`malformed: true\` means a lock file
+exists but could not be parsed as a well-formed lock body.
+`);
+}

--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -1,0 +1,331 @@
+// idd-generated-from: src/scripts/cli-args.mts
+//
+// The scripts/cli-args.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Shared node:util parseArgs wrapper (#1446). Owns the tail every
+// hand-rolled CLI parser in this repository re-implements: strict flag
+// parsing, the repo's established error-message shape, and canonical
+// positive/non-negative integer coercion with both contracts (throw /
+// resolve-to-null) that exist across the existing parsers.
+//
+// Design invariants a caller MUST follow (see #1446's settled review):
+//
+// 1. **Flag-spec keys stay the dashed literal** (e.g. a spec entry shaped
+//    like --pr: { type: 'string' }), never a bare key (pr: {...}).
+//    `tests/flag-name-matrix.test.mts` scans each helper's own *compiled*
+//    .mjs source text for each canonical flag written as a quoted string
+//    literal -- the only net under ~30 parsers with no parse-level tests.
+//    A bare-key spec would still parse correctly at runtime but silently
+//    vanish from that guard. This wrapper strips the leading `--` only
+//    internally, right before calling `util.parseArgs` -- never at the
+//    caller's spec-declaration site. (This module's own comments avoid
+//    writing example flag names inside matching quote marks, on purpose:
+//    doing so would let a comment mask a real rename of that same flag
+//    in a file the guard scans -- see #1446's PR description.)
+// 2. **Define each spec object locally, inside the helper's own .mts
+//    file** -- never centralize specs into this module or any other
+//    shared constants file. The quoted dashed literal must physically
+//    remain in the migrated helper's own generated .mjs for the guard
+//    above to keep working; a spec that only lives here would move the
+//    literal out of the file the guard actually scans.
+//
+// Error-message shape (#1446 design lever #2 -- a free choice, since no
+// doc or instruction file depends on the exact current text): this
+// wrapper re-wraps Node's native parseArgs errors into the repository's
+// existing hand-rolled idiom (`unknown argument: --x` / `missing value
+// for argument: --x`) rather than surfacing Node's own text
+// (`ERR_PARSE_ARGS_UNKNOWN_OPTION` / "Unknown option '--x'", etc.). This
+// keeps CLI stderr output consistent across migrated and not-yet-migrated
+// helpers instead of splitting the fleet into two different error styles.
+//
+// Comma-split list-flag and enum-validation helpers (named in #1446's
+// proposed change as capabilities the wrapper should eventually own) are
+// deliberately NOT included in this first version: none of this issue's
+// three pilot call sites need them (`advisory-convergence.mts`'s
+// `--trusted-marker-logins` stays a raw string at the parseArgs layer --
+// splitting happens later in `resolveTrustedMarkerActors`), so adding them
+// now would mean tests are their only caller. Left for whichever of
+// #1450/#1451 first needs them.
+import { parseArgs as nodeParseArgs } from 'node:util';
+
+const NODE_OPTION_KEY_PATTERN = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
+/**
+ * Node's native `util.parseArgs` (`strict: true`) throws
+ * `ERR_PARSE_ARGS_INVALID_OPTION_VALUE` ("... argument is ambiguous") for
+ * `--flag VALUE` whenever VALUE starts with a single dash and could
+ * plausibly be another option -- even plainly-numeric values like `-3`
+ * (Node's own error message suggests the fix: `--flag=-XYZ`). This
+ * wrapper's own pre-migration pilots (`branch-name.mts`,
+ * `ci-wait-policy.mts`) never had this ambiguity: each had a
+ * `requireValue()`-style helper that only rejected a value starting with
+ * `--` (a long flag), always accepting a single-dash-prefixed token like
+ * `-3` as the literal value -- and `branch-name.test.mts`'s existing
+ * `'0'`/`'-3'` test requires that exact contract to keep working
+ * unchanged after migration. This is not a claim about every hand-rolled
+ * parser in the repository: at least one (`review-disposition-verify.mts`)
+ * rejects any single-dash-prefixed value, not only a `--`-prefixed one, so
+ * a future migration of that file (or a similarly-stricter one) needs its
+ * own contract check, not an assumption that this preprocessing is a
+ * drop-in behavioral match for every existing parser. Rewriting `--flag
+ * VALUE` to `--flag=VALUE` up front for
+ * every declared `string`-type flag (whenever VALUE is present and does
+ * not itself start with `--`) restores that established contract without
+ * weakening the genuine flag-shaped-value guard: a VALUE that starts with
+ * `--` (i.e. looks like another long option) is deliberately left
+ * untouched, so `['--owner', '--assert']` still reaches `util.parseArgs`
+ * unmodified and still throws.
+ *
+ * A short alias (`short: 'p'`) hits the identical two-token ambiguity for
+ * `-p -3`, rewritten the same way onto the long key's `=` form (`['-p',
+ * '-3']` becomes `['--pr=-3']`, not `['-p=-3']` -- see the next paragraph
+ * for why the short form's own `=` cannot carry it). A short token with no
+ * matching long-flag entry in `spec` is left untouched (`util.parseArgs`
+ * will report its own unknown-option or missing-value error for it, same
+ * as before this preprocessing pass existed for the long-flag case).
+ *
+ * A short alias also needs a SEPARATE, single-token rewrite Node's own
+ * `--flag=value` handling does not cover: unlike a long option, Node does
+ * NOT special-case `=` splitting for a short option at all, so `-p=5` (an
+ * entirely ordinary invocation, not just a `-3`-shaped edge case) parses
+ * to the literal value `"=5"`, not `"5"` (verified empirically) --
+ * silently wrong for common input, not merely an ambiguity throw. Every
+ * `-<short>=<value>` token whose short letter maps to a declared
+ * `string`-type flag is rewritten onto that flag's long `=` form before
+ * `util.parseArgs` ever sees it: `-p=5` becomes `--pr=5`, `-p=-3` becomes
+ * `--pr=-3`. A short letter with no matching flag entry is left untouched.
+ */
+// Matches a short option's `=value` form as ONE argv token, e.g. `-p=5`
+// or `-p=-3` -- captures the short letter and everything after `=`
+// (including an embedded `=` or a leading `-`, so `-p=-3` and `-p==` both
+// capture their full intended value).
+const SHORT_FLAG_EQUALS_PATTERN = /^-([A-Za-z])=([\s\S]*)$/;
+function disambiguateSingleDashValues(argv, spec) {
+  const stringFlags = new Set(
+    Object.entries(spec)
+      .filter(([, flagSpec]) => flagSpec.type === 'string')
+      .map(([dashedKey]) => dashedKey),
+  );
+  const shortToLong = new Map(
+    Object.entries(spec)
+      .filter(([, flagSpec]) => flagSpec.type === 'string' && flagSpec.short)
+      .map(([dashedKey, flagSpec]) => [`-${flagSpec.short}`, dashedKey]),
+  );
+  const rewritten = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    // Single-token case: `-p=VALUE`. Node only special-cases `=` splitting
+    // for LONG options; for a short option it keeps the literal `=` as
+    // part of the value (`-p=5` parses to `"=5"`, not `"5"` -- verified
+    // empirically), which is silently wrong for entirely ordinary input,
+    // not just an ambiguity edge case. Rewrite onto the long key's own
+    // (correctly `=`-splitting) form before Node ever sees it.
+    const shortEquals = SHORT_FLAG_EQUALS_PATTERN.exec(token);
+    if (shortEquals) {
+      const longKey = shortToLong.get(`-${shortEquals[1]}`);
+      if (longKey !== undefined) {
+        rewritten.push(`${longKey}=${shortEquals[2]}`);
+        continue;
+      }
+    }
+    // Two-token case: `--flag VALUE` / `-p VALUE` where VALUE starts with
+    // a single dash and could plausibly be another option.
+    const next = argv[index + 1];
+    const isAmbiguousValue =
+      typeof next === 'string' &&
+      next.startsWith('-') &&
+      !next.startsWith('--');
+    if (stringFlags.has(token) && isAmbiguousValue) {
+      rewritten.push(`${token}=${next}`);
+      index += 1;
+      continue;
+    }
+    const longKey = shortToLong.get(token);
+    if (longKey !== undefined && isAmbiguousValue) {
+      rewritten.push(`${longKey}=${next}`);
+      index += 1;
+      continue;
+    }
+    rewritten.push(token);
+  }
+  return rewritten;
+}
+/** Extract the offending flag token from a parseArgs error message. The
+ * message shape differs by error code (see the empirical cases this
+ * pattern was built against): `"Unknown option '--bogus'"`, `"Option
+ * '--pr <value>' argument missing"`, `"Option '--owner' argument is
+ * ambiguous...."`, `"Option '--assert' does not take an argument"`, and
+ * `"Unexpected argument 'stray'. ..."` (no leading dash, for a positional).
+ * A flag with a `short` alias adds a sixth shape for the "missing value"
+ * case specifically -- meaning the value is entirely absent (the flag is
+ * the last token in argv, so there is nothing left to even look ambiguous
+ * -- see the distinct "ambiguous" shape below for a present-but-suspect
+ * value): Node reports the **combined** descriptor `"Option '-p, --pr
+ * <value>' argument missing"` regardless of which of the two forms the
+ * caller actually typed (verified empirically for both) -- the long form
+ * is always preferred when both appear together in the quoted span,
+ * matching this repository's established `--flag`-only error idiom. The
+ * "ambiguous" / "does not take an argument" shapes never combine forms
+ * this way; each always echoes exactly the single token the caller typed
+ * (also verified empirically, including for a short-typed ambiguous
+ * value: `-p --assert` reports only `'-p'`, never the combined pair). */
+function extractFlagToken(message) {
+  const quoted = /'([^']*)'/.exec(message)?.[1] ?? '';
+  if (!quoted.startsWith('-')) {
+    // Not a flag-shaped quoted span (the positional-argument case). Node's
+    // "Unexpected argument '<token>'. ..." message closes the quote
+    // immediately after the exact token -- unlike the flag-missing-value
+    // shape, there is no trailing "<value>" (or anything else) sharing
+    // the same quoted span to trim off -- so the captured content is
+    // already the whole token verbatim. Return it as-is rather than
+    // splitting on whitespace/commas, which would truncate a positional
+    // that itself contains one of those characters (checked before the
+    // flag-form searches below, which otherwise risk matching an embedded
+    // hyphen inside an ordinary word, e.g. "stray-positional").
+    return quoted || '<unknown>';
+  }
+  // Flag-shaped: prefer a long form found anywhere in the span -- Node's
+  // combined "-p, --pr <value>" missing-value message (a flag declared
+  // with a `short` alias) puts the long form second -- else fall back to
+  // the leading token (a lone short or long form with no combined pair).
+  return (
+    /(--[\w-]+)/.exec(quoted)?.[1] ??
+    /^(-{1,2}[\w-]+)/.exec(quoted)?.[1] ??
+    '<unknown>'
+  );
+}
+/**
+ * Re-shape a `util.parseArgs` error into this repository's existing
+ * hand-rolled error idiom (see module header for why). Rethrows any error
+ * shape this function does not recognize unchanged, rather than risk
+ * swallowing information about an error class this wrapper was not built
+ * against.
+ */
+function toRepoShapedError(error) {
+  if (!(error instanceof Error) || typeof error.code !== 'string') {
+    throw error;
+  }
+  const err = error;
+  const token = extractFlagToken(err.message);
+  switch (err.code) {
+    case 'ERR_PARSE_ARGS_UNKNOWN_OPTION':
+    case 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL':
+      return new Error(`unknown argument: ${token}`);
+    case 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE':
+      return new Error(
+        err.message.includes('does not take an argument')
+          ? `unexpected value for argument: ${token}`
+          : `missing value for argument: ${token}`,
+      );
+    default:
+      return err;
+  }
+}
+/**
+ * Parse `argv` against a declarative flag spec, using `util.parseArgs`
+ * under `strict: true` / `allowPositionals: false`. Throws an `Error`
+ * shaped in this repository's existing idiom (never Node's native
+ * `ERR_PARSE_ARGS_*` text) on an unknown flag, a missing or ambiguous
+ * value, an unexpected value on a boolean flag, or a stray positional.
+ */
+export function parseCliArgs(argv, spec) {
+  const nodeOptions = {};
+  for (const [dashedKey, flagSpec] of Object.entries(spec)) {
+    if (!NODE_OPTION_KEY_PATTERN.test(dashedKey)) {
+      throw new Error(
+        `cli-args: flag spec key must be a dashed long-option literal (e.g. '--pr'), got: ${dashedKey}`,
+      );
+    }
+    nodeOptions[dashedKey.slice(2)] = flagSpec;
+  }
+  let parsed;
+  try {
+    parsed = nodeParseArgs({
+      args: disambiguateSingleDashValues(argv, spec),
+      options: nodeOptions,
+      strict: true,
+      allowPositionals: false,
+    });
+  } catch (error) {
+    throw toRepoShapedError(error);
+  }
+  return {
+    values: parsed.values,
+    positionals: parsed.positionals,
+    help: Boolean(parsed.values.help),
+  };
+}
+/** The repository's established canonical-integer token shape, generalized
+ * with an inclusive `min` bound: `min: 1` (the default) reproduces the
+ * established `/^[1-9]\d*$/` positive-integer guard exactly (see
+ * `branch-name.mts`'s pre-migration `parsePositiveInteger`); `min: 0`
+ * additionally accepts the single token `"0"`, needed for
+ * `ci-wait-policy.mts`'s non-negative `--rerun-count`. Never falls back to
+ * `Number.parseInt`'s lenient truncation (`"3.5"` -> 3, `"5abc"` -> 5) --
+ * the whole token must match before it is parsed. */
+const CANONICAL_INTEGER_PATTERN = /^(?:0|[1-9]\d*)$/;
+function parseCanonicalIntegerToken(token, min) {
+  if (typeof token !== 'string' || !CANONICAL_INTEGER_PATTERN.test(token)) {
+    return null;
+  }
+  const value = Number.parseInt(token, 10);
+  return value >= min ? value : null;
+}
+/**
+ * Parse a canonical integer token, throwing this repository's shaped error
+ * when `token` is missing or invalid. Use for flags whose existing
+ * contract is to fail the whole command on a bad value (e.g.
+ * `ci-wait-policy.mts`'s `--rerun-count`).
+ */
+export function parseCanonicalIntegerOrThrow(token, flagName, min = 1) {
+  const value = parseCanonicalIntegerToken(token, min);
+  if (value === null) {
+    throw new Error(`invalid value for argument: ${flagName}`);
+  }
+  return value;
+}
+/**
+ * Parse a canonical integer token, resolving to `null` when `token` is
+ * missing or invalid rather than throwing. Use for flags whose existing
+ * contract fails closed at the *caller* instead of at parse time (e.g.
+ * `advisory-convergence.mts`'s `--pr` / `--claim-issue`:
+ * "an invalid --pr resolves to null (fails closed at the caller)").
+ */
+export function parseCanonicalIntegerOrNull(token, min = 1) {
+  return parseCanonicalIntegerToken(token, min);
+}
+/**
+ * Validate that a required CLI flag's value is present and non-empty,
+ * returning it narrowed to `string`. Throws this repository's established
+ * `--flag is required` shape -- the same wording `branch-name.mts`'s
+ * `--number`/`--title` checks, `claim-lock.mts`'s `--worktree` check,
+ * `verify-install-deps.mts`'s `--key-binary`/`--install-command` checks, and
+ * many other hand-rolled parsers across `src/scripts/` already use verbatim
+ * -- when `value` is `undefined`, an empty string, or any non-string (e.g. a
+ * boolean flag's value passed where a value-flag was expected).
+ *
+ * Deliberately separate from {@link parseCliArgs}: several write-path
+ * helpers (`emit-marker.mts`, `post-idd-marker.mts`) collect a
+ * marker-type-dependent, dynamically-keyed field set that `parseCliArgs`'s
+ * static, declared spec cannot express -- see each of those files' own
+ * `parseArgs` doc comment for the full reasoning behind that exclusion. This
+ * function is the narrow, spec-free primitive those hand-rolled parsers can
+ * still reuse to report a missing required field BY NAME, instead of
+ * deferring to an aggregate downstream guard (a renderer's own payload
+ * validation) that only ever reports an unattributed "invalid ... payload"
+ * error with no indication of which flag was missing (#1722).
+ *
+ * Checks `value === ''` explicitly rather than `!value`: several required
+ * fields this function guards are numeric-looking strings that are falsy as
+ * a *number* but a perfectly valid, present string value -- e.g.
+ * `--total-item-count '0'` (emit-marker.mts / post-idd-marker.mts's
+ * watermark type). A bare `!value` truthiness check would reject that `'0'`
+ * as if the flag were missing.
+ */
+export function requireFlag(value, flagName) {
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${flagName} is required`);
+  }
+  return value;
+}

--- a/scripts/collaborator-permission.mjs
+++ b/scripts/collaborator-permission.mjs
@@ -1,0 +1,226 @@
+// idd-generated-from: src/scripts/collaborator-permission.mts
+//
+// The scripts/collaborator-permission.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Shared collaborator-permission lookups and forced-handoff authority
+// helpers consumed by:
+//
+// - scripts/forced-handoff-marker.mjs
+// - scripts/audit-pr-cleanup.mjs
+// - scripts/pre-merge-readiness.mjs
+// - scripts/live-status-digest.mjs
+// - scripts/resume-claim-routing.mjs
+//
+// Replaces the five copy-pasted implementations that drifted in
+// roadmap #745 / #748 / #754. Single source of truth so the next
+// behavioural change lands in one place rather than five.
+import { readFileSync } from 'node:fs';
+import { ghText } from './gh-exec.mjs';
+import { operationalMarkerPrefix } from './marker-helpers.mjs';
+import { normalizePolicyConfig } from './policy-helpers.mjs';
+
+const DEFAULT_POLICY_PATH = '.github/idd/config.json';
+/**
+ * Fetch a collaborator's permission triple from the GitHub
+ * collaborators-permission endpoint. Returns both the legacy
+ * `permission` field (admin|write|read|none) and the granular
+ * `role_name` (admin|maintain|write|triage|read|none or a custom
+ * repository-role name). Callers apply each policy against the field
+ * that matches its semantics — see `isAuthorizedForcedHandoffActor`.
+ *
+ * Failures (unreachable GitHub, missing collaborator, malformed JSON)
+ * are swallowed and yield empty strings so the calling policy check
+ * returns false (fail-closed).
+ *
+ * The `cache` is a per-caller Map so concurrent calls within one
+ * script share lookups, but separate scripts don't share state.
+ */
+export function collaboratorPermission(owner, repo, login, cache) {
+  const normalizedLogin = String(login ?? '')
+    .trim()
+    .toLowerCase();
+  // Scope the cache key by repository so a single Map can be safely
+  // reused across owner/repo pairs without cross-repo poisoning of
+  // authorization decisions.
+  const cacheKey = `${owner}/${repo}:${normalizedLogin}`;
+  const cached = cache?.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let permission = '';
+  let roleName = '';
+  try {
+    const raw = ghText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalizedLogin)}/permission`,
+      ],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    const parsed = JSON.parse(raw);
+    permission = String(parsed?.permission ?? '')
+      .trim()
+      .toLowerCase();
+    roleName = String(parsed?.role_name ?? '')
+      .trim()
+      .toLowerCase();
+  } catch {
+    // both stay empty
+  }
+  const result = { permission, roleName };
+  if (cache) {
+    cache.set(cacheKey, result);
+  }
+  return result;
+}
+/**
+ * Returns true when `login` is authorized to act as the `forcedBy`
+ * actor for a forced-handoff marker under the given policy:
+ *
+ *   - `owners-and-maintainers-only` (default policy semantics):
+ *     accepts `role_name == admin / maintain` and `permission == admin`
+ *     as a backstop. Maintain role recognition requires `role_name`
+ *     because the legacy `permission` field collapses maintain to
+ *     write.
+ *
+ *   - `all-write-permission-actors`: above plus `role_name == write`
+ *     and `permission == write` so custom write-base roles (whose
+ *     `role_name` may be a custom string) still satisfy the loose
+ *     policy via the legacy field.
+ */
+export function isAuthorizedForcedHandoffActor(
+  owner,
+  repo,
+  login,
+  policy,
+  cache,
+) {
+  const normalized = String(login ?? '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const { permission, roleName } = collaboratorPermission(
+    owner,
+    repo,
+    normalized,
+    cache,
+  );
+  if (policy === 'all-write-permission-actors') {
+    return (
+      roleName === 'admin' ||
+      roleName === 'maintain' ||
+      roleName === 'write' ||
+      permission === 'admin' ||
+      permission === 'write'
+    );
+  }
+  return (
+    roleName === 'admin' || roleName === 'maintain' || permission === 'admin'
+  );
+}
+/**
+ * Read `.github/idd/config.json` and return the normalized
+ * forcedHandoff policy block, falling back to schema defaults
+ * (`{ mode: "disabled", authorityPolicy: "owners-and-maintainers-only" }`)
+ * when the file is missing or malformed. Pass a custom `configPath`
+ * to read from a different location (useful for tests).
+ */
+export function readForcedHandoffPolicy(configPath = DEFAULT_POLICY_PATH) {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    raw = {};
+  }
+  const normalized = normalizePolicyConfig(raw);
+  return {
+    mode: normalized.forcedHandoff.mode,
+    authorityPolicy: normalized.forcedHandoff.authorityPolicy,
+  };
+}
+/**
+ * Convenience helper that returns the forcedHandoff mode string
+ * ("disabled" or "human-gated") from the configured policy file.
+ */
+export function readForcedHandoffMode(configPath = DEFAULT_POLICY_PATH) {
+  return readForcedHandoffPolicy(configPath).mode;
+}
+/**
+ * Convenience helper that returns the forcedHandoff authority policy
+ * string from the configured policy file.
+ */
+export function readForcedHandoffAuthorityPolicy(
+  configPath = DEFAULT_POLICY_PATH,
+) {
+  return readForcedHandoffPolicy(configPath).authorityPolicy;
+}
+/**
+ * Resolve collaborator-marker-trust logins from a comment stream:
+ * marker-authors-first (#1693). Only comment authors whose comment body is
+ * itself marker-shaped per `isMarkerShaped` (default: any recognized
+ * operational-marker prefix via `operationalMarkerPrefix`) are even
+ * candidates; only those candidates get a collaborator-permission lookup,
+ * and only Write/Maintain/Admin permission earns trust.
+ *
+ * Checking every unique comment author regardless of whether they ever
+ * posted anything marker-shaped over-trusts ordinary commenters (anyone
+ * with write+ access who merely left an unrelated comment would be treated
+ * as a trusted marker actor) and wastes a permission lookup per unique
+ * commenter. This mirrors `pre-merge-readiness.mts` /
+ * `advisory-convergence.mts`'s identically-named local function (kept
+ * local there rather than migrated here: both call `safeGhText` with
+ * `GH_TEXT_LOOP_OPTIONS` loop-safety timeouts that this shared
+ * `collaboratorPermission`-based implementation does not apply, and
+ * `advisory-wait-state.mts`'s local variant intentionally narrows the
+ * marker-shape predicate to advisory-wait markers only). New consumers
+ * (`force-handoff.mts`, `external-check-waiver.mts`) call this instead of
+ * hand-rolling a fourth/fifth "check every comment author" copy.
+ *
+ * Deliberately checks only the legacy `permission` field (admin/maintain/
+ * write), matching the sibling implementations' `--jq '.permission'`
+ * shape exactly rather than also checking `role_name` -- parity with the
+ * sibling filter is an explicit acceptance criterion, and GitHub's legacy
+ * `permission` field already collapses a `maintain` role to `write` (see
+ * `collaboratorPermission`'s doc comment above), so a `role_name` check
+ * would only widen trust, never narrow it, and would make "parity"
+ * untestable against a real HTTP response shape.
+ */
+export function resolveTrustedCollaboratorMarkerLogins(
+  owner,
+  repo,
+  comments,
+  options = {},
+) {
+  const isMarkerShaped =
+    options.isMarkerShaped ??
+    ((body) => operationalMarkerPrefix(body) !== null);
+  const markerAuthors = [
+    ...new Set(
+      comments
+        .filter((comment) => isMarkerShaped(String(comment.body ?? '')))
+        .map((comment) =>
+          String(comment.author?.login ?? comment.user?.login ?? '')
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
+    ),
+  ];
+  return markerAuthors.filter((login) => {
+    const { permission } = collaboratorPermission(
+      owner,
+      repo,
+      login,
+      options.cache,
+    );
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+}

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -1,0 +1,766 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-orphan-filter.mts
+//
+// The scripts/discover-orphan-filter.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import {
+  buildAuthoringLabelWarning,
+  resolveAuthoringGuardPolicy,
+} from './authoring-label-guard.mjs';
+import {
+  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitability,
+  rankAndRouteBySuitability,
+} from './autopilot-suitability.mjs';
+import {
+  extractBlockedByIssueNumbers,
+  extractDependencyIssueNumbers,
+  isParentEpicIssue,
+} from './discover-readiness-check.mjs';
+import {
+  annotateLeafClaimState,
+  buildClaimStateResolution,
+} from './discover-roadmap-graph.mjs';
+import { effortOrdinal, parseEffort } from './effort.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { createMarkerRegex } from './marker-regex.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+if (import.meta.main) {
+  await runCli();
+}
+/**
+ * Collect the visible `Blocked by #N` references in `body`. Delegates to the
+ * readiness composer's `extractBlockedByIssueNumbers` (#1311) instead of a
+ * second inline "Blocked by" regex, so this filter and the readiness gate
+ * share one dependency-line primitive — including its colon tolerance
+ * (`Blocked by: #123`), blockquote/list-bullet prefix tolerance, and
+ * code-region stripping.
+ */
+export function extractBlockedByReferences(body) {
+  return extractBlockedByIssueNumbers(String(body ?? ''));
+}
+export function getOrphanFirstPolicy(config) {
+  if (!config || typeof config !== 'object') {
+    return 'none';
+  }
+  const commands = config.commands;
+  if (
+    commands &&
+    typeof commands === 'object' &&
+    typeof commands['orphan-first-policy'] === 'string'
+  ) {
+    return commands['orphan-first-policy'];
+  }
+  const orphanFirstPolicy = config.orphanFirstPolicy;
+  if (typeof orphanFirstPolicy === 'string') {
+    return orphanFirstPolicy;
+  }
+  return 'none';
+}
+export function classifyIssue(issue, options) {
+  const labels = new Set(normalizeLabels(issue.labels));
+  const body = String(issue.body ?? '');
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const authoringLabelName = normalizeAuthoringLabelName(
+    options.authoringLabelName,
+  );
+  const blockedByHumanLabelName = normalizeBlockedByHumanLabelName(
+    options.blockedByHumanLabelName,
+  );
+  const needsDecisionLabelName = normalizeNeedsDecisionLabelName(
+    options.needsDecisionLabelName,
+  );
+  const roadmapMarkerRegex = createMarkerRegex(markerPrefix, 'roadmap-id');
+  const blockedMarkerRegex = createMarkerRegex(markerPrefix, 'blocked-by');
+  if (roadmapMarkerRegex.test(body)) {
+    return { orphan: false, reason: 'roadmap_marker' };
+  }
+  if (blockedMarkerRegex.test(body)) {
+    return { orphan: false, reason: 'blocked_by_marker' };
+  }
+  const blockedLabels = new Set([
+    blockedByHumanLabelName,
+    needsDecisionLabelName,
+  ]);
+  const blockedLabel = [...labels].find((label) => blockedLabels.has(label));
+  if (blockedLabel) {
+    return { orphan: false, reason: 'blocked_label', details: blockedLabel };
+  }
+  if (labels.has(authoringLabelName)) {
+    return {
+      orphan: false,
+      reason: 'authoring_label',
+      details: authoringLabelName,
+    };
+  }
+  // Two independent reference families, matching A3's own dependency check
+  // in `discover-readiness-check.mts` (#1536): visible `Blocked by #NNN`
+  // lines (a hard sequential dependency, no exemption) and `Depends on
+  // #NNN` / task-list dependency references (which exempt an open parent
+  // epic / aggregate issue, mirroring `isParentEpicIssue`). A0-O passes
+  // survivors directly to A3.5 and skips A3 entirely, so without this
+  // second family a helper-driven run could select an orphan whose only
+  // open blocker is a dependency reference, even though the roadmap path
+  // would already filter it out. `Blocked by` is checked first (matching
+  // the original single-list order) so an issue that carries both kinds
+  // reports the same `blocked_by_open_reference` / `unresolvable_reference`
+  // reason it always has when that reference alone already blocks.
+  const blockedRefs = extractBlockedByReferences(body);
+  const dependencyRefs = extractDependencyIssueNumbers(body);
+  if (blockedRefs.length === 0 && dependencyRefs.length === 0) {
+    return { orphan: true, reason: 'orphan' };
+  }
+  const unresolved = [];
+  for (const ref of blockedRefs) {
+    const state = resolveIssueState(
+      ref,
+      options.issueStateByNumber,
+      options.fetchIssueStateByNumber,
+    );
+    if ((state ?? '').toUpperCase() === 'OPEN') {
+      return {
+        orphan: false,
+        reason: 'blocked_by_open_reference',
+        details: ref,
+      };
+    }
+    if (state === 'UNRESOLVABLE') {
+      unresolved.push(ref);
+    }
+  }
+  for (const ref of dependencyRefs) {
+    const state = resolveIssueState(
+      ref,
+      options.issueStateByNumber,
+      options.fetchIssueStateByNumber,
+    );
+    if ((state ?? '').toUpperCase() === 'OPEN') {
+      if (isDependencyEpicExempt(ref, options)) {
+        continue;
+      }
+      return {
+        orphan: false,
+        reason: 'open_dependency_reference',
+        details: ref,
+      };
+    }
+    if (state === 'UNRESOLVABLE') {
+      unresolved.push(ref);
+    }
+  }
+  if (unresolved.length > 0) {
+    return {
+      orphan: false,
+      reason: 'unresolvable_reference',
+      details: [...new Set(unresolved)],
+    };
+  }
+  // Reaching here means blockedRefs/dependencyRefs was non-empty (the
+  // earlier both-empty check already returned `orphan`) and every ref
+  // resolved to a non-open, non-unresolvable state (closed, or an
+  // exempt open parent epic) -- never "no refs at all" again.
+  return { orphan: true, reason: 'blocked_references_closed' };
+}
+/**
+ * Resolve whether an **open** dependency reference is exempt as a parent
+ * epic / aggregate issue (#1536), reusing `isParentEpicIssue` from
+ * `discover-readiness-check.mts` rather than re-implementing the exemption.
+ * Only ever consulted for `Depends on` / task-list references, never for
+ * `Blocked by` references, matching A3's asymmetry. Fails closed (not
+ * exempt) when `openIssueDetailsByNumber` is absent or does not carry the
+ * referenced issue's details.
+ */
+function isDependencyEpicExempt(ref, options) {
+  const detail = options.openIssueDetailsByNumber?.get(ref);
+  if (!detail) {
+    return false;
+  }
+  return isParentEpicIssue(
+    {
+      title: String(detail.title ?? ''),
+      labels: new Set(normalizeLabels(detail.labels)),
+    },
+    normalizeRoadmapLabelName(options.roadmapLabelName),
+  );
+}
+export async function filterOrphanIssues(issues, options = {}) {
+  const issueStateByNumber = new Map(options.issueStateByNumber ?? []);
+  const fetchIssueStateByNumber =
+    typeof options.fetchIssueStateByNumber === 'function'
+      ? options.fetchIssueStateByNumber
+      : () => 'UNRESOLVABLE';
+  const filtered = {
+    roadmap_marker: [],
+    blocked_by_marker: [],
+    blocked_label: [],
+    authoring_label: [],
+    blocked_by_open_reference: [],
+    open_dependency_reference: [],
+    unresolvable_reference: [],
+  };
+  const orphans = [];
+  const unresolvable = [];
+  const warnings = [];
+  // Self-batch lookup for the dependency parent-epic exemption (#1536): in
+  // the CLI wiring `issues` is always the full open-issue batch
+  // (`fetchOpenIssues`), so any `Depends on` / task-list reference that
+  // resolves OPEN is guaranteed to already be present here — zero extra
+  // GitHub API calls. A reference outside this batch (e.g. a partial list
+  // passed directly to `filterOrphanIssues`, such as in a test) fails
+  // closed via `isDependencyEpicExempt`'s own absent-entry handling.
+  const openIssueDetailsByNumber = new Map(
+    issues.map((candidate) => [
+      candidate.number,
+      { title: candidate.title, labels: candidate.labels },
+    ]),
+  );
+  for (const issue of issues) {
+    const result = classifyIssue(issue, {
+      issueStateByNumber,
+      fetchIssueStateByNumber,
+      markerPrefix: options.markerPrefix,
+      authoringLabelName: options.authoringLabelName,
+      blockedByHumanLabelName: options.blockedByHumanLabelName,
+      needsDecisionLabelName: options.needsDecisionLabelName,
+      roadmapLabelName: options.roadmapLabelName,
+      openIssueDetailsByNumber,
+    });
+    if (result.reason === 'unresolvable_reference') {
+      for (const number of result.details ?? []) {
+        unresolvable.push({
+          issue: issue.number,
+          reference: number,
+          reason: 'issue-not-found-or-inaccessible',
+        });
+      }
+    }
+    if (result.reason === 'authoring_label') {
+      const warning = buildAuthoringLabelWarning({
+        issueNumber: issue.number,
+        labelName: result.details,
+        labelEvents: resolveIssueLabelEvents(
+          issue,
+          options.fetchLabelEventsByIssueNumber,
+        ),
+        now: options.now ?? new Date(),
+        staleAgeMs: options.authoringStaleAgeMs ?? 4 * 60 * 60 * 1000,
+      });
+      if (warning) {
+        warnings.push(warning);
+      }
+    }
+    if (result.orphan) {
+      orphans.push({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        reason: result.reason,
+        url: issue.url ?? '',
+        autopilotSuitability: parseAutopilotSuitability(
+          issue.body,
+          typeof options.markerPrefix === 'string'
+            ? options.markerPrefix
+            : undefined,
+        ),
+        effort: parseEffort(
+          issue.body,
+          typeof options.markerPrefix === 'string'
+            ? options.markerPrefix
+            : undefined,
+        ),
+      });
+      continue;
+    }
+    const entry = {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      reason: result.reason,
+      details: result.details ?? null,
+      url: issue.url ?? '',
+    };
+    filtered[result.reason].push(entry);
+  }
+  // Opt-in (#1395): annotate each orphan candidate with active-claim
+  // eligibility, mirroring `discover-roadmap-graph`'s own sequential
+  // per-leaf loop. Gated on `options.claimState` so the default path makes
+  // no extra GitHub API call and the output shape stays byte-stable. Runs
+  // before the ranking/routing split below so both the ranked `orphans` and
+  // `routed_to_human` partitions carry the annotation (they share the same
+  // object references; `rankAndRouteBySuitability` only reorders/filters).
+  if (options.claimState) {
+    const claimState = options.claimState;
+    for (const orphan of orphans) {
+      const annotated = await annotateLeafClaimState(orphan.number, claimState);
+      orphan.activeClaim = annotated.activeClaim;
+      orphan.claimEligible = annotated.claimEligible;
+    }
+  }
+  // Rank the orphan candidate list by authored autopilot-suitability
+  // score. Pre-sort by the soft effort tie-breaker (lower effort first,
+  // with a missing hint at the neutral middle) and then issue number, so
+  // the stable score sort below resolves equal scores by effort and then
+  // lowest number (the Step 2 tie-breaks) rather than by API fetch order.
+  // Below-floor routing is opt-in (autopilot runs only): in attended
+  // discovery the low-score issues stay selectable, just ranked last.
+  // Advisory throughout — the A4.5/A5 gates still run on any selected
+  // candidate, and unscored issues are never routed out (fail-safe).
+  const orphansByEffortThenNumber = [...orphans].sort(
+    (left, right) =>
+      effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
+      left.number - right.number,
+  );
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(
+    orphansByEffortThenNumber,
+    {
+      floor:
+        options.autopilotSuitabilityFloor ??
+        DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+      enabled: options.autopilotSuitabilityEnabled !== false,
+      routeBelowFloor: options.autopilot === true,
+      getScore: (orphan) => orphan.autopilotSuitability,
+    },
+  );
+  const counts = {
+    scanned: issues.length,
+    orphans: ranked.length,
+    routed_to_human: routedToHuman.length,
+    filtered: Object.fromEntries(
+      Object.entries(filtered).map(([reason, entries]) => [
+        reason,
+        entries.length,
+      ]),
+    ),
+    unresolvable: unresolvable.length,
+  };
+  return {
+    orphans: ranked,
+    routed_to_human: routedToHuman,
+    filtered,
+    unresolvable,
+    warnings,
+    counts,
+  };
+}
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repoRef = `${owner}/${repo}`;
+  const policy = loadPolicy(args.policy);
+  const openIssues = fetchOpenIssues(repoRef);
+  const openStateByNumber = new Map(
+    openIssues.map((issue) => [issue.number, String(issue.state)]),
+  );
+  // The claim-state annotation is strictly opt-in: only when
+  // --with-claim-state is passed do we build the comment loader (the sole
+  // new GitHub API surface) and resolve the trusted-actor / stale-age
+  // policy. The default path leaves `claimState` undefined, so no extra
+  // fetch is made and the output is byte-stable (mirrors
+  // discover-roadmap-graph's own CLI wiring).
+  const claimState = args.withClaimState
+    ? buildClaimStateResolution(
+        owner,
+        repo,
+        {
+          claimTiming: policy.claimTiming,
+          trustedMarkerActors: policy.trustedMarkerActors,
+        },
+        args.currentClaimId,
+      )
+    : undefined;
+  const result = await filterOrphanIssues(openIssues, {
+    issueStateByNumber: openStateByNumber,
+    fetchIssueStateByNumber: (issueNumber) =>
+      fetchIssueState(repoRef, issueNumber),
+    fetchLabelEventsByIssueNumber: (issueNumber) =>
+      fetchIssueLabelEvents(repoRef, issueNumber),
+    markerPrefix: policy.markerPrefix,
+    authoringLabelName: policy.authoringLabelName,
+    authoringStaleAgeMs: policy.authoringStaleAgeMs,
+    blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    needsDecisionLabelName: policy.needsDecisionLabelName,
+    roadmapLabelName: policy.roadmapLabelName,
+    autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
+    autopilot: args.autopilot,
+    now: args.now || new Date(),
+    claimState,
+  });
+  const output = {
+    repository: { owner, repo },
+    diagnostics: {
+      pr: args.pr,
+    },
+    policy: {
+      source: policy.source,
+      orphanFirstPolicy: policy.orphanFirstPolicy,
+      markerPrefix: policy.markerPrefix,
+      authoringLabelName: policy.authoringLabelName,
+      authoringStaleAge: policy.authoringStaleAge,
+      autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
+      autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
+    },
+    ...result,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+// Excluded from the #1446 cli-args.mts wrapper: --current-claim-id below
+// is an optional-value flag -- it may appear bare or take a following
+// value, and only consumes the next token when one is present and does
+// not itself look like another flag. `util.parseArgs` cannot express this:
+// a `string`-type option always requires exactly one value and a
+// `boolean`-type option never takes one; there is no in-between mode.
+function parseArgs(argv) {
+  const parsed = {
+    owner: '',
+    repo: '',
+    policy: '',
+    pr: null,
+    help: false,
+    now: '',
+    autopilot: false,
+    withClaimState: false,
+    currentClaimId: '',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--policy') {
+      parsed.policy = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--pr') {
+      const parsedNumber = Number.parseInt(String(value ?? ''), 10);
+      if (!Number.isInteger(parsedNumber) || parsedNumber <= 0) {
+        throw new Error(`invalid --pr value: ${value ?? ''}`);
+      }
+      parsed.pr = parsedNumber;
+      index += 1;
+      continue;
+    }
+    if (token === '--now') {
+      parsed.now = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--autopilot') {
+      parsed.autopilot = true;
+      continue;
+    }
+    if (token === '--with-claim-state') {
+      parsed.withClaimState = true;
+      continue;
+    }
+    if (token === '--current-claim-id') {
+      // Only consume the next token as the id when it exists and is not
+      // itself a flag, mirroring discover-roadmap-graph's own parsing, so
+      // `--current-claim-id --with-claim-state` does not swallow the
+      // following flag as the id. A missing/flag value leaves
+      // currentClaimId empty and the next flag is left for its own
+      // iteration.
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.currentClaimId = value;
+        index += 1;
+      }
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-orphan-filter.mjs [--owner <owner>] [--repo <repo>] [--policy <path>] [--pr <number>] [--now <ISO8601>] [--autopilot] [--with-claim-state] [--current-claim-id <id>]
+
+Output schema:
+{
+  "repository": {"owner": "...", "repo": "..."},
+  "diagnostics": {"pr": 404},
+  "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "...", "autopilotSuitabilityFloor": 3, "autopilotSuitabilityEnabled": true},
+  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null"}],
+  "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null"}],
+  "filtered": {
+    "roadmap_marker": [...],
+    "blocked_by_marker": [...],
+    "blocked_label": [...],
+    "authoring_label": [...],
+    "blocked_by_open_reference": [...],
+    "open_dependency_reference": [...],
+    "unresolvable_reference": [...]
+  },
+  "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
+  "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
+  "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
+}
+
+"filtered.open_dependency_reference" (#1536) mirrors A3's own dependency
+check in discover-readiness-check.mjs: a candidate whose body contains an
+open "Depends on #NNN" line or an open task-list "- [ ] #NNN" reference is
+excluded, UNLESS that referenced issue is itself a parent epic / aggregate
+issue (title starting with "roadmap", or carrying the configured roadmap
+label) -- matching A3's exemption exactly. This exemption never applies to
+"Blocked by #NNN" references (filtered.blocked_by_open_reference), which
+stay a hard sequential dependency with no exemption. An unresolvable
+dependency reference (issue not found or inaccessible) is treated as
+blocking, the same fail-safe "unresolvable_reference" applies to an
+unresolvable "Blocked by" reference.
+
+orphans are always ranked by authored autopilot-suitability score (high
+first; equal scores tie-break by lowest issue number). With --autopilot
+(autopilot runs), orphans whose score is below autopilotSuitabilityFloor
+(default 3) are moved to routed_to_human; without it (attended runs) they
+stay in orphans, ranked last. A missing or out-of-range score is treated
+as no score: the issue stays in orphans and is never routed out.
+
+--with-claim-state (opt-in) annotates each candidate in "orphans" and
+"routed_to_human" with active-claim eligibility, exactly mirroring
+discover-roadmap-graph's flag of the same name: it fetches that issue's
+comments and resolves the active claim using the configured
+trustedMarkerActors, claimTiming.staleAge (default PT24H), and
+claimTiming.heartbeatInterval (default PT12H). Each annotated candidate
+gains (activeClaim is always an object):
+  "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null, "heartbeatOverdue": bool }
+                 (present:false with claimId/agentId null = no trusted claim)
+  "claimEligible": bool   (eligible = no present, non-stale, trusted claim)
+Absent the flag, NO comment API calls are made and no claim fields are
+emitted (the output shape is byte-stable).
+heartbeatOverdue is true when the latest valid claimed-by/heartbeat
+created_at is at or past claimTiming.heartbeatInterval with no later trusted
+heartbeat; false otherwise, including whenever present is false. It is
+PURELY DIAGNOSTIC: it never feeds claimEligible or any other gate.
+--current-claim-id <id> additionally sets "ownedByCurrentSession": bool on
+each activeClaim (true when the active claim's claimId equals <id>).
+NOTE: claimEligible is a best-effort SOFT discovery hint (same limitation
+as discover-roadmap-graph's annotation): it resolves only new-format
+claimed-by markers and intentionally does NOT account for legacy
+claim-id-less markers or forced-handoff transfers; the authoritative A5
+claim gate (idd-claim.instructions.md) remains the real protection.
+`);
+}
+function loadPolicy(policyPath) {
+  // Read-and-parse failure semantics (explicit path throws; default path
+  // silently falls back only on ENOENT) are converged in idd-config.mts's
+  // loadPolicyConfig (#1721) — this function keeps only its own shape
+  // normalization on top of that raw config.
+  const { path: source, config: rawConfig } = loadPolicyConfig(policyPath);
+  const config = rawConfig ?? {};
+  const authoringPolicy = resolveAuthoringGuardPolicy(config);
+  const labelsPolicy = normalizePolicyConfig(config).labels;
+  return {
+    source,
+    orphanFirstPolicy: getOrphanFirstPolicy(config),
+    markerPrefix: normalizeMarkerPrefix(config.markerPrefix),
+    authoringLabelName: authoringPolicy.labelName,
+    authoringStaleAge: authoringPolicy.staleAge,
+    authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
+    autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
+    // Passed through verbatim (raw, un-normalized) for
+    // buildClaimStateResolution (#1395), which expects this same shape —
+    // it is only consumed when --with-claim-state is passed. Undefined
+    // when no config was found (default path, ENOENT), matching
+    // buildClaimStateResolution's own defaults (24h stale age, env-only
+    // trusted actors) — the same soft-default philosophy the graph helper
+    // already relies on.
+    claimTiming: config.claimTiming,
+    trustedMarkerActors: config.trustedMarkerActors,
+  };
+}
+function resolveAutopilotSuitabilityFloor(config) {
+  // Delegate range/default validation to the shared normalizer so the
+  // 1-5 rule and the default cannot drift between modules.
+  return normalizeAutopilotSuitabilityFloor(
+    config?.autopilotSuitability?.floor,
+  );
+}
+function resolveAutopilotSuitabilityEnabled(config) {
+  return config?.autopilotSuitability?.enabled !== false;
+}
+function normalizeIssue(issue) {
+  return {
+    number: Number.parseInt(String(issue.number), 10),
+    title: issue.title ?? '',
+    state: issue.state ?? '',
+    labels: normalizeLabels(issue.labels),
+    labelEvents: Array.isArray(issue.labelEvents) ? issue.labelEvents : [],
+    body: issue.body ?? '',
+    url: issue.url ?? issue.html_url ?? '',
+  };
+}
+function resolveIssueLabelEvents(issue, fetchLabelEventsByIssueNumber) {
+  if (Array.isArray(issue.labelEvents) && issue.labelEvents.length > 0) {
+    return issue.labelEvents;
+  }
+  if (typeof fetchLabelEventsByIssueNumber !== 'function') {
+    return [];
+  }
+  try {
+    return fetchLabelEventsByIssueNumber(issue.number);
+  } catch {
+    return [];
+  }
+}
+function normalizeLabels(labels) {
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+  return labels
+    .map((label) => {
+      if (typeof label === 'string') {
+        return label;
+      }
+      return String(label?.name ?? '');
+    })
+    .filter(Boolean);
+}
+function resolveIssueState(
+  number,
+  issueStateByNumber,
+  fetchIssueStateByNumber,
+) {
+  if (issueStateByNumber.has(number)) {
+    return issueStateByNumber.get(number);
+  }
+  const state = fetchIssueStateByNumber(number);
+  issueStateByNumber.set(number, state);
+  return state;
+}
+function fetchIssueState(repoRef, issueNumber) {
+  try {
+    const state = ghText(
+      [
+        'issue',
+        'view',
+        String(issueNumber),
+        '--repo',
+        repoRef,
+        '--json',
+        'state',
+        '--jq',
+        '.state',
+      ],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    return state || 'UNRESOLVABLE';
+  } catch {
+    return 'UNRESOLVABLE';
+  }
+}
+function fetchIssueLabelEvents(repoRef, issueNumber) {
+  const events = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${issueNumber}/timeline?per_page=${pageSize}&page=${page}`,
+    ]);
+    events.push(...rawPage.filter((event) => event?.event === 'labeled'));
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return events;
+}
+function ghJson(args) {
+  return JSON.parse(runGh(args).trim() || '[]');
+}
+function runGh(args) {
+  try {
+    return ghText(args, GH_TEXT_LOOP_TIMEOUT_OPTIONS);
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}
+function normalizeMarkerPrefix(prefix) {
+  if (typeof prefix !== 'string' || prefix.length === 0) {
+    return DEFAULT_MARKER_PREFIX;
+  }
+  return prefix;
+}
+function normalizeAuthoringLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : 'status:authoring';
+}
+/** Resolve the configured `labels.blockedByHumanLabelName` (#1273). */
+function normalizeBlockedByHumanLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+}
+/** Resolve the configured `labels.needsDecisionLabelName` (#1273). */
+function normalizeNeedsDecisionLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.needsDecisionLabelName;
+}
+/**
+ * Resolve the configured `labels.roadmapLabelName` for the dependency
+ * parent-epic exemption (#1536), following this file's established
+ * defensive-default pattern for the other configurable label names.
+ */
+function normalizeRoadmapLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.roadmapLabelName;
+}
+function fetchOpenIssues(repoRef) {
+  const issues = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = ghJson([
+      'api',
+      `repos/${repoRef}/issues?state=open&per_page=${pageSize}&page=${page}`,
+    ]);
+    const pageItems = rawPage
+      .filter((item) => item?.pull_request === undefined)
+      .map((item) => normalizeIssue(item));
+    issues.push(...pageItems);
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return issues;
+}

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -1,0 +1,901 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-readiness-check.mts
+//
+// The scripts/discover-readiness-check.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import {
+  buildAuthoringLabelWarning,
+  resolveAuthoringGuardPolicy,
+} from './authoring-label-guard.mjs';
+import {
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitability,
+} from './autopilot-suitability.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_OPTIONS,
+  ghText,
+} from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+import { escapeRegex } from './marker-regex.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
+// It tolerates optional indentation, nested blockquote (`>`) markers, and a
+// single list bullet (`-`/`*`/`+`) while staying line-anchored, so a dependency
+// written as `- Blocked by #55` or `> Depends on #66` is still recognized. The
+// extractors run `stripMarkdownCodeRegions` over the body first, so a
+// dependency line merely quoted inside inline code or a fenced block is already
+// masked out — treating code-quoted markers as false positives, consistent with
+// the #1121 repo behavior; excluding backticks from this prefix is a second
+// line of defense for the inline-code case. This const is declared before the
+// `import.meta.main` CLI block on purpose so it is initialized when the CLI
+// path runs `extractBlockedByIssueNumbers` (a const declared after that block
+// would be in the temporal dead zone).
+const DEPENDENCY_LINE_PREFIX = String.raw`^[ \t]*(?:>[ \t]*)*(?:[-*+][ \t]+)?`;
+const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
+  __iddLookupStatus: 'inaccessible',
+});
+const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger block calls parseArgs()
+// synchronously at module-evaluation time, and a `const` declared after
+// that point is still in the temporal dead zone when the trigger fires
+// (see ci-wait-policy.mts's identical note).
+const DISCOVER_READINESS_CHECK_FLAG_SPEC = {
+  '--issue': { type: 'string', multiple: true },
+  '--issues': { type: 'string', multiple: true },
+  '--include-unresolvable': { type: 'boolean', default: false },
+  '--csv': { type: 'boolean', default: false },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--policy': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--swarm-floor': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.swarmFloor === null && args.issueNumbers.length === 0) {
+    throw new Error(
+      'missing required --issue <number> (repeatable) or --issues <n1,n2,...>',
+    );
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const policyConfig = loadPolicy(args.policy);
+  const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
+  const markerPrefix = resolveMarkerPrefix(policyConfig);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
+  // `--swarm-floor` sweeps every open issue (orphans included); otherwise
+  // evaluate exactly the issues the caller named.
+  const issueNumbers =
+    args.swarmFloor === null
+      ? args.issueNumbers
+      : listOpenIssueNumbers(owner, repo);
+  const summary = await evaluateDiscoverReadiness(issueNumbers, {
+    includeUnresolvable: args.includeUnresolvable,
+    loadIssue: buildIssueLoader(owner, repo),
+    // `--swarm-floor` output never surfaces the stale-authoring warning, so
+    // skip the per-issue timeline fetch this loader runs — over a whole-repo
+    // sweep that is one extra paginated API call per open issue. The
+    // authoring-label *filter* reads issue labels (always loaded), so
+    // eligibility is unchanged; only the unsurfaced warning is dropped.
+    loadIssueLabelEvents:
+      args.swarmFloor === null
+        ? buildIssueLabelEventsLoader(owner, repo)
+        : undefined,
+    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
+    authoringLabelName: authoringPolicy.labelName,
+    authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    markerPrefix,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    autopilotSuitabilityFloor:
+      args.swarmFloor ?? resolveSuitabilityFloor(policyConfig),
+    autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
+    now: args.now || new Date(),
+  });
+  if (args.swarmFloor !== null) {
+    process.stdout.write(
+      `${JSON.stringify(summarizeSwarmFloorEligibility(summary), null, 2)}\n`,
+    );
+  } else if (args.csv) {
+    process.stdout.write(renderCsv(summary));
+  } else {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  }
+}
+export async function evaluateDiscoverReadiness(issueNumbers, options) {
+  const {
+    includeUnresolvable = false,
+    loadIssue,
+    findRoadmapsByMarker,
+    loadIssueLabelEvents,
+    authoringLabelName = 'status:authoring',
+    authoringStaleAgeMs = 4 * 60 * 60 * 1000,
+    markerPrefix,
+    roadmapLabelName: rawRoadmapLabelName,
+    blockedByHumanLabelName: rawBlockedByHumanLabelName,
+    needsDecisionLabelName: rawNeedsDecisionLabelName,
+    autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled,
+    now = new Date(),
+  } = options ?? {};
+  // Route the three label-name options through normalizePolicyConfig rather
+  // than a bare destructure default (which only applies on `undefined`), so
+  // an invalid or empty-string input also falls back to POLICY_DEFAULTS
+  // instead of silently disabling the blocked-label / roadmap-label checks
+  // below (consistent with the other five helpers in #1273).
+  const { roadmapLabelName, blockedByHumanLabelName, needsDecisionLabelName } =
+    normalizePolicyConfig({
+      labels: {
+        roadmapLabelName: rawRoadmapLabelName,
+        blockedByHumanLabelName: rawBlockedByHumanLabelName,
+        needsDecisionLabelName: rawNeedsDecisionLabelName,
+      },
+    }).labels;
+  if (typeof loadIssue !== 'function') {
+    throw new Error(
+      'evaluateDiscoverReadiness requires loadIssue(issueNumber)',
+    );
+  }
+  if (typeof findRoadmapsByMarker !== 'function') {
+    throw new Error(
+      'evaluateDiscoverReadiness requires findRoadmapsByMarker(markerId)',
+    );
+  }
+  const resolvedMarkerPrefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  // Delegate range/default validation to the shared normalizer so the 1-5
+  // rule and the default floor cannot drift from the discovery rankers.
+  const suitabilityFloor = normalizeAutopilotSuitabilityFloor(
+    autopilotSuitabilityFloor,
+  );
+  // `autopilotSuitability.enabled: false` is the discovery kill switch: the
+  // ranker ignores the score entirely (see rankAndRouteBySuitability). Mirror
+  // that here so this readiness signal does not flag below-floor work the
+  // operator turned the suitability system off for.
+  const suitabilityEnabled = autopilotSuitabilityEnabled !== false;
+  // Parse the authored autopilot-suitability score once per body and derive
+  // the below-floor flag. A null score ("no score") is never below floor; when
+  // the kill switch is off, force a fully neutral signal (ignore the score).
+  const suitabilitySignal = (body) => {
+    if (!suitabilityEnabled) {
+      return { autopilotSuitability: null, belowFloor: false };
+    }
+    const score = parseAutopilotSuitability(body, resolvedMarkerPrefix);
+    return {
+      autopilotSuitability: score,
+      belowFloor: score !== null && score < suitabilityFloor,
+    };
+  };
+  const ready = [];
+  const filteredOut = [];
+  const unresolvable = [];
+  const warnings = [];
+  const issueCache = new Map();
+  const markerCache = new Map();
+  for (const issueNumber of normalizeIssueNumbers(issueNumbers)) {
+    const issue = await getIssue(issueNumber, issueCache, loadIssue);
+    if (!issue || isInaccessibleIssue(issue)) {
+      const issueReason = isInaccessibleIssue(issue)
+        ? 'issue_inaccessible'
+        : 'issue_not_found';
+      unresolvable.push({
+        issueNumber,
+        kind: 'issue',
+        reference: `#${issueNumber}`,
+        reason: issueReason,
+      });
+      filteredOut.push({
+        number: issueNumber,
+        title: '',
+        reasons: [issueReason],
+        // No body is available for a not-found / inaccessible issue, so the
+        // score is "no score" and the issue is never flagged below floor.
+        ...suitabilitySignal(''),
+      });
+      continue;
+    }
+    if (issue.state !== 'OPEN') {
+      filteredOut.push({
+        number: issue.number,
+        title: issue.title,
+        reasons: ['issue_not_open'],
+        ...suitabilitySignal(issue.body),
+      });
+      continue;
+    }
+    const reasons = new Set();
+    const labels = normalizeLabels(issue.labels);
+    if (labels.has(blockedByHumanLabelName)) {
+      reasons.add(`label:${blockedByHumanLabelName}`);
+    }
+    if (labels.has(needsDecisionLabelName)) {
+      reasons.add(`label:${needsDecisionLabelName}`);
+    }
+    if (labels.has(authoringLabelName)) {
+      reasons.add(`label:${authoringLabelName}`);
+      const warning = buildAuthoringLabelWarning({
+        issueNumber: issue.number,
+        labelName: authoringLabelName,
+        labelEvents: await resolveLabelEvents(issue, loadIssueLabelEvents),
+        now,
+        staleAgeMs: authoringStaleAgeMs,
+      });
+      if (warning) {
+        warnings.push(warning);
+      }
+    }
+    for (const dependencyNumber of extractDependencyIssueNumbers(issue.body)) {
+      const dependencyIssue = await getIssue(
+        dependencyNumber,
+        issueCache,
+        loadIssue,
+      );
+      if (!dependencyIssue || isInaccessibleIssue(dependencyIssue)) {
+        const dependencyReason = isInaccessibleIssue(dependencyIssue)
+          ? 'issue_inaccessible'
+          : 'issue_not_found';
+        reasons.add('unresolvable_dependency_issue');
+        unresolvable.push({
+          issueNumber: issue.number,
+          kind: 'dependency',
+          reference: `#${dependencyNumber}`,
+          reason: dependencyReason,
+        });
+        continue;
+      }
+      if (
+        dependencyIssue.state === 'OPEN' &&
+        !isParentEpicIssue(dependencyIssue, roadmapLabelName)
+      ) {
+        reasons.add(`open_dependency_issue:#${dependencyNumber}`);
+      }
+    }
+    for (const blockedNumber of extractBlockedByIssueNumbers(issue.body)) {
+      const blockedIssue = await getIssue(blockedNumber, issueCache, loadIssue);
+      if (!blockedIssue || isInaccessibleIssue(blockedIssue)) {
+        const blockedReason = isInaccessibleIssue(blockedIssue)
+          ? 'issue_inaccessible'
+          : 'issue_not_found';
+        reasons.add('unresolvable_blocked_by_issue');
+        unresolvable.push({
+          issueNumber: issue.number,
+          kind: 'blocked_by_issue',
+          reference: `#${blockedNumber}`,
+          reason: blockedReason,
+        });
+        continue;
+      }
+      if (blockedIssue.state === 'OPEN') {
+        reasons.add(`blocked_by_open_issue:#${blockedNumber}`);
+      }
+    }
+    for (const marker of extractBlockedByRoadmapMarkers(
+      issue.body,
+      resolvedMarkerPrefix,
+    )) {
+      const markerMatches = await getRoadmapsByMarker(
+        marker,
+        markerCache,
+        findRoadmapsByMarker,
+      );
+      if (markerMatches.length === 0) {
+        reasons.add('unresolvable_blocked_by_marker');
+        unresolvable.push({
+          issueNumber: issue.number,
+          kind: 'blocked_by_marker',
+          reference: marker,
+          reason: 'roadmap_marker_not_found',
+        });
+        continue;
+      }
+      if (markerMatches.some((candidate) => candidate.state === 'OPEN')) {
+        reasons.add(`blocked_by_open_roadmap_marker:${marker}`);
+      }
+    }
+    const signal = suitabilitySignal(issue.body);
+    if (reasons.size === 0) {
+      ready.push({
+        number: issue.number,
+        title: issue.title,
+        ...signal,
+      });
+      continue;
+    }
+    filteredOut.push({
+      number: issue.number,
+      title: issue.title,
+      reasons: [...reasons].sort(),
+      ...signal,
+    });
+  }
+  const filteredByReason = countReasons(filteredOut);
+  return {
+    ready,
+    filteredOut,
+    unresolvable: includeUnresolvable ? unresolvable : [],
+    warnings,
+    summary: {
+      total: ready.length + filteredOut.length,
+      readyCount: ready.length,
+      filteredCount: filteredOut.length,
+      unresolvableCount: unresolvable.length,
+      filteredByReason,
+    },
+  };
+}
+/**
+ * Reduce a full readiness summary to the swarm-floor answer: the ready issues
+ * at or above the configured floor (a "no score" issue is never below floor,
+ * so it stays eligible, matching the discovery ranker), plus counts. Pure so
+ * the `--swarm-floor` CLI sweep and the tests share one definition.
+ */
+export function summarizeSwarmFloorEligibility(summary) {
+  const eligible = summary.ready.filter((issue) => !issue.belowFloor);
+  return {
+    eligible,
+    eligible_count: eligible.length,
+    total: summary.summary.total,
+  };
+}
+/**
+ * Parse and range-check the `--swarm-floor <N>` value. The floor is the
+ * autopilot-suitability 1-5 band, so a non-integer, fractional, or
+ * out-of-range value is a hard error rather than being silently coerced to
+ * the default floor — coercion would loosen the eligibility gate on a typo
+ * (e.g. `--swarm-floor 50` quietly answering at floor 3), which is exactly
+ * the mis-read this stop-condition query must avoid.
+ */
+export function parseSwarmFloorArg(value) {
+  const raw = String(value ?? '').trim();
+  const floor = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || floor < 1 || floor > 5) {
+    throw new Error('--swarm-floor requires an integer 1-5');
+  }
+  return floor;
+}
+/**
+ * Collect the `#N` references declared on a dependency-keyword line.
+ *
+ * A line is a dependency declaration when, after the shared
+ * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
+ * begins with `keyword`, an optional `:` (#1311 — a natural bulleted phrasing
+ * such as `- Blocked by: #123` is tolerated the same as `- Blocked by #123`,
+ * aligned with the colon-tolerant `extractKeywordReferenceTargets` edge
+ * extractor in `discover-roadmap-graph.mts`), then horizontal whitespace and
+ * at least one `#N`. From there `consumeDependencyRefList` collects the
+ * contiguous dependency-ref list, so `Blocked by #A, #B, #C` (comma- or
+ * space-separated) yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+`
+ * (not `\s+`) so it cannot span a newline and swallow a bare `#N` on the
+ * following line, and the `.*$` capture plus the `m` flag (no `s` flag)
+ * keeps the match on the single keyword line. Callers pass a
+ * code-region-stripped body, so a quoted example line is already masked (see
+ * `DEPENDENCY_LINE_PREFIX`).
+ */
+function extractKeywordLineRefs(body, keyword) {
+  const linePattern = new RegExp(
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}:?[ \\t]+(#\\d+.*)$`,
+    'gim',
+  );
+  const numbers = [];
+  for (const lineMatch of body.matchAll(linePattern)) {
+    numbers.push(...consumeDependencyRefList(lineMatch[1]));
+  }
+  return numbers;
+}
+/**
+ * Consume the contiguous dependency-ref list at the start of `segment`: bare
+ * local `#N` entries separated by commas, "and", and/or whitespace. Parsing
+ * stops at the first token that is neither a bare local ref nor such a
+ * separator, so trailing prose (`; similar to #402`) and cross-repo mentions
+ * (`(see other/repo#20)`) are excluded instead of being mis-read as local
+ * blockers. This mirrors the separator-bounded reference parsing in
+ * `discover-roadmap-graph.mts`, extended to also accept a plain-whitespace
+ * separator so the space-separated multi-ref form is captured too.
+ */
+function consumeDependencyRefList(segment) {
+  const numbers = [];
+  let remaining = segment;
+  while (remaining) {
+    const refMatch = remaining.match(/^#(\d+)\b/);
+    if (!refMatch) {
+      break;
+    }
+    numbers.push(Number.parseInt(refMatch[1], 10));
+    remaining = remaining.slice(refMatch[0].length);
+    const separatorMatch = remaining.match(
+      /^(?:\s*,\s*(?:and\s+)?|\s+and\s+|\s+)/i,
+    );
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
+  }
+  return numbers;
+}
+export function extractBlockedByIssueNumbers(body) {
+  return dedupeNumbers(
+    extractKeywordLineRefs(stripMarkdownCodeRegions(body), 'Blocked by'),
+  );
+}
+export function extractBlockedByRoadmapMarkers(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  // Regex-escape the configurable prefix so a namespaced adopter prefix
+  // (which may contain a metacharacter) cannot corrupt or break the
+  // extraction pattern. For the default `idd-skill` this is byte-identical
+  // to the prior hardcoded literal.
+  const matches = body.matchAll(
+    new RegExp(
+      `<!--\\s*${escapeRegex(markerPrefix)}-blocked-by:\\s*([^\\s>]+)\\s*-->`,
+      'gi',
+    ),
+  );
+  return [...new Set([...matches].map((match) => match[1]))];
+}
+export function extractDependencyIssueNumbers(body) {
+  const stripped = stripMarkdownCodeRegions(body);
+  const explicitDependencies = extractKeywordLineRefs(stripped, 'Depends on');
+  const taskListDependencies = [
+    ...stripped.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
+  ];
+  return dedupeNumbers([
+    ...explicitDependencies,
+    ...taskListDependencies.map((match) => Number.parseInt(match[1], 10)),
+  ]);
+}
+/**
+ * Walk `argv` and return every occurrence of the given long-flag literals
+ * (e.g. `--issue`, `--issues`) in argv order, tagged with which flag
+ * matched and its literal string value. `parseCliArgs` has already thrown
+ * on anything malformed (a missing value, a flag-shaped value, an unknown
+ * flag) by the time this runs, so this is a pure order-reconstruction pass
+ * over already-validated input, not a second parse/validation pass. Covers
+ * both the `--flag value` and `--flag=value` forms Node's `util.parseArgs`
+ * itself accepts for a long option (#1450 review follow-up: grouping every
+ * `--issue` occurrence before every `--issues` occurrence silently
+ * reordered interleaved input, e.g. `--issues 1,2 --issue 3`).
+ */
+function collectOrderedOccurrences(argv, flagNames) {
+  const occurrences = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const equalsIndex = token.indexOf('=');
+    const bareFlag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+    if (!flagNames.includes(bareFlag)) {
+      continue;
+    }
+    const value =
+      equalsIndex === -1 ? argv[index + 1] : token.slice(equalsIndex + 1);
+    occurrences.push({ flag: bareFlag, value });
+  }
+  return occurrences;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    DISCOVER_READINESS_CHECK_FLAG_SPEC,
+  );
+  // Preserves the existing "collect every --issue occurrence plus every
+  // comma-split --issues entry, in argv order, then silently drop
+  // non-numeric tokens" contract (normalizeIssueNumbers) unchanged by this
+  // migration -- only the flag-syntax parsing (missing/flag-shaped values,
+  // unknown flags) is now strict.
+  const issueTokens = collectOrderedOccurrences(argv, [
+    '--issue',
+    '--issues',
+  ]).flatMap((occurrence) =>
+    occurrence.flag === '--issues'
+      ? occurrence.value.split(',')
+      : [occurrence.value],
+  );
+  const swarmFloorToken = values['swarm-floor'];
+  return {
+    issueNumbers: normalizeIssueNumbers(issueTokens),
+    includeUnresolvable: values['include-unresolvable'],
+    csv: values.csv,
+    owner: values.owner,
+    repo: values.repo,
+    policy: values.policy,
+    now: values.now,
+    // parseSwarmFloorArg keeps its existing throw-on-invalid contract
+    // (range 1-5, hard error on a non-integer or out-of-range value)
+    // unchanged; only called when --swarm-floor is actually present.
+    swarmFloor:
+      swarmFloorToken === undefined
+        ? null
+        : parseSwarmFloorArg(swarmFloorToken),
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-readiness-check.mjs --issue <number> [--issue <number> ...]
+  node scripts/discover-readiness-check.mjs --issues <n1,n2,...>
+    [--include-unresolvable] [--csv] [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>] [--help]
+  node scripts/discover-readiness-check.mjs --swarm-floor <N>
+    [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>] [--help]
+
+  --swarm-floor <N> ignores --issue/--issues, sweeps every open issue in the
+  repository (orphans included, pull requests excluded), runs readiness, and
+  reports the ready issues at or above autopilot-suitability floor N (an
+  integer 1-5) in one call. An out-of-range or non-integer N is a hard error
+  rather than a silent coercion. A "no score" issue is never below floor,
+  matching discovery ranking.
+
+Output schema (JSON mode):
+  {
+    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false }],
+    "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
+    "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
+    "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
+  }
+
+Output schema (--swarm-floor mode):
+  {
+    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "eligible_count": 1,
+    "total": 7
+  }
+`);
+}
+function normalizeIssueNumbers(values) {
+  const parsed = values
+    .map((value) => Number.parseInt(String(value).trim(), 10))
+    .filter((value) => Number.isInteger(value) && value > 0);
+  return [...new Set(parsed)];
+}
+function dedupeNumbers(values) {
+  return [
+    ...new Set(values.filter((value) => Number.isInteger(value) && value > 0)),
+  ];
+}
+function normalizeIssue(issue) {
+  return {
+    number: Number.parseInt(String(issue.number ?? issue.id ?? 0), 10),
+    title: String(issue.title ?? ''),
+    state: String(issue.state ?? '').toUpperCase(),
+    body: String(issue.body ?? ''),
+    labels: normalizeLabels(issue.labels),
+    labelEvents: Array.isArray(issue.labelEvents) ? issue.labelEvents : [],
+    url: String(issue.url ?? ''),
+  };
+}
+function normalizeLabels(labelsInput) {
+  if (!labelsInput) {
+    return new Set();
+  }
+  if (labelsInput instanceof Set) {
+    return new Set(
+      [...labelsInput].map((label) => String(label ?? '')).filter(Boolean),
+    );
+  }
+  if (Array.isArray(labelsInput)) {
+    return new Set(
+      labelsInput
+        .map((label) => {
+          if (typeof label === 'string') {
+            return label;
+          }
+          return String(label?.name ?? '');
+        })
+        .filter(Boolean),
+    );
+  }
+  return new Set();
+}
+/**
+ * Parent-epic / aggregate-issue exemption for the dependency check (#1536):
+ * an open dependency issue does not block when it is itself a roadmap/epic.
+ * Exported so `discover-orphan-filter.mts` can reuse this exact exemption for
+ * A0-O's own dependency check instead of re-implementing it (#1536). The
+ * parameter type is intentionally the minimal structural shape this function
+ * actually reads (not the full `NormalizedIssue`), so a reusing caller can
+ * pass any object with these two fields without constructing a full
+ * `NormalizedIssue` (`NormalizedIssue` itself stays structurally assignable,
+ * so this widening does not affect the call site below).
+ */
+export function isParentEpicIssue(
+  issue,
+  roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
+) {
+  // Title heuristic is intentionally independent of the configured roadmap
+  // label (#1273): it is a naming-convention signal on free-form title text,
+  // not a label comparison, so it is not wired to `labels.roadmapLabelName`.
+  if (issue.title.toLowerCase().startsWith('roadmap')) {
+    return true;
+  }
+  return issue.labels.has(roadmapLabelName);
+}
+async function getIssue(issueNumber, cache, loadIssue) {
+  if (cache.has(issueNumber)) {
+    return cache.get(issueNumber) ?? null;
+  }
+  const rawIssue = await loadIssue(issueNumber);
+  const issue = isInaccessibleIssue(rawIssue)
+    ? INACCESSIBLE_ISSUE_SENTINEL
+    : rawIssue
+      ? normalizeIssue(rawIssue)
+      : null;
+  cache.set(issueNumber, issue);
+  return issue;
+}
+async function getRoadmapsByMarker(marker, cache, findRoadmapsByMarker) {
+  const cached = cache.get(marker);
+  if (cached) {
+    return cached;
+  }
+  const rawMatches = await findRoadmapsByMarker(marker);
+  const matches = (rawMatches ?? [])
+    .map((issue) => normalizeIssue(issue))
+    .filter((issue) => Number.isInteger(issue.number) && issue.number > 0);
+  cache.set(marker, matches);
+  return matches;
+}
+async function resolveLabelEvents(issue, loadIssueLabelEvents) {
+  if (
+    issue.labelEvents.length > 0 ||
+    typeof loadIssueLabelEvents !== 'function'
+  ) {
+    return issue.labelEvents;
+  }
+  try {
+    const events = await loadIssueLabelEvents(issue.number);
+    return Array.isArray(events) ? events : [];
+  } catch {
+    return [];
+  }
+}
+function countReasons(filteredOut) {
+  const counts = {};
+  for (const item of filteredOut) {
+    for (const reason of item.reasons) {
+      counts[reason] = (counts[reason] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+function renderCsv(summary) {
+  const lines = ['number,title,status,reasons,suitability,belowFloor'];
+  for (const item of summary.ready) {
+    lines.push(
+      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+    );
+  }
+  for (const item of summary.filteredOut) {
+    lines.push(
+      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+function formatScore(score) {
+  return score === null ? '' : String(score);
+}
+function escapeCsv(value) {
+  const text = String(value ?? '');
+  if (!/[",\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
+}
+function buildIssueLoader(owner, repo) {
+  return async (issueNumber) => {
+    const args = [
+      'api',
+      `repos/${owner}/${repo}/issues/${issueNumber}`,
+      '--jq',
+      '.',
+    ];
+    try {
+      const result = runGh(args).trim();
+      if (!result || result === 'null') {
+        return null;
+      }
+      return JSON.parse(result);
+    } catch (error) {
+      // `gh` exits 1 for every HTTP error, so derive the real status from
+      // its output. Fail closed: a genuine 404 maps to issue_not_found,
+      // a visibility 403/410/451 maps to issue_inaccessible, and auth /
+      // rate-limit / network / unknown failures propagate to abort.
+      if (deriveGhHttpStatus(error) === 404) {
+        return null;
+      }
+      if (isInaccessibleIssueLookupError(error)) {
+        return INACCESSIBLE_ISSUE_SENTINEL;
+      }
+      throw error;
+    }
+  };
+}
+function buildIssueLabelEventsLoader(owner, repo) {
+  return async (issueNumber) => {
+    const repoRef = `${owner}/${repo}`;
+    return fetchIssueLabelEvents(repoRef, issueNumber);
+  };
+}
+function fetchIssueLabelEvents(repoRef, issueNumber) {
+  const events = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = JSON.parse(
+      runGh([
+        'api',
+        `repos/${repoRef}/issues/${issueNumber}/timeline?per_page=${pageSize}&page=${page}`,
+      ]).trim() || '[]',
+    );
+    const labeled = rawPage.filter((event) => event?.event === 'labeled');
+    events.push(...labeled);
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return events;
+}
+export function buildRoadmapMarkerSearchQuery(
+  owner,
+  repo,
+  markerPrefix,
+  marker,
+) {
+  // Thread the configurable prefix into the GitHub search query WITHOUT
+  // regex-escaping: this is a literal `in:body` search term, so escaping the
+  // prefix would corrupt the exact marker string the resolver looks for.
+  return `repo:${owner}/${repo} is:issue in:body "<!-- ${markerPrefix}-roadmap-id: ${marker} -->"`;
+}
+export function buildRoadmapMarkerResolver(owner, repo, markerPrefix) {
+  return async (marker) => {
+    const query = buildRoadmapMarkerSearchQuery(
+      owner,
+      repo,
+      markerPrefix,
+      marker,
+    );
+    const encodedQuery = encodeURIComponent(query);
+    const result = runGh([
+      'api',
+      `search/issues?q=${encodedQuery}&per_page=100`,
+      '--jq',
+      '.items',
+    ]).trim();
+    return JSON.parse(result || '[]');
+  };
+}
+/**
+ * Every open issue number in the repository, orphans included. `--paginate`
+ * walks all pages; `select(.pull_request == null)` drops pull requests, which
+ * the REST issues endpoint otherwise returns alongside issues. Used by the
+ * `--swarm-floor` sweep to answer "is there any eligible work left?".
+ */
+function listOpenIssueNumbers(owner, repo) {
+  return parseIssueNumberLines(
+    ghText(
+      [
+        'api',
+        '--paginate',
+        `repos/${owner}/${repo}/issues?state=open&per_page=100`,
+        '--jq',
+        '.[] | select(.pull_request == null) | .number',
+      ],
+      { ...GH_TEXT_LOOP_OPTIONS, timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS },
+    ),
+  );
+}
+/**
+ * Parse the newline-delimited issue numbers emitted by the
+ * `listOpenIssueNumbers` `gh api --jq` sweep into a deduped list of positive
+ * integers. Only **full-integer** lines are kept: blank, partially-numeric
+ * (`5abc`), or non-positive lines are dropped rather than truncated by
+ * `Number.parseInt`, so an empty sweep yields `[]`. Exported so the parse
+ * contract is unit-testable without a live `gh` call — pull requests are
+ * already excluded upstream by the `select(.pull_request == null)` jq filter.
+ */
+export function parseIssueNumberLines(raw) {
+  return dedupeNumbers(
+    raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => /^\d+$/.test(line))
+      .map((line) => Number.parseInt(line, 10)),
+  );
+}
+// Read-and-parse failure semantics (explicit path throws; default path
+// silently falls back only on ENOENT) are converged in idd-config.mts's
+// loadPolicyConfig (#1721); this helper has no shape normalization of its
+// own beyond returning the raw config.
+function loadPolicy(policyPath) {
+  return loadPolicyConfig(policyPath).config;
+}
+function resolveMarkerPrefix(config) {
+  const prefix = config?.markerPrefix;
+  return typeof prefix === 'string' && prefix.length > 0
+    ? prefix
+    : DEFAULT_MARKER_PREFIX;
+}
+function resolveSuitabilityFloor(config) {
+  // Delegate range/default validation to the shared normalizer so the 1-5
+  // rule and the default cannot drift between modules.
+  return normalizeAutopilotSuitabilityFloor(
+    config?.autopilotSuitability?.floor,
+  );
+}
+function resolveSuitabilityEnabled(config) {
+  // Match resolveAutopilotSuitabilityEnabled in discover-orphan-filter.mts:
+  // the kill switch is off only when explicitly set to `false`.
+  return config?.autopilotSuitability?.enabled !== false;
+}
+function runGh(args) {
+  try {
+    return ghText(args, GH_TEXT_LOOP_OPTIONS);
+  } catch (error) {
+    const rawStatus = error?.status;
+    const status = typeof rawStatus === 'number' ? rawStatus : null;
+    const stderr = String(error?.stderr ?? '').trim();
+    const stdout = String(error?.stdout ?? '').trim();
+    const prefix = `gh ${args.join(' ')}`;
+    // Preserve stderr and stdout on the wrapped error so deriveGhHttpStatus
+    // can recover the real HTTP status; the process exit status is always
+    // 1 and is kept only for diagnostics.
+    const wrapped = new Error(
+      stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
+    );
+    wrapped.status = status;
+    wrapped.stderr = stderr;
+    wrapped.stdout = stdout;
+    throw wrapped;
+  }
+}
+function isInaccessibleIssue(value) {
+  return value?.__iddLookupStatus === 'inaccessible';
+}
+export function isInaccessibleIssueLookupError(error) {
+  const status = deriveGhHttpStatus(error);
+  // Only a true 403/410/451 can be an inaccessible-issue downgrade.
+  if (status === null || !INACCESSIBLE_HTTP_STATUSES.has(status)) {
+    return false;
+  }
+  // Among those, downgrade only on visibility / integration-permission
+  // wording. A 403 secondary-rate-limit (or an auth failure that somehow
+  // surfaces as 403) must abort instead of being downgraded, so the regex
+  // deliberately excludes generic "forbidden" / "requires authentication".
+  const candidate = error;
+  const stderr = String(candidate.stderr ?? candidate.message ?? '');
+  return /resource not accessible|not accessible by integration|visibility/i.test(
+    stderr,
+  );
+}

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1,0 +1,2212 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-roadmap-graph.mts
+//
+// The scripts/discover-roadmap-graph.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mjs';
+import {
+  isAutopilotSuitabilityScore,
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitability,
+} from './autopilot-suitability.mjs';
+import {
+  buildRoadmapMarkerResolver,
+  evaluateDiscoverReadiness,
+} from './discover-readiness-check.mjs';
+import { effortOrdinal, parseEffort } from './effort.mjs';
+import {
+  GH_TEXT_LOOP_OPTIONS,
+  ghText,
+  ghTextAsync,
+  withBoundedRetry,
+} from './gh-exec.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+import {
+  normalizePolicyConfig,
+  POLICY_DEFAULTS,
+  parseIsoDurationToMs,
+} from './policy-helpers.mjs';
+import {
+  isStaleAt,
+  resolveActiveClaim,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// GitHub's search API returns at most 1000 results for a single query. The
+// open-roadmap-roots loader pins each search at this cap and warns when a
+// single search returns the full cap (a possible silent truncation).
+const GH_SEARCH_RESULT_CAP = 1000;
+// #1136: default in-flight bound for the concurrent prefetch crawl. Each
+// in-flight slot is one live `gh` subprocess (one network round-trip), so the
+// bound caps parallel I/O without risking GitHub secondary rate limits. The
+// default trades a comfortable speed-up against politeness; `--concurrency`
+// (or the `concurrency` option) tunes it, and `1` runs the fetches serially
+// (one in flight at a time).
+const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
+// #1449: explicit above the promisified execFile's 1 MiB default. Applied
+// PER STREAM (confirmed empirically: a 6 MiB stdout plus a 6 MiB stderr,
+// 12 MiB combined, succeeds under this 10 MiB value) — worst-case buffered
+// memory is up to ~2x this bound (stdout and stderr each maxed
+// independently), not this value as a combined total. The two hot-path
+// callers (a single GitHub issue's REST JSON — body capped at 64 KiB by
+// GitHub — and a paginated 100-node sub-issue GraphQL page) stay far below
+// this on either stream; 10 MiB per stream is a generous ceiling that
+// still bounds worst-case memory instead of accepting the old
+// accumulation's unbounded growth (Copilot review, #1463).
+const GH_ASYNC_MAX_BUFFER = 10 * 1024 * 1024;
+/**
+ * Async `gh` invocation used ONLY by the traversal hot-path loaders
+ * (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking sync
+ * runner — which serializes even concurrent `await`s because it holds the
+ * event loop — {@link ghTextAsync} lets multiple `gh` subprocesses run in
+ * parallel; the actual in-flight bound is enforced by the prefetch crawl's
+ * `mapPool` using the resolved `concurrency` (default
+ * {@link DEFAULT_TRAVERSAL_CONCURRENCY}). The non-hot-path callers (owner/repo
+ * resolution, claim-state comments, `--all-roadmaps` search) keep the sync
+ * runner, so their behavior is byte-unchanged.
+ *
+ * #1675: delegates to gh-exec.mts's shared `ghTextAsync` (extracted from
+ * this function's own #1449 `promisify(execFile)` implementation) instead
+ * of spawning `gh` directly, so this hot path also gets the shared default
+ * timeout. `.trim()`ed stdout is a behavior-preserving change here: every
+ * caller of `runGhCapture` already trims (or `JSON.parse`s, which ignores
+ * surrounding whitespace) its result.
+ */
+function runGhCapture(args) {
+  return ghTextAsync(args, { maxBuffer: GH_ASYNC_MAX_BUFFER });
+}
+// Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
+// the default baked into protocol-helpers' `isStaleAt`, so when the configured
+// stale age equals this default the shared `isStaleAt` path is
+// reused verbatim instead of re-deriving the 24h math here.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+// Policy default claim heartbeat interval (`claimTiming.heartbeatInterval`,
+// `PT12H`), used only for the diagnostic `heartbeatOverdue` annotation
+// (#1433) — it never feeds the 24h stale-takeover gate above.
+const DEFAULT_CLAIM_HEARTBEAT_INTERVAL_MS = 12 * 60 * 60 * 1000;
+const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
+  __iddLookupStatus: 'inaccessible',
+});
+const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+const KEYWORD_REFERENCE_REGEX =
+  /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
+const SUB_ISSUES_QUERY = `
+query($owner:String!, $repo:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    issue(number:$number) {
+      subIssues(first:100, after:$after) {
+        nodes {
+          number
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`;
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  const hasIssue = Number.isInteger(args.issue) && args.issue > 0;
+  // --issue and --all-roadmaps are mutually exclusive: exactly one route
+  // must be selected. The single-root --issue contract (required when
+  // --all-roadmaps is absent) is preserved.
+  if (args.allRoadmaps && hasIssue) {
+    throw new Error('--all-roadmaps cannot be combined with --issue');
+  }
+  if (!args.allRoadmaps && !hasIssue) {
+    throw new Error(
+      'missing required --issue <number> (or pass --all-roadmaps)',
+    );
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const policy = loadPolicy(args.policy);
+  // The claim-state annotation is strictly opt-in: only when --with-claim-state
+  // is passed do we build the comment loader (the sole new GitHub API surface)
+  // and resolve the trusted-actor / stale-age policy. The default path leaves
+  // `claimState` undefined, so no extra fetch is made and the output is
+  // byte-stable.
+  const claimState = args.withClaimState
+    ? buildClaimStateResolution(owner, repo, policy, args.currentClaimId)
+    : undefined;
+  // The readiness annotation is strictly opt-in: only when --with-readiness is
+  // passed do we build the marker / label-event loaders and resolve the
+  // authoring-hold policy. The default path leaves `readiness` undefined, so no
+  // extra fetch is made and the output is byte-stable.
+  const readiness = args.withReadiness
+    ? buildReadinessResolution(owner, repo, policy)
+    : undefined;
+  const report = args.allRoadmaps
+    ? await enumerateAllRoadmapsGraph({
+        markerPrefix: policy.markerPrefix,
+        roadmapLabelName: policy.labels?.roadmapLabelName,
+        floor: policy.autopilotSuitability?.floor,
+        owner,
+        repo,
+        loadIssue: buildIssueLoader(owner, repo),
+        loadSubIssues: buildSubIssueLoader(owner, repo),
+        loadOpenRoadmapRoots: buildOpenRoadmapRootsLoader(
+          owner,
+          repo,
+          policy.markerPrefix,
+          buildSearchIssuesRunner(),
+          policy.labels?.roadmapLabelName,
+          policy.discover?.legacyRoots,
+        ),
+        claimState,
+        readiness,
+        concurrency: args.concurrency,
+      })
+    : await enumerateRoadmapGraph(args.issue, {
+        markerPrefix: policy.markerPrefix,
+        roadmapLabelName: policy.labels?.roadmapLabelName,
+        owner,
+        repo,
+        loadIssue: buildIssueLoader(owner, repo),
+        loadSubIssues: buildSubIssueLoader(owner, repo),
+        claimState,
+        readiness,
+        concurrency: args.concurrency,
+      });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+/**
+ * Normalize the traversal `concurrency` option to an integer `>= 1`, falling
+ * back to {@link DEFAULT_TRAVERSAL_CONCURRENCY} for unset, non-integer, or
+ * `< 1` values. `1` is preserved so callers can force the serial path.
+ *
+ * String input is parsed with `Number` (not `parseInt`) so a non-integer
+ * string such as `"2.5"` fails the `Number.isInteger` check and falls back to
+ * the default, instead of being silently truncated to `2`. This keeps CLI
+ * string input and typed numeric input consistent.
+ */
+export function normalizeConcurrency(value) {
+  const numeric =
+    typeof value === 'number' ? value : Number(String(value ?? '').trim());
+  return Number.isInteger(numeric) && numeric >= 1
+    ? numeric
+    : DEFAULT_TRAVERSAL_CONCURRENCY;
+}
+/**
+ * Run `task` over `items` with at most `limit` invocations in flight at once,
+ * returning results in input order. A fixed pool of workers pulls from a shared
+ * cursor, so a slow item never blocks faster siblings (continuous, not
+ * lock-step batches). An empty input runs no workers; the first rejection
+ * propagates (mirroring the previous serial traversal's fail-closed abort).
+ */
+async function mapPool(items, limit, task) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await task(items[index]);
+    }
+  };
+  const workerCount = Math.min(Math.max(1, limit), items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const roadmapLabelName = normalizeRoadmapLabelName(options.roadmapLabelName);
+  const loadIssueOption = options.loadIssue;
+  const loadSubIssues =
+    typeof options.loadSubIssues === 'function'
+      ? options.loadSubIssues
+      : async () => [];
+  const currentRepoRef = normalizeRepoRef(options.owner, options.repo);
+  if (typeof loadIssueOption !== 'function') {
+    throw new Error('enumerateRoadmapGraph requires loadIssue(issueNumber)');
+  }
+  // Re-bind after the guard so the hoisted helper closures below see the
+  // narrowed function type.
+  const loadIssue = loadIssueOption;
+  const issueCache = new Map();
+  const nodeRecords = new Map();
+  const edges = [];
+  const provenancePaths = [];
+  const diagnostics = {
+    duplicateReferences: [],
+    cycles: [],
+    inaccessibleReferences: [],
+    unresolvedReferences: [],
+  };
+  const pathKeys = new Set();
+  const visitedIssuePaths = new Set();
+  const edgeKeys = new Set();
+  const duplicateKeys = new Set();
+  const cycleKeys = new Set();
+  const inaccessibleKeys = new Set();
+  const unresolvedKeys = new Set();
+  const referenceCache = new Map();
+  const fetchedRoot = await getIssue(rootIssueNumber, issueCache, loadIssue);
+  if (!fetchedRoot) {
+    throw new Error(`root issue #${rootIssueNumber} was not found`);
+  }
+  if (isInaccessibleIssue(fetchedRoot)) {
+    throw new Error(`root issue #${rootIssueNumber} is inaccessible`);
+  }
+  if (fetchedRoot.isPullRequest) {
+    throw new Error(`root issue #${rootIssueNumber} is a pull request`);
+  }
+  // Re-bind after the guards so the hoisted helper closures below see the
+  // narrowed issue type.
+  const rootIssue = fetchedRoot;
+  // #1136: warm issueCache + referenceCache with a bounded-concurrency prefetch
+  // crawl BEFORE the (unchanged) serial graph build below, so `visitIssue` runs
+  // entirely against warm caches and issues zero I/O. The crawl visits exactly
+  // the same reachable, accessible, non-PR node set the DFS expands, so the
+  // resulting graph stays byte-identical to a fully serial run — only the
+  // wall-clock changes.
+  await prefetchReachableIssues(
+    rootIssue.number,
+    normalizeConcurrency(options.concurrency),
+  );
+  await visitIssue(rootIssue.number, [rootIssue.number]);
+  const nodes = [...nodeRecords.values()]
+    .map((node) => ({
+      number: node.number,
+      title: node.title,
+      state: node.state,
+      labels: [...node.labels].sort(),
+      classification: node.classification,
+      roadmapMarkerId: node.roadmapMarkerId,
+      autopilotSuitability: node.autopilotSuitability ?? null,
+      effort: node.effort ?? null,
+      depth: node.depth,
+    }))
+    .sort(compareByNumber);
+  const sortedEdges = [...edges].sort(compareEdges);
+  const sortedProvenancePaths = [...provenancePaths].sort(comparePaths);
+  const roadmapNodes = nodes
+    .filter(
+      (node) =>
+        node.classification === 'roadmap' && node.number !== rootIssue.number,
+    )
+    .map((node) => node.number);
+  const executionCandidates = nodes
+    .filter(
+      (node) => node.classification === 'execution' && node.state === 'OPEN',
+    )
+    .map((node) => node.number);
+  const rootNode = nodeRecords.get(rootIssue.number);
+  if (!rootNode) {
+    throw new Error(`root issue #${rootIssueNumber} was not recorded`);
+  }
+  // Both opt-in annotation passes below operate on the open execution-leaf
+  // nodes, so resolve the execution-candidate set once — only when a pass
+  // actually runs, keeping the default path allocation-free and byte-stable.
+  const executionCandidateSet =
+    options.claimState || options.readiness
+      ? new Set(executionCandidates)
+      : null;
+  // Opt-in (#1008): annotate each open execution-leaf node with active-claim
+  // eligibility. Gated on `options.claimState` so the default path makes no
+  // extra GitHub API call and the output shape stays byte-stable.
+  if (options.claimState && executionCandidateSet) {
+    for (const node of nodes) {
+      if (!executionCandidateSet.has(node.number)) {
+        continue;
+      }
+      const annotated = await annotateLeafClaimState(
+        node.number,
+        options.claimState,
+      );
+      node.activeClaim = annotated.activeClaim;
+      node.claimEligible = annotated.claimEligible;
+    }
+  }
+  // Opt-in (#1123): annotate each open execution-leaf node with its A3
+  // readiness in a single batch call, after the claim loop so `startable` can
+  // fold in `claimEligible`. Gated on `options.readiness` so the default path
+  // makes no extra API call and the output shape stays byte-stable.
+  if (options.readiness && executionCandidateSet) {
+    const executionNodes = nodes.filter((node) =>
+      executionCandidateSet.has(node.number),
+    );
+    await annotateReadiness(
+      executionNodes,
+      options.readiness,
+      loadIssue,
+      markerPrefix,
+    );
+  }
+  return {
+    root: {
+      number: rootNode.number,
+      title: rootNode.title,
+      state: rootNode.state,
+      classification: rootNode.classification,
+      roadmapMarkerId: rootNode.roadmapMarkerId,
+    },
+    nodes,
+    edges: sortedEdges,
+    provenancePaths: sortedProvenancePaths,
+    roadmapNodes,
+    executionCandidates,
+    diagnostics: {
+      duplicateReferences:
+        diagnostics.duplicateReferences.sort(compareDiagnostics),
+      cycles: diagnostics.cycles.sort(compareCycles),
+      inaccessibleReferences:
+        diagnostics.inaccessibleReferences.sort(compareDiagnostics),
+      unresolvedReferences:
+        diagnostics.unresolvedReferences.sort(compareDiagnostics),
+    },
+    summary: {
+      rootNumber: rootNode.number,
+      nodeCount: nodes.length,
+      edgeCount: sortedEdges.length,
+      roadmapNodeCount: roadmapNodes.length,
+      executionCandidateCount: executionCandidates.length,
+      duplicateReferenceCount: diagnostics.duplicateReferences.length,
+      cycleCount: diagnostics.cycles.length,
+      inaccessibleReferenceCount: diagnostics.inaccessibleReferences.length,
+      unresolvedReferenceCount: diagnostics.unresolvedReferences.length,
+      maxDepth: nodes.reduce(
+        (maxDepth, node) => Math.max(maxDepth, node.depth),
+        0,
+      ),
+    },
+  };
+  async function visitIssue(issueNumber, path) {
+    const issue = await getIssue(issueNumber, issueCache, loadIssue);
+    if (!issue || isInaccessibleIssue(issue)) {
+      return;
+    }
+    const visitKey = `${issue.number}:${path.join('>')}`;
+    if (visitedIssuePaths.has(visitKey)) {
+      return;
+    }
+    visitedIssuePaths.add(visitKey);
+    recordNode(issue, path);
+    const references = await getReferences(issue);
+    const seenSourceTargets = new Set();
+    const seenSourceEdgeKeys = new Set();
+    const firstReferenceBySourceTarget = new Map();
+    for (const reference of references) {
+      const edge = {
+        source: issue.number,
+        target: reference.target,
+        relationship: reference.relationship,
+        evidence: reference.evidence,
+      };
+      const edgeKey = buildEdgeKey(edge);
+      if (seenSourceEdgeKeys.has(edgeKey)) {
+        recordDuplicateReference(edge, edge);
+        continue;
+      }
+      seenSourceEdgeKeys.add(edgeKey);
+      if (!edgeKeys.has(edgeKey)) {
+        edgeKeys.add(edgeKey);
+        edges.push(edge);
+        const sourceTargetKey = `${edge.source}:${edge.target}`;
+        if (seenSourceTargets.has(sourceTargetKey)) {
+          recordDuplicateReference(
+            edge,
+            firstReferenceBySourceTarget.get(sourceTargetKey) ?? edge,
+          );
+        }
+        seenSourceTargets.add(sourceTargetKey);
+        const firstReference =
+          firstReferenceBySourceTarget.get(sourceTargetKey);
+        if (firstReference) {
+          recordDuplicateReference(edge, firstReference);
+        } else {
+          firstReferenceBySourceTarget.set(sourceTargetKey, edge);
+        }
+      }
+      if (path.includes(edge.target)) {
+        // #1278: a plain `Refs` back-reference from a CLOSED non-roadmap leaf
+        // to an ancestor is the provenance breadcrumb the A1.5 follow-up rule
+        // requires in follow-up issue bodies, not closure-order ambiguity.
+        // Keep the edge itself as informational provenance and record no
+        // cycle diagnostic. Back-edges from OPEN nodes, from roadmap nodes,
+        // and via any stronger relationship (task-list, dependency,
+        // closing-keyword, sub-issue) still record a cycle (fail closed).
+        const sourceRecord = nodeRecords.get(edge.source);
+        if (
+          edge.relationship === 'reference' &&
+          sourceRecord?.classification === 'execution' &&
+          sourceRecord.state === 'CLOSED'
+        ) {
+          continue;
+        }
+        const cyclePath = [...path, edge.target];
+        const cycleKey = cyclePath.join('>');
+        if (!cycleKeys.has(cycleKey)) {
+          cycleKeys.add(cycleKey);
+          diagnostics.cycles.push({
+            source: edge.source,
+            target: edge.target,
+            relationship: edge.relationship,
+            path: cyclePath,
+          });
+        }
+        continue;
+      }
+      const targetIssue = await getIssue(edge.target, issueCache, loadIssue);
+      if (!targetIssue) {
+        recordReferenceDiagnostic(
+          diagnostics.unresolvedReferences,
+          unresolvedKeys,
+          edge,
+          'issue_not_found',
+        );
+        continue;
+      }
+      if (isInaccessibleIssue(targetIssue)) {
+        recordReferenceDiagnostic(
+          diagnostics.inaccessibleReferences,
+          inaccessibleKeys,
+          edge,
+          'issue_inaccessible',
+        );
+        continue;
+      }
+      if (targetIssue.isPullRequest) {
+        recordReferenceDiagnostic(
+          diagnostics.unresolvedReferences,
+          unresolvedKeys,
+          edge,
+          'issue_not_found',
+        );
+        continue;
+      }
+      const nextPath = [...path, edge.target];
+      recordProvenancePath(edge.target, nextPath);
+      await visitIssue(edge.target, nextPath);
+    }
+  }
+  async function getReferences(issue) {
+    const cached = referenceCache.get(issue.number);
+    if (cached) {
+      return cached;
+    }
+    // #1072: skip the per-node native sub-issue GraphQL round-trip when the
+    // REST `sub_issues_summary.total` proves the issue has zero native
+    // sub-issues. `loadSubIssues` would return `[]` in that case, so the
+    // reference set — and every downstream edge, node, provenance path, and
+    // diagnostic — is byte-identical. A null total (summary absent / unknown)
+    // still queries, so behavior is unchanged for callers without the field.
+    const nativeSubIssues =
+      issue.subIssueSummaryTotal === 0
+        ? []
+        : normalizeSubIssueReferences(await loadSubIssues(issue.number));
+    const references = [
+      ...extractTaskListReferences(issue.body),
+      ...extractKeywordReferences(issue.body, { currentRepoRef }),
+      ...nativeSubIssues,
+    ];
+    referenceCache.set(issue.number, references);
+    return references;
+  }
+  // #1136: bounded-concurrency BFS that warms issueCache + referenceCache for
+  // every reachable node before the serial graph build. It calls the same
+  // getIssue / getReferences the DFS uses (so caches and the
+  // subIssueSummaryTotal===0 skip are shared), but fans the frontier out
+  // through `mapPool`. A genuine loader error rejects here and propagates,
+  // matching the previous serial traversal's fail-closed abort; 404→null and
+  // 403/410/451→sentinel still resolve without throwing.
+  async function prefetchReachableIssues(startNumber, concurrency) {
+    const scheduled = new Set([startNumber]);
+    let frontier = [startNumber];
+    while (frontier.length > 0) {
+      const targetLists = await mapPool(
+        frontier,
+        concurrency,
+        expandForPrefetch,
+      );
+      const next = [];
+      for (const targets of targetLists) {
+        for (const target of targets) {
+          if (!scheduled.has(target)) {
+            scheduled.add(target);
+            next.push(target);
+          }
+        }
+      }
+      frontier = next;
+    }
+  }
+  // Fetch one node and return its reference targets for the next BFS frontier.
+  // Mirrors the DFS expansion guard: only accessible, non-PR issues are
+  // expanded (PRs / inaccessible / not-found contribute no children), so the
+  // crawl's reachable set equals the DFS's.
+  async function expandForPrefetch(issueNumber) {
+    const issue = await getIssue(issueNumber, issueCache, loadIssue);
+    if (!issue || isInaccessibleIssue(issue) || issue.isPullRequest) {
+      return [];
+    }
+    return (await getReferences(issue)).map((reference) => reference.target);
+  }
+  function recordNode(issue, path) {
+    const existing = nodeRecords.get(issue.number);
+    const classification = classifyIssue(issue, markerPrefix, roadmapLabelName);
+    if (issue.number === rootIssue.number) {
+      classification.kind = 'roadmap';
+    }
+    const depth = path.length - 1;
+    if (existing) {
+      existing.depth = Math.min(existing.depth, depth);
+      return;
+    }
+    nodeRecords.set(issue.number, {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      labels: issue.labels,
+      classification: classification.kind,
+      roadmapMarkerId: classification.roadmapMarkerId,
+      autopilotSuitability: parseAutopilotSuitability(issue.body, markerPrefix),
+      effort: parseEffort(issue.body, markerPrefix),
+      depth,
+    });
+    recordProvenancePath(issue.number, path);
+  }
+  function recordProvenancePath(target, path) {
+    const pathKey = `${target}:${path.join('>')}`;
+    if (pathKeys.has(pathKey)) {
+      return;
+    }
+    pathKeys.add(pathKey);
+    provenancePaths.push({ target, path });
+  }
+  function recordDuplicateReference(edge, firstReference) {
+    const key = `${edge.source}:${edge.target}:${edge.relationship}:${edge.evidence}`;
+    if (duplicateKeys.has(key)) {
+      return;
+    }
+    duplicateKeys.add(key);
+    diagnostics.duplicateReferences.push({
+      source: edge.source,
+      target: edge.target,
+      relationship: edge.relationship,
+      evidence: edge.evidence,
+      firstSeenFrom: firstReference.source,
+    });
+  }
+}
+/**
+ * True when `error` is one of the three "this root number is not a usable
+ * roadmap root" failures {@link enumerateRoadmapGraph} throws for
+ * `rootNumber` itself (not found / inaccessible / is a pull request) — the
+ * only cases a configured `discover.legacyRoots` entry (#1315) or a
+ * race-closed label/marker root can legitimately hit. Matched by exact
+ * message text against this specific root number so an unrelated error
+ * that happens to share wording never matches by accident.
+ *
+ * Deliberately narrow (Copilot review, #1327): any other error — including
+ * the "was not recorded" internal-invariant guard, or an auth/rate-limit/
+ * network failure from `loadIssue`/`loadSubIssues` — is NOT expected here
+ * and must propagate, so a genuine systemic failure still fails the run
+ * instead of being silently downgraded to a per-root skip.
+ */
+function isExpectedRootEnumerationFailure(error, rootNumber) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error.message === `root issue #${rootNumber} was not found` ||
+    error.message === `root issue #${rootNumber} is inaccessible` ||
+    error.message === `root issue #${rootNumber} is a pull request`
+  );
+}
+/**
+ * Cross-roadmap autopilot discovery (additive `--all-roadmaps` mode).
+ *
+ * Discovers every OPEN roadmap root (an open issue carrying the
+ * `roadmap` label OR an `<!-- {markerPrefix}-roadmap-id: ... -->`
+ * marker), runs the existing single-root {@link enumerateRoadmapGraph}
+ * from each root, and returns the UNION of open execution leaves. A leaf
+ * reachable from several sibling roots is recorded once, carrying every
+ * `sourceRoots` it is reachable from (provenance), so it is never
+ * double-counted.
+ *
+ * Ranking (global-by-score): the union is sorted by `autopilotSuitability`
+ * DESCENDING, tie-broken by issue number ASCENDING (stable). Missing or
+ * out-of-range suitability is treated as the configured floor for
+ * ordering, but a leaf with no coherent score never ranks above a scored
+ * leaf at the same effective value — scored work always sorts first at a
+ * tie. See {@link compareUnionLeaves}.
+ *
+ * The helper stays READ-ONLY / evidence-only: it reads issue bodies and
+ * GitHub sub-issue relationships and never claims, mutates, or writes to
+ * GitHub. The single-root report shape is unchanged; this union shape is
+ * only produced in `--all-roadmaps` mode.
+ */
+export async function enumerateAllRoadmapsGraph(options = {}) {
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  // Resolve the configured suitability floor (normalized to an integer
+  // 1-5, falling back to the default when unset) once, then rank unscored
+  // leaves at that configured floor.
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor);
+  const loadOpenRoadmapRoots = options.loadOpenRoadmapRoots;
+  if (typeof loadOpenRoadmapRoots !== 'function') {
+    throw new Error(
+      'enumerateAllRoadmapsGraph requires loadOpenRoadmapRoots()',
+    );
+  }
+  const rootNumbers = normalizeOpenRoadmapRootNumbers(
+    await loadOpenRoadmapRoots(),
+  );
+  const roots = [];
+  const leafRecords = new Map();
+  // Diagnostics accumulate across every per-root enumeration, deduped on
+  // the same identity keys the single-root report uses so a reference
+  // shared by sibling roots is reported once.
+  const duplicateReferences = new Map();
+  const cycles = new Map();
+  const inaccessibleReferences = new Map();
+  const unresolvedReferences = new Map();
+  for (const rootNumber of rootNumbers) {
+    let graph;
+    try {
+      graph = await enumerateRoadmapGraph(rootNumber, {
+        markerPrefix,
+        roadmapLabelName: options.roadmapLabelName,
+        owner: options.owner,
+        repo: options.repo,
+        loadIssue: options.loadIssue,
+        loadSubIssues: options.loadSubIssues,
+        // #1136: each per-root enumeration prefetches its own subtree
+        // concurrently; thread the same bound through.
+        concurrency: options.concurrency,
+      });
+    } catch (error) {
+      // #1315: a configured `discover.legacyRoots` entry is static,
+      // human-entered config that can go stale (typo, deleted or
+      // transferred issue) far more easily than a label/marker root, which
+      // a live search just confirmed exists moments earlier. Skip the
+      // unusable root with a NON-FATAL warning (mirrors
+      // warnOnSearchResultCap's degraded-but-not-fatal precedent) instead
+      // of aborting the whole union — one bad configured number must not
+      // break cross-roadmap discovery for every other root.
+      //
+      // Narrow on purpose (Copilot review, #1327): only the three "this
+      // root number is not a usable root" failures qualify. Anything else
+      // — an auth/rate-limit/network error from loadIssue/loadSubIssues, a
+      // GraphQL failure, or the "was not recorded" internal-invariant
+      // guard — must rethrow, or a genuine systemic failure would be
+      // silently masked as a per-root skip and produce an incomplete
+      // report that still exits successfully.
+      if (!isExpectedRootEnumerationFailure(error, rootNumber)) {
+        throw error;
+      }
+      const reason = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `discover-roadmap-graph: --all-roadmaps root #${rootNumber} could not be enumerated (${reason}); skipping — root discovery may be incomplete.\n`,
+      );
+      continue;
+    }
+    roots.push({
+      number: graph.root.number,
+      title: graph.root.title,
+      state: graph.root.state,
+      roadmapMarkerId: graph.root.roadmapMarkerId,
+    });
+    const executionSet = new Set(graph.executionCandidates);
+    for (const node of graph.nodes) {
+      if (!executionSet.has(node.number)) {
+        continue;
+      }
+      const existing = leafRecords.get(node.number);
+      if (existing) {
+        if (!existing.sourceRoots.includes(graph.root.number)) {
+          existing.sourceRoots.push(graph.root.number);
+        }
+        continue;
+      }
+      leafRecords.set(node.number, {
+        number: node.number,
+        title: node.title,
+        state: node.state,
+        labels: node.labels,
+        // Only execution candidates reach this branch (filtered by
+        // executionSet above), so the classification is always 'execution'.
+        classification: 'execution',
+        roadmapMarkerId: node.roadmapMarkerId,
+        autopilotSuitability: node.autopilotSuitability,
+        effort: node.effort,
+        sourceRoots: [graph.root.number],
+      });
+    }
+    mergeDiagnostic(
+      duplicateReferences,
+      graph.diagnostics.duplicateReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.evidence}`,
+    );
+    mergeDiagnostic(
+      cycles,
+      graph.diagnostics.cycles,
+      (entry) => `${entry.source}:${entry.target}:${entry.path.join('>')}`,
+    );
+    mergeDiagnostic(
+      inaccessibleReferences,
+      graph.diagnostics.inaccessibleReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.reason}`,
+    );
+    mergeDiagnostic(
+      unresolvedReferences,
+      graph.diagnostics.unresolvedReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.reason}`,
+    );
+  }
+  const leaves = [...leafRecords.values()]
+    .map((leaf) => ({
+      ...leaf,
+      sourceRoots: [...leaf.sourceRoots].sort((left, right) => left - right),
+    }))
+    .sort((left, right) => compareUnionLeaves(left, right, floor));
+  // Opt-in (#1008): annotate the deduped union leaves once each. The per-root
+  // enumerations above intentionally run without `claimState`, so each issue's
+  // comments are fetched at most once here regardless of how many roots reach
+  // it. Gated on `options.claimState`, so the default path adds no extra
+  // GitHub API call and the union output shape stays byte-stable.
+  if (options.claimState) {
+    for (const leaf of leaves) {
+      const annotated = await annotateLeafClaimState(
+        leaf.number,
+        options.claimState,
+      );
+      leaf.activeClaim = annotated.activeClaim;
+      leaf.claimEligible = annotated.claimEligible;
+    }
+  }
+  // Opt-in (#1123): annotate the open union leaves with their A3 readiness in a
+  // single batch call. Runs after the claim loop so `startable` can fold in
+  // `claimEligible`. Gated on `options.readiness`, so the default path adds no
+  // extra API call and the output shape stays byte-stable.
+  // `options.loadIssue` is required for any enumeration to succeed (each
+  // per-root `enumerateRoadmapGraph` above throws without it), so by here it is
+  // always a function; the typeof guard narrows the optional option type for
+  // the required `annotateReadiness` parameter without an unsafe cast.
+  if (options.readiness && typeof options.loadIssue === 'function') {
+    await annotateReadiness(
+      leaves,
+      options.readiness,
+      options.loadIssue,
+      markerPrefix,
+    );
+  }
+  const scoredLeafCount = leaves.filter((leaf) =>
+    isAutopilotSuitabilityScore(leaf.autopilotSuitability),
+  ).length;
+  const sharedLeafCount = leaves.filter(
+    (leaf) => leaf.sourceRoots.length > 1,
+  ).length;
+  // Only meaningful when readiness was annotated above; the same gate keeps
+  // the flag-absent summary byte-stable (both counts stay absent).
+  const readinessAnnotated = Boolean(
+    options.readiness && typeof options.loadIssue === 'function',
+  );
+  const readinessCounts = readinessAnnotated
+    ? {
+        startableCount: leaves.filter(
+          (leaf) => leaf.readiness?.startable === true,
+        ).length,
+        readyCount: leaves.filter((leaf) => leaf.readiness?.ready === true)
+          .length,
+      }
+    : {};
+  return {
+    mode: 'all-roadmaps',
+    roots: roots.sort(compareByNumber),
+    leaves,
+    diagnostics: {
+      duplicateReferences: [...duplicateReferences.values()].sort(
+        compareDiagnostics,
+      ),
+      cycles: [...cycles.values()].sort(compareCycles),
+      inaccessibleReferences: [...inaccessibleReferences.values()].sort(
+        compareDiagnostics,
+      ),
+      unresolvedReferences: [...unresolvedReferences.values()].sort(
+        compareDiagnostics,
+      ),
+    },
+    summary: {
+      rootCount: roots.length,
+      leafCount: leaves.length,
+      scoredLeafCount,
+      sharedLeafCount,
+      ...readinessCounts,
+      duplicateReferenceCount: duplicateReferences.size,
+      cycleCount: cycles.size,
+      inaccessibleReferenceCount: inaccessibleReferences.size,
+      unresolvedReferenceCount: unresolvedReferences.size,
+    },
+  };
+}
+/**
+ * Global-by-score comparator for the cross-roadmap union.
+ *
+ * Sort key, in order:
+ *   1. effective suitability DESCENDING — a coherent 1-5 score uses its
+ *      own value; a missing/out-of-range score uses the configured floor
+ *      so unscored pre-existing work is not buried below the floor;
+ *   2. scored-before-unscored at a tie — a leaf with a coherent score
+ *      never ranks below an unscored leaf at the same effective value, so
+ *      "missing is treated as the configured floor" never lets unscored
+ *      work jump ahead of genuinely scored work;
+ *   3. issue number ASCENDING — a stable, repository-deterministic
+ *      tie-break that keeps the order from thrashing between epics.
+ *
+ * `floor` is the configured `autopilotSuitability.floor` (already
+ * normalized to an integer 1-5). The comparator stays a total order.
+ */
+function compareUnionLeaves(left, right, floor) {
+  const leftScored = isAutopilotSuitabilityScore(left.autopilotSuitability);
+  const rightScored = isAutopilotSuitabilityScore(right.autopilotSuitability);
+  // Unscored or out-of-range leaves rank at the configured floor.
+  const leftEffective = leftScored ? left.autopilotSuitability : floor;
+  const rightEffective = rightScored ? right.autopilotSuitability : floor;
+  // Soft effort tie-breaker (after the suitability score, before the
+  // lowest-issue-number fallback): within one effective-score band prefer
+  // the lower-effort leaf (S < M < L). A missing/invalid hint resolves to
+  // the neutral middle ordinal via effortOrdinal, so a band with no effort
+  // hints stays ordered by issue number exactly as before. This never
+  // crosses a score band and never drops a leaf — a large issue is still
+  // selectable when it is the only ready work.
+  return (
+    rightEffective - leftEffective ||
+    Number(rightScored) - Number(leftScored) ||
+    effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
+    left.number - right.number
+  );
+}
+function mergeDiagnostic(store, entries, keyOf) {
+  for (const entry of entries) {
+    const key = keyOf(entry);
+    if (!store.has(key)) {
+      store.set(key, entry);
+    }
+  }
+}
+function normalizeOpenRoadmapRootNumbers(roots) {
+  if (!Array.isArray(roots)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      roots
+        .map((entry) => {
+          if (typeof entry === 'number') {
+            return entry;
+          }
+          return Number.parseInt(String(entry?.number ?? entry), 10);
+        })
+        .filter((value) => Number.isInteger(value) && value > 0),
+    ),
+  ].sort((left, right) => left - right);
+}
+/**
+ * Annotate each OPEN entry with its A3 readiness verdict (`--with-readiness`)
+ * by composing the batch `evaluateDiscoverReadiness` helper over the open
+ * entry numbers — one call, reusing the enclosing enumeration's `loadIssue`
+ * and `markerPrefix` so no second issue loader is constructed. Closed entries
+ * are skipped (only open execution work is a start candidate).
+ *
+ * `evaluateDiscoverReadiness` classifies every input number into `ready` or
+ * `filteredOut` (an inaccessible/closed issue lands in `filteredOut` with a
+ * sentinel reason), so each open entry resolves to a definite verdict. The
+ * combined `startable` hint folds in `claimEligible` when `--with-claim-state`
+ * also ran; otherwise claim eligibility is unknown and treated as
+ * non-blocking. The suitability floor is left to the helper default because
+ * the readiness classification (labels + dependencies) does not read the
+ * score.
+ */
+async function annotateReadiness(entries, readiness, loadIssue, markerPrefix) {
+  const openEntries = entries.filter(
+    (entry) => String(entry.state).toUpperCase() === 'OPEN',
+  );
+  if (openEntries.length === 0) {
+    return;
+  }
+  const summary = await evaluateDiscoverReadiness(
+    openEntries.map((entry) => entry.number),
+    {
+      // We read only `ready` / `filteredOut[].reasons`, so the unresolvable
+      // bucket and the authoring-stale `warning` (and thus its
+      // `loadIssueLabelEvents` timeline fetch) are intentionally not wired —
+      // `authoringHeld` is label-presence-based and needs neither.
+      includeUnresolvable: false,
+      loadIssue,
+      findRoadmapsByMarker: readiness.findRoadmapsByMarker,
+      authoringLabelName: readiness.authoringLabelName,
+      authoringStaleAgeMs: readiness.authoringStaleAgeMs,
+      roadmapLabelName: readiness.roadmapLabelName,
+      blockedByHumanLabelName: readiness.blockedByHumanLabelName,
+      needsDecisionLabelName: readiness.needsDecisionLabelName,
+      markerPrefix,
+      now: readiness.nowIso,
+    },
+  );
+  const readyNumbers = new Set(summary.ready.map((entry) => entry.number));
+  const reasonsByNumber = new Map(
+    summary.filteredOut.map((entry) => [entry.number, entry.reasons]),
+  );
+  const authoringReason = `label:${readiness.authoringLabelName}`;
+  for (const entry of openEntries) {
+    const ready = readyNumbers.has(entry.number);
+    const reasons = reasonsByNumber.get(entry.number) ?? [];
+    entry.readiness = {
+      ready,
+      reasons,
+      authoringHeld: reasons.includes(authoringReason),
+      startable: ready && entry.claimEligible !== false,
+    };
+  }
+}
+/**
+ * Resolve one execution leaf's active-claim eligibility (#1008).
+ *
+ * Fetches the leaf issue's comments via the injected `loadComments` loader,
+ * resolves the ACTIVE claim with the SHARED `resolveActiveClaim` from
+ * protocol-helpers (trusted-author gated, stale-age aware), then derives
+ * present/stale/eligibility. `activeClaim` is ALWAYS returned as an object
+ * (Design O): `present: false` (with `claimId: null`, `agentId: null`) when no
+ * trusted claim is present, `present: true` otherwise. A leaf is eligible when
+ * there is NO present, non-stale, trusted-actor claim. The shared
+ * `parseClaimComment` / `resolveActiveClaim` parsing is reused read-only and
+ * never re-implemented here.
+ *
+ * Intentional limitation: this annotation resolves only NEW-format
+ * `claimed-by` markers via the shared `resolveActiveClaim`. It deliberately
+ * does NOT factor in legacy claim-id-less markers nor forced-handoff
+ * transfers, both of which the authoritative resume/claim path handles
+ * (resume-claim-routing's `resolveLegacyClaimState` and forced-handoff
+ * authorization). Replicating that here would require duplicating that
+ * machinery plus per-candidate permission API calls, which is out of scope
+ * for this read-only discovery hint. `claimEligible` is therefore a
+ * best-effort SOFT signal only; the authoritative A5 claim gate
+ * (`idd-claim.instructions.md`), which DOES account for legacy markers and
+ * forced handoffs, remains the real protection.
+ */
+export async function annotateLeafClaimState(issueNumber, claimState) {
+  const comments = normalizeClaimComments(
+    await claimState.loadComments(issueNumber),
+  );
+  const active = resolveActiveClaim(comments, {
+    isTrustedAuthor: claimState.isTrustedAuthor,
+    // The 24h math is not re-derived: when the configured stale age equals the
+    // PT24H default, the shared `isStaleAt` is reused as-is;
+    // otherwise the same comparison is applied with the configured age.
+    isStale: (activeCreatedAt, nextCreatedAt) =>
+      isClaimStaleByAge(activeCreatedAt, nextCreatedAt, claimState.staleAgeMs),
+  });
+  if (!active) {
+    // No present trusted claim → eligible. When `--current-claim-id` is
+    // supplied, `ownedByCurrentSession` is still emitted (as `false`) because
+    // there is no claim id to match it; it is omitted only when no
+    // `--current-claim-id` was passed. `heartbeatOverdue` is always `false`
+    // here (#1433): with no present claim there is nothing to be overdue.
+    return {
+      activeClaim: {
+        present: false,
+        stale: false,
+        claimId: null,
+        agentId: null,
+        heartbeatOverdue: false,
+        ...(claimState.currentClaimId ? { ownedByCurrentSession: false } : {}),
+      },
+      claimEligible: true,
+    };
+  }
+  // Staleness of the present claim is measured against "now": a claim whose
+  // createdAt is older than the configured stale age is a stale (takeover-
+  // eligible) claim, mirroring resume-claim-routing's active-claim staleness.
+  const stale = isClaimStaleByAge(
+    active.createdAt,
+    claimState.nowIso,
+    claimState.staleAgeMs,
+  );
+  // `active.createdAt` already reflects the LATEST valid claimed-by/heartbeat
+  // event (resolveActiveClaim / applyClaimEvent folds every accepted
+  // heartbeat's own createdAt into it), so no separate heartbeat-only scan is
+  // needed to answer "no later trusted heartbeat exists" — this reuses the
+  // exact same timestamp the `stale` computation above already resolved,
+  // just against the shorter, purely-diagnostic heartbeat interval (#1433).
+  const heartbeatOverdue = isClaimHeartbeatOverdue(
+    active.createdAt,
+    claimState.nowIso,
+    claimState.heartbeatIntervalMs,
+  );
+  const annotation = {
+    present: true,
+    stale,
+    claimId: active.claimId,
+    agentId: active.agentId,
+    heartbeatOverdue,
+  };
+  if (claimState.currentClaimId) {
+    annotation.ownedByCurrentSession =
+      active.claimId === claimState.currentClaimId;
+  }
+  // Eligible only when there is no present, NON-stale, trusted claim. A stale
+  // claim is takeover-eligible, so it does not block. `heartbeatOverdue` NEVER
+  // factors into this: it is purely diagnostic (#1433) and must not change
+  // who is claim-eligible.
+  return { activeClaim: annotation, claimEligible: stale };
+}
+/** Coerce a loaded comment payload into the `resolveActiveClaim` event shape. */
+function normalizeClaimComments(raw) {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.map((entry) => {
+    const comment = entry ?? {};
+    return {
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      author: {
+        login: String(comment.author?.login ?? comment.user?.login ?? ''),
+      },
+    };
+  });
+}
+/**
+ * Claim staleness by configured age. When the configured age equals the PT24H
+ * policy default, the shared `isStaleAt` is reused verbatim
+ * (the 24h math lives there, not here); otherwise the same millisecond
+ * comparison is applied with the configured age. Mirrors
+ * resume-claim-routing's `isStaleByAge`.
+ */
+export function isClaimStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
+  if (staleAgeMs === DEFAULT_CLAIM_STALE_AGE_MS) {
+    return isStaleAt(activeCreatedAt, nextCreatedAt);
+  }
+  const start = Date.parse(activeCreatedAt ?? '');
+  const end = Date.parse(nextCreatedAt ?? '');
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return false;
+  }
+  return end - start >= staleAgeMs;
+}
+/**
+ * Whether the latest valid claimed-by/heartbeat `createdAt` is at or past the
+ * configured `claimTiming.heartbeatInterval` relative to `nowIso`, with no
+ * later trusted heartbeat (#1433). The caller already threads every valid
+ * heartbeat's `createdAt` through `resolveActiveClaim` / `applyClaimEvent`
+ * (a heartbeat replaces the active claim's `createdAt` with its own event
+ * timestamp), so `activeCreatedAt` here already IS the latest valid
+ * claimed-by/heartbeat event — no separate heartbeat-only comment scan is
+ * needed.
+ *
+ * Reuses {@link isClaimStaleByAge}'s generic "duration between two ISO
+ * timestamps >= configured age" comparison under a name that matches this
+ * call site's intent: that function's `stale`-specific name describes its
+ * primary caller, not its logic, which is a plain millisecond-difference
+ * check with a same-default-value fast path. This is purely diagnostic: it
+ * never feeds the 24h stale-takeover gate, only the informational
+ * `heartbeatOverdue` annotation.
+ */
+export function isClaimHeartbeatOverdue(
+  activeCreatedAt,
+  nowIso,
+  heartbeatIntervalMs,
+) {
+  return isClaimStaleByAge(activeCreatedAt, nowIso, heartbeatIntervalMs);
+}
+/**
+ * Build the CLI-side claim-state resolution: the live comment loader plus the
+ * resolved trusted-actor predicate, configured stale age, and "now". Only
+ * invoked when `--with-claim-state` is passed, so the live comment fetch is
+ * never wired in the default path.
+ *
+ * Exported (#1395) so `discover-orphan-filter.mts`'s CLI can build the same
+ * resolution from its own parsed policy/args instead of re-implementing this
+ * wiring. `policy` intentionally takes the *raw* parsed config shape (as
+ * returned by this file's own `loadPolicy`), not a normalized/flattened view.
+ */
+export function buildClaimStateResolution(owner, repo, policy, currentClaimId) {
+  const staleAgeMs =
+    parseClaimStaleAgeMs(policy.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
+  const heartbeatIntervalMs =
+    parseClaimHeartbeatIntervalMs(policy.claimTiming?.heartbeatInterval) ??
+    DEFAULT_CLAIM_HEARTBEAT_INTERVAL_MS;
+  return {
+    loadComments: buildCommentLoader(owner, repo),
+    isTrustedAuthor: buildTrustedAuthorPredicate(policy),
+    staleAgeMs,
+    heartbeatIntervalMs,
+    nowIso: new Date().toISOString(),
+    currentClaimId: String(currentClaimId ?? '').trim(),
+  };
+}
+/**
+ * Build the CLI-side readiness resolution: the roadmap-marker resolver (the
+ * one new GitHub API surface, an A3-authorized scoped body search) plus the
+ * resolved authoring-hold policy. Only invoked when `--with-readiness` is
+ * passed, so the resolver is never wired in the default path.
+ */
+function buildReadinessResolution(owner, repo, policy) {
+  const authoringPolicy = resolveAuthoringGuardPolicy(policy);
+  const markerPrefix = normalizeMarkerPrefix(policy.markerPrefix);
+  const labelsPolicy = normalizePolicyConfig(policy).labels;
+  return {
+    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
+    authoringLabelName: authoringPolicy.labelName,
+    authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    nowIso: new Date().toISOString(),
+  };
+}
+/**
+ * Build the case-insensitive trusted-marker-author predicate for the
+ * `--with-claim-state` annotation.
+ *
+ * Trusted actors are resolved through the shared
+ * {@link resolveTrustedMarkerActors} helper so this CLI honors the
+ * `IDD_TRUSTED_MARKER_ACTORS` env override exactly like every other evidence
+ * helper, not just the `trustedMarkerActors` array declared in policy. The
+ * resolved actors are already trimmed, lowercased, and deduped, so the
+ * predicate only needs to normalize the incoming login the same way.
+ *
+ * When the resolved set is empty no author is trusted, so no claim resolves
+ * and every leaf reads as `claimEligible: true`. This is a soft,
+ * availability-preferring default for the advisory discovery hint (it does
+ * NOT fail closed on eligibility): an unverifiable claim marker is simply not
+ * honored. The authoritative A5 claim gate (idd-claim.instructions.md) remains
+ * the real protection against acting on a contested claim.
+ */
+export function buildTrustedAuthorPredicate(policy) {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: policy,
+  });
+  const trustedActors = new Set(actors);
+  return (login) =>
+    trustedActors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+/**
+ * Live per-issue comment loader (the sole new GitHub API surface).
+ *
+ * Exported (#1395) so `discover-orphan-filter.mts` can reuse the identical
+ * loader instead of duplicating this pagination/`gh` wiring.
+ *
+ * Async (#1394) so each page's `runGh(...) + JSON.parse(...)` fetch can be
+ * bounded-retried on a transient failure (e.g. truncated captured stdout
+ * under heavy concurrent load). Behavior-preserving: the sole caller
+ * (`annotateLeafClaimState`) already `await`s the returned value, and
+ * `ClaimStateResolution.loadComments` is typed as `Awaitable<...>` (#1395)
+ * to accommodate exactly this.
+ */
+export function buildCommentLoader(owner, repo) {
+  return async (issueNumber) => {
+    const comments = [];
+    const pageSize = 100;
+    for (let page = 1; ; page += 1) {
+      const pageItems = await withBoundedRetry(async () => {
+        const raw = runGh([
+          'api',
+          `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+          '--jq',
+          '.',
+        ]).trim();
+        return raw && raw !== 'null' ? JSON.parse(raw) : [];
+      });
+      if (!Array.isArray(pageItems) || pageItems.length === 0) {
+        break;
+      }
+      comments.push(...pageItems);
+      if (pageItems.length < pageSize) {
+        break;
+      }
+    }
+    return comments;
+  };
+}
+/**
+ * Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; `null` on garbage OR
+ * a non-positive total. A `PT0S` (or any zero/empty-component) duration is
+ * rejected so the caller falls back to `DEFAULT_CLAIM_STALE_AGE_MS` instead of
+ * configuring a 0ms stale age that would mark every claim immediately stale.
+ *
+ * Thin wrapper over the shared `parseIsoDurationToMs` from policy-helpers
+ * (the single source of truth for ISO-8601 duration parsing, with its own
+ * tests). It already returns `null` for both garbage and a non-positive total,
+ * which is exactly the behavior required here. The unknown input is coerced to
+ * a trimmed string first so non-string/nullish values resolve to `null`
+ * (the shared parser accepts only strings).
+ */
+export function parseClaimStaleAgeMs(value) {
+  return parseIsoDurationToMs(String(value ?? '').trim());
+}
+/**
+ * Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms for
+ * `claimTiming.heartbeatInterval` (#1433); `null` on garbage OR a
+ * non-positive total, mirroring {@link parseClaimStaleAgeMs}'s
+ * garbage/non-positive handling so the caller falls back to
+ * `DEFAULT_CLAIM_HEARTBEAT_INTERVAL_MS` the same way a rejected stale age
+ * falls back to `DEFAULT_CLAIM_STALE_AGE_MS`.
+ */
+export function parseClaimHeartbeatIntervalMs(value) {
+  return parseIsoDurationToMs(String(value ?? '').trim());
+}
+export function extractRoadmapMarkerId(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(markerPrefix)}-roadmap-id:\\s*([^\\s>]+)\\s*-->`,
+    'i',
+  );
+  const match = regex.exec(stripMarkdownCodeRegions(String(body ?? '')));
+  return match ? match[1] : '';
+}
+export function classifyIssue(
+  issue,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+  roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
+) {
+  // Re-validate even though the parameter already has a default: a caller
+  // (direct or test) that explicitly passes an empty string would otherwise
+  // bypass the default (parameter defaults only trigger on `undefined`) and
+  // silently disable the roadmap-label check. Use a cheap non-empty-string
+  // check rather than the full normalizeRoadmapLabelName()/
+  // normalizePolicyConfig() — classifyIssue() runs once per node during
+  // graph enumeration, so rebuilding the whole policy-defaults object here
+  // would be avoidable per-node overhead; callers that need policy-level
+  // normalization already do it once via normalizeRoadmapLabelName() before
+  // reaching this function.
+  const resolvedRoadmapLabelName =
+    typeof roadmapLabelName === 'string' && roadmapLabelName.length > 0
+      ? roadmapLabelName
+      : POLICY_DEFAULTS.labels.roadmapLabelName;
+  const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
+  const labels = normalizeLabels(issue.labels);
+  if (roadmapMarkerId || labels.has(resolvedRoadmapLabelName)) {
+    return {
+      kind: 'roadmap',
+      roadmapMarkerId,
+    };
+  }
+  return {
+    kind: 'execution',
+    roadmapMarkerId: '',
+  };
+}
+export function extractTaskListReferences(body) {
+  // Match against a code-masked copy so a checkbox merely quoted inside inline
+  // code or a fenced block is not walked as a real task-list edge — consistent
+  // with the #1121 boundary already applied to extractRoadmapMarkerId (#1204).
+  // stripMarkdownCodeRegions preserves the line count, so the masked and raw
+  // lines share an index and evidence stays the raw line for any surviving edge
+  // (e.g. one that shares a line with unrelated inline code).
+  const rawBody = String(body ?? '');
+  const rawLines = rawBody.split(/\r?\n/u);
+  const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
+  return maskedLines.flatMap((maskedLine, index) => {
+    const match = maskedLine.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
+    if (!match) {
+      return [];
+    }
+    const target = Number.parseInt(match[1], 10);
+    return Number.isInteger(target) && target > 0
+      ? [
+          {
+            target,
+            relationship: 'task-list',
+            evidence: (rawLines[index] ?? maskedLine).trim(),
+          },
+        ]
+      : [];
+  });
+}
+export function extractKeywordReferences(body, options = {}) {
+  const references = [];
+  const currentRepoRef = normalizeRepoRef(
+    options.currentRepoRef
+      ? options.currentRepoRef.split('/')[0]
+      : options.owner,
+    options.currentRepoRef
+      ? options.currentRepoRef.split('/')[1]
+      : options.repo,
+  );
+  // Run the keyword match AND the trailing-segment scan against a code-masked
+  // copy of the body so a reference merely quoted inside inline code or a fenced
+  // block is not walked as a real graph edge — consistent with the #1121
+  // boundary already applied to extractRoadmapMarkerId (#1204). Only `evidence`
+  // reads the raw line; stripMarkdownCodeRegions preserves the line count, so
+  // the masked and raw lines share an index and evidence stays byte-identical
+  // for any surviving edge that is not itself inside/adjacent to code.
+  const rawBody = String(body ?? '');
+  const rawLines = rawBody.split(/\r?\n/u);
+  const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
+  for (let lineIndex = 0; lineIndex < maskedLines.length; lineIndex += 1) {
+    const maskedLine = maskedLines[lineIndex];
+    const rawLine = rawLines[lineIndex] ?? maskedLine;
+    const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
+    for (let index = 0; index < keywordMatches.length; index += 1) {
+      const match = keywordMatches[index];
+      const segmentStart = (match.index ?? 0) + match[0].length;
+      const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
+      const segment = maskedLine.slice(segmentStart, segmentEnd);
+      for (const target of extractKeywordReferenceTargets(
+        segment,
+        currentRepoRef,
+      )) {
+        if (!Number.isInteger(target) || target <= 0) {
+          continue;
+        }
+        references.push({
+          target,
+          relationship: classifyKeywordRelationship(match[1]),
+          evidence: rawLine.trim(),
+        });
+      }
+    }
+  }
+  return references;
+}
+function classifyKeywordRelationship(keyword) {
+  const normalized = String(keyword ?? '').toLowerCase();
+  if (normalized.startsWith('depend') || normalized.startsWith('blocked')) {
+    return 'dependency';
+  }
+  if (normalized.startsWith('sub')) {
+    return 'sub-issue-reference';
+  }
+  if (normalized.startsWith('ref')) {
+    return 'reference';
+  }
+  return 'closing-keyword';
+}
+function extractKeywordReferenceTargets(segment, currentRepoRef) {
+  const targets = [];
+  let remaining = String(segment ?? '')
+    .trimStart()
+    .replace(/^:\s*/u, '');
+  while (remaining) {
+    const match = remaining.match(/^(?:([\w.-]+\/[\w.-]+)#(\d+)|#(\d+))/u);
+    if (!match) {
+      break;
+    }
+    const qualifiedRepoRef = match[1]
+      ? normalizeRepoRef(...match[1].split('/'))
+      : '';
+    const target = Number.parseInt(match[2] ?? match[3] ?? '', 10);
+    if (
+      (!qualifiedRepoRef || qualifiedRepoRef === currentRepoRef) &&
+      Number.isInteger(target) &&
+      target > 0
+    ) {
+      targets.push(target);
+    }
+    remaining = remaining.slice(match[0].length);
+    const separatorMatch = remaining.match(
+      /^\s*(?:,\s*(?:and\s*)?|\band\b\s*)/iu,
+    );
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
+  }
+  return targets;
+}
+function normalizeRepoRef(owner, repo) {
+  const normalizedOwner = String(owner ?? '')
+    .trim()
+    .toLowerCase();
+  const normalizedRepo = String(repo ?? '')
+    .trim()
+    .toLowerCase();
+  return normalizedOwner && normalizedRepo
+    ? `${normalizedOwner}/${normalizedRepo}`
+    : '';
+}
+function normalizeSubIssueReferences(subIssues) {
+  return normalizeSubIssueNumbers(subIssues).map((target) => ({
+    target,
+    relationship: 'sub-issue',
+    evidence: `GitHub sub-issue #${target}`,
+  }));
+}
+function normalizeSubIssueNumbers(subIssues) {
+  if (!Array.isArray(subIssues)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      subIssues
+        .map((entry) => {
+          if (typeof entry === 'number') {
+            return entry;
+          }
+          return Number.parseInt(String(entry?.number ?? entry), 10);
+        })
+        .filter((value) => Number.isInteger(value) && value > 0),
+    ),
+  ];
+}
+// Excluded from the #1446 cli-args.mts wrapper: --current-claim-id and
+// --concurrency below are optional-value flags -- each may appear bare or
+// take a following value, consuming the next token only when one is
+// present and does not itself look like another flag. `util.parseArgs`
+// cannot express this: a `string`-type option always requires exactly one
+// value and a `boolean`-type option never takes one; there is no
+// in-between mode.
+function parseArgs(argv) {
+  const parsed = {
+    issue: 0,
+    allRoadmaps: false,
+    owner: '',
+    repo: '',
+    policy: '',
+    withClaimState: false,
+    withReadiness: false,
+    currentClaimId: '',
+    concurrency: 0,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--issue') {
+      parsed.issue = Number.parseInt(String(value ?? ''), 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--all-roadmaps') {
+      parsed.allRoadmaps = true;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--policy') {
+      parsed.policy = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--with-claim-state') {
+      parsed.withClaimState = true;
+      continue;
+    }
+    if (token === '--with-readiness') {
+      parsed.withReadiness = true;
+      continue;
+    }
+    if (token === '--concurrency') {
+      // Only consume the next token as the value when it exists and is not
+      // itself a flag, mirroring --current-claim-id, so
+      // `--concurrency --issue 700` does not swallow the following flag. A
+      // missing/flag value leaves concurrency unset (0 → normalized default).
+      if (value !== undefined && !value.startsWith('--')) {
+        // Use Number (not parseInt) so a non-integer like "2.5" stays
+        // non-integer and normalizeConcurrency falls back to the default,
+        // rather than being truncated to 2.
+        parsed.concurrency = Number(value);
+        index += 1;
+      }
+      continue;
+    }
+    if (token === '--current-claim-id') {
+      // Only consume the next token as the id when it exists and is not itself
+      // a flag, so `--current-claim-id --with-claim-state` does not swallow the
+      // following flag as the id. A missing/flag value leaves currentClaimId
+      // empty and the next flag is left for its own iteration.
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.currentClaimId = value;
+        index += 1;
+      }
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>] [--concurrency <n>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>] [--concurrency <n>]
+
+  --issue and --all-roadmaps are mutually exclusive; exactly one is required.
+
+  --concurrency <n> (default 8) bounds how many issue fetches the traversal
+  prefetch keeps in flight at once. The graph is byte-identical for any n;
+  only fetch ordering and wall-clock change. Pass 1 to fetch serially.
+  --all-roadmaps enumerates open execution leaves across every open roadmap
+  root (the union), each tagged with its sourceRoots and ranked by
+  autopilotSuitability (descending, tie-broken by ascending issue number).
+
+  --with-claim-state (opt-in) annotates each OPEN execution leaf with active-
+  claim eligibility: it fetches that issue's comments and resolves the active
+  claim using the configured trustedMarkerActors, claimTiming.staleAge
+  (default PT24H), and claimTiming.heartbeatInterval (default PT12H). Each
+  annotated leaf gains (activeClaim is always an object):
+    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null, "heartbeatOverdue": bool }
+                   (present:false with claimId/agentId null = no trusted claim)
+    "claimEligible": bool   (eligible = no present, non-stale, trusted claim)
+  Absent the flag, NO comment API calls are made and no claim fields are
+  emitted (the output shape is byte-stable).
+  heartbeatOverdue is true when the latest valid claimed-by/heartbeat
+  created_at is at or past claimTiming.heartbeatInterval with no later
+  trusted heartbeat; false otherwise, including whenever present is false.
+  It is PURELY DIAGNOSTIC: it never feeds claimEligible or any other gate — a
+  heartbeat-overdue claim can still be well inside the 24h stale window.
+  --current-claim-id <id> additionally sets "ownedByCurrentSession": bool on
+  each activeClaim (true when the active claim's claimId equals <id>).
+  NOTE: claimEligible is a best-effort SOFT discovery hint. It resolves only
+  new-format claimed-by markers and intentionally does NOT account for legacy
+  claim-id-less markers or forced-handoff transfers; the authoritative A5
+  claim gate (idd-claim.instructions.md) remains the real protection.
+
+  --with-readiness (opt-in) annotates each OPEN execution leaf with its A3
+  startability by composing the discover-readiness-check helper (dependency
+  resolution + authoring-hold). Each annotated leaf gains:
+    "readiness": { "ready": bool, "reasons": [str], "authoringHeld": bool, "startable": bool }
+      ready      = no blocking label + every dep closed (Blocked by #N / Depends on #N
+                   / task-list refs / {prefix}-blocked-by markers)
+      reasons    = sorted filter reasons (e.g. "blocked_by_open_issue:#N"); empty when ready
+      startable  = ready AND not claim-blocked (folds in claimEligible when --with-claim-state
+                   also ran; otherwise claim eligibility is unknown and treated as non-blocking)
+  Absent the flag, NO extra API calls are made and no readiness field is emitted
+  (the output shape is byte-stable). Like claimEligible this is a SOFT hint; the
+  A3/A4/A4.5/A5 gates remain authoritative.
+
+Output schema (JSON mode) — --issue single-root report:
+  {
+    "root": { "number": 638, "title": "...", "state": "OPEN", "classification": "roadmap", "roadmapMarkerId": "..." },
+    "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "autopilotSuitability": null, "depth": 0 }],
+    "edges": [{ "source": 638, "target": 640, "relationship": "task-list", "evidence": "- [ ] #640" }],
+    "provenancePaths": [{ "target": 640, "path": [638, 640] }],
+    "roadmapNodes": [],
+    "executionCandidates": [640],
+    "diagnostics": {
+      "duplicateReferences": [],
+      "cycles": [],
+      "inaccessibleReferences": [],
+      "unresolvedReferences": []
+    },
+    "summary": {
+      "rootNumber": 638,
+      "nodeCount": 2,
+      "edgeCount": 1,
+      "roadmapNodeCount": 0,
+      "executionCandidateCount": 1,
+      "duplicateReferenceCount": 0,
+      "cycleCount": 0,
+      "inaccessibleReferenceCount": 0,
+      "unresolvedReferenceCount": 0,
+      "maxDepth": 1
+    }
+  }
+
+Output schema (JSON mode) — --all-roadmaps union report (a different
+top-level shape from the single-root report above):
+  {
+    "mode": "all-roadmaps",
+    "roots": [{ "number": 638, "title": "...", "state": "OPEN", "roadmapMarkerId": "..." }],
+    "leaves": [{ "number": 640, "title": "...", "state": "OPEN", "labels": ["..."], "classification": "execution", "roadmapMarkerId": "", "autopilotSuitability": null, "sourceRoots": [638] }],
+    "diagnostics": {
+      "duplicateReferences": [],
+      "cycles": [],
+      "inaccessibleReferences": [],
+      "unresolvedReferences": []
+    },
+    "summary": {
+      "rootCount": 1,
+      "leafCount": 1,
+      "scoredLeafCount": 0,
+      "sharedLeafCount": 0,
+      "duplicateReferenceCount": 0,
+      "cycleCount": 0,
+      "inaccessibleReferenceCount": 0,
+      "unresolvedReferenceCount": 0
+    }
+  }
+  (Under --with-readiness the summary also carries "startableCount" and
+  "readyCount" aggregating the union leaves' readiness; both are absent
+  otherwise so the flag-absent output stays byte-stable.)
+`);
+}
+function normalizeIssue(issue) {
+  return {
+    number: Number.parseInt(String(issue.number ?? issue.id ?? 0), 10),
+    title: String(issue.title ?? ''),
+    state: String(issue.state ?? '').toUpperCase(),
+    body: String(issue.body ?? ''),
+    labels: normalizeLabels(issue.labels),
+    isPullRequest: Boolean(issue.pull_request),
+    subIssueSummaryTotal: extractSubIssueSummaryTotal(issue.sub_issues_summary),
+  };
+}
+/**
+ * Read the native sub-issue count from a REST `sub_issues_summary` object.
+ * Returns the non-negative integer `total`, or null when the field is absent
+ * or not a coherent count — the "unknown" case that keeps the sub-issue query
+ * (fail-safe), so only a proven `0` skips it.
+ */
+function extractSubIssueSummaryTotal(summary) {
+  const total = summary?.total;
+  return typeof total === 'number' && Number.isInteger(total) && total >= 0
+    ? total
+    : null;
+}
+function normalizeLabels(labelsInput) {
+  if (!labelsInput) {
+    return new Set();
+  }
+  if (labelsInput instanceof Set) {
+    return new Set([...labelsInput].map(normalizeLabelName).filter(Boolean));
+  }
+  if (Array.isArray(labelsInput)) {
+    return new Set(
+      labelsInput
+        .map((label) => {
+          if (typeof label === 'string') {
+            return normalizeLabelName(label);
+          }
+          return normalizeLabelName(label?.name);
+        })
+        .filter(Boolean),
+    );
+  }
+  return new Set();
+}
+function normalizeLabelName(label) {
+  return String(label ?? '')
+    .trim()
+    .toLowerCase();
+}
+function normalizeMarkerPrefix(markerPrefix) {
+  const normalized = String(markerPrefix ?? '').trim();
+  return normalized || DEFAULT_MARKER_PREFIX;
+}
+/**
+ * Resolve the configured `labels.roadmapLabelName` (#1273), falling back to
+ * the `policy-helpers.mts` default (`'roadmap'`) for an absent or invalid
+ * value. Routing an already-`unknown` field through `normalizePolicyConfig`
+ * (rather than hand-rolling the same non-empty-string check again) keeps the
+ * validation and the default in the single source of truth.
+ */
+function normalizeRoadmapLabelName(roadmapLabelName) {
+  return normalizePolicyConfig({ labels: { roadmapLabelName } }).labels
+    .roadmapLabelName;
+}
+/**
+ * Resolve the configured `discover.legacyRoots` (issue numbers of legacy
+ * roadmap roots that predate the `roadmap` label / `roadmap-id` marker),
+ * falling back to the `policy-helpers.mts` default (`[]`) for an absent or
+ * invalid value. Same routing-through-`normalizePolicyConfig` shape as
+ * {@link normalizeRoadmapLabelName}, so the fail-safe parsing stays in the
+ * single source of truth.
+ */
+function normalizeLegacyRoots(legacyRoots) {
+  return normalizePolicyConfig({ discover: { legacyRoots } }).discover
+    .legacyRoots;
+}
+async function getIssue(issueNumber, cache, loadIssue) {
+  if (cache.has(issueNumber)) {
+    return cache.get(issueNumber) ?? null;
+  }
+  const rawIssue = await loadIssue(issueNumber);
+  const issue = isInaccessibleIssue(rawIssue)
+    ? INACCESSIBLE_ISSUE_SENTINEL
+    : rawIssue
+      ? normalizeIssue(rawIssue)
+      : null;
+  cache.set(issueNumber, issue);
+  return issue;
+}
+/**
+ * Live per-issue loader for the traversal hot path.
+ *
+ * Bounded-retried (#1394): the `runGhAsync(...) + JSON.parse(...)` body runs
+ * inside {@link withBoundedRetry} so a transient hiccup — including a
+ * truncated-stdout JSON parse failure — gets up to 2 additional fresh `gh`
+ * round-trips before this loader gives up. `isRetryable` reuses the same
+ * `isNotFoundIssueLookupError` / `isInaccessibleIssueLookupError` pair the
+ * outer `catch` already classifies with, so a genuine 404 or access-style
+ * failure is still recognized on the FIRST attempt (retried zero times,
+ * exactly like before this change) and still reaches the outer `catch`
+ * below unchanged.
+ */
+export function buildIssueLoader(owner, repo) {
+  return async (issueNumber) => {
+    const args = [
+      'api',
+      `repos/${owner}/${repo}/issues/${issueNumber}`,
+      '--jq',
+      '.',
+    ];
+    try {
+      return await withBoundedRetry(
+        async () => {
+          const result = (
+            await runGhAsync(args, { allowStatuses: [404] })
+          ).trim();
+          if (!result || result === 'null') {
+            return null;
+          }
+          return JSON.parse(result);
+        },
+        {
+          isRetryable: (error) =>
+            !isNotFoundIssueLookupError(error) &&
+            !isInaccessibleIssueLookupError(error),
+        },
+      );
+    } catch (error) {
+      if (isNotFoundIssueLookupError(error)) {
+        return null;
+      }
+      if (isInaccessibleIssueLookupError(error)) {
+        return INACCESSIBLE_ISSUE_SENTINEL;
+      }
+      throw error;
+    }
+  };
+}
+/**
+ * Live sub-issue loader for the traversal hot path.
+ *
+ * Bounded-retried (#1394): each page's `runGraphqlQuery(...)` call runs
+ * inside {@link withBoundedRetry} with the default retry-everything
+ * classifier — unlike {@link buildIssueLoader}, this loader has no
+ * pre-existing REST-status-based classification to preserve, and every
+ * failure `runGraphqlQuery` can produce today (a transient truncated-stdout
+ * parse failure, a reported GraphQL `errors[]` entry, or a process-exec
+ * failure) already rethrows unclassified. A genuinely persistent failure
+ * (e.g. an inaccessible parent issue) still rethrows, just after up to 2
+ * extra bounded round-trips instead of 0 — a small, deliberate latency cost,
+ * not a fail-closed regression. The connection/cursor-shape checks below
+ * stay un-retried on purpose: they only fire once `runGraphqlQuery` already
+ * resolved without a transport/parse error, so retrying them would not
+ * change the outcome.
+ */
+export function buildSubIssueLoader(owner, repo) {
+  return async (issueNumber) => {
+    const numbers = [];
+    let after = '';
+    while (true) {
+      const variables = {
+        owner,
+        repo,
+        number: issueNumber,
+      };
+      if (after) {
+        variables.after = after;
+      }
+      const result = await withBoundedRetry(() =>
+        runGraphqlQuery(SUB_ISSUES_QUERY, variables),
+      );
+      const connection = result?.data?.repository?.issue?.subIssues;
+      if (
+        !connection ||
+        !Array.isArray(connection.nodes) ||
+        !connection.pageInfo
+      ) {
+        throw new Error(
+          `subIssues connection missing for issue #${issueNumber}`,
+        );
+      }
+      numbers.push(...normalizeSubIssueNumbers(connection.nodes));
+      if (!connection.pageInfo.hasNextPage) {
+        break;
+      }
+      if (!connection.pageInfo.endCursor) {
+        throw new Error(
+          `subIssues pagination cursor missing for issue #${issueNumber}`,
+        );
+      }
+      after = String(connection.pageInfo.endCursor);
+    }
+    return [...new Set(numbers)];
+  };
+}
+/**
+ * Live open-roadmap-roots loader (#1017): search-narrowed root discovery.
+ *
+ * Replaces the previous full open-issue scan (which fetched every open
+ * issue's `body` plus up to 100 labels just to detect a root) with two
+ * cheap server-side searches whose union is the SAME open-root set:
+ *
+ *   1. Label roots — `gh search issues --label <roadmapLabelName> --state
+ *      open` (the configured `labels.roadmapLabelName`, #1273; defaults to
+ *      `roadmap`) returns every open issue carrying that label. These are
+ *      roots by label with NO body inspection needed; the old scan's
+ *      `labels.has(roadmapLabelName)` branch is reproduced exactly (the
+ *      GitHub search `--label` qualifier is a case-insensitive exact-name
+ *      match, as is the `normalizeLabels`-backed `Set.has(...)` it
+ *      replaces).
+ *   2. Marker-only roots — `gh search issues --match body "<...>roadmap-id"
+ *      --state open` narrows to open issues whose body text contains the
+ *      `idd-skill-roadmap-id`-style marker token, then RE-CONFIRMS each
+ *      candidate with the same `extractRoadmapMarkerId(body, prefix)` regex
+ *      the old scan used (the search already returns the body, so no extra
+ *      per-issue fetch is made). Only confirmed markers are kept, so a
+ *      non-marker text hit on the token never inflates the root set.
+ *   3. Configured legacy roots (#1315) — the `discover.legacyRoots` policy
+ *      array (issue numbers), for roots that predate both signals above
+ *      (e.g. an ad-hoc umbrella convention adopted before IDD). No extra
+ *      search or fetch: the numbers are unioned in directly, and each still
+ *      goes through the normal per-root {@link enumerateRoadmapGraph} fetch
+ *      downstream, so a stale or now-closed configured root is handled the
+ *      same way a race-closed label/marker root already is.
+ *
+ * The candidate sets are unioned and deduped by number, then sorted
+ * ascending. The output is the identical `number[]` (deduped, ascending) the
+ * previous scan returned, so the downstream union/provenance/ranking is
+ * byte-stable.
+ *
+ * Result-cap boundary: `gh search` is hard-capped at
+ * {@link GH_SEARCH_RESULT_CAP} results per query. When a single label or
+ * body-marker search returns the full cap it may have been truncated, so a
+ * repo with >= {@link GH_SEARCH_RESULT_CAP} hits could silently yield an
+ * incomplete root set. The loader emits a NON-FATAL one-line WARNING to stderr
+ * in that case (see {@link warnOnSearchResultCap}) rather than aborting — the
+ * body-marker search can legitimately match many re-confirmed-and-dropped
+ * prose mentions, so a hard error would over-abort. The JSON report itself
+ * goes to stdout, so the stderr warning never corrupts it.
+ *
+ * Boundary (documented parity note): the marker search uses GitHub's
+ * full-text body index. The label search is exact and complete on its own,
+ * so every LABELED root is always found regardless of the marker index. A
+ * marker-ONLY root (no `roadmap` label, marker only in the body) is found
+ * when the body-text index surfaces the broad `roadmap-id` token, which the
+ * `re`-confirm step then verifies — this is the only path that depends on
+ * the search index rather than an exact qualifier. The IDD authoring path
+ * applies the `roadmap` label to roadmap roots, so in practice marker-only
+ * roots are covered by the label search; the marker search is the additive
+ * safety net for unlabeled markers.
+ */
+export function buildOpenRoadmapRootsLoader(
+  owner,
+  repo,
+  markerPrefix,
+  searchIssues = buildSearchIssuesRunner(),
+  roadmapLabelName,
+  legacyRoots,
+) {
+  const prefix = normalizeMarkerPrefix(markerPrefix);
+  const label = normalizeRoadmapLabelName(roadmapLabelName);
+  const configuredLegacyRoots = normalizeLegacyRoots(legacyRoots);
+  return async () => {
+    // 3. Configured legacy roots: seeded directly into the Set ahead of the
+    //    two searches below so they dedupe against label/marker roots for
+    //    free; see the loader's doc comment for why no extra fetch is made.
+    const numbers = new Set(configuredLegacyRoots);
+    // 1. Label roots: roadmap-labeled open issues are roots by label.
+    const labelResults = searchIssues({
+      owner,
+      repo,
+      label,
+      fields: ['number'],
+    });
+    warnOnSearchResultCap(labelResults, 'label');
+    for (const issue of labelResults) {
+      const issueNumber = normalizeSearchIssueNumber(issue);
+      if (issueNumber !== null) {
+        numbers.add(issueNumber);
+      }
+    }
+    // 2. Marker-only roots: narrow to open issues whose body carries the
+    //    marker token, then re-confirm with the exact regex on the body the
+    //    search already returned (no extra per-issue body fetch).
+    const markerResults = searchIssues({
+      owner,
+      repo,
+      matchBody: `${prefix}-roadmap-id`,
+      fields: ['number', 'body'],
+    });
+    warnOnSearchResultCap(markerResults, 'body-marker');
+    for (const issue of markerResults) {
+      const issueNumber = normalizeSearchIssueNumber(issue);
+      if (issueNumber === null) {
+        continue;
+      }
+      const body = issue?.body;
+      if (extractRoadmapMarkerId(body, prefix)) {
+        numbers.add(issueNumber);
+      }
+    }
+    // Ascending, deduped — matches the documented `number[]` contract.
+    return [...numbers].sort((left, right) => left - right);
+  };
+}
+/**
+ * GitHub's search API caps a single query at 1000 results
+ * ({@link GH_SEARCH_RESULT_CAP}). When a root search returns the full cap it
+ * may have been truncated, so a repo with >= 1000 label or marker-token hits
+ * could silently yield an incomplete root set.
+ *
+ * This is NON-FATAL: the body-marker search can legitimately match many prose
+ * mentions that are re-confirmed and dropped, so a hard error would over-abort.
+ * Instead emit one clear WARNING line to STDERR (the JSON report goes to
+ * stdout, so stderr keeps the report stream clean) and continue. Exported for
+ * the focused loader test that asserts the warning fires.
+ */
+export function warnOnSearchResultCap(results, searchKind) {
+  if (Array.isArray(results) && results.length >= GH_SEARCH_RESULT_CAP) {
+    process.stderr.write(
+      `discover-roadmap-graph: --all-roadmaps root search hit the ${GH_SEARCH_RESULT_CAP}-result cap (${searchKind}); root discovery may be incomplete on this scale.\n`,
+    );
+  }
+}
+/** Coerce a `gh search issues` JSON entry's number to a positive integer. */
+function normalizeSearchIssueNumber(issue) {
+  const issueNumber = Number.parseInt(String(issue?.number ?? ''), 10);
+  return Number.isInteger(issueNumber) && issueNumber > 0 ? issueNumber : null;
+}
+/**
+ * Build the live `gh search issues` runner used by the open-roadmap-roots
+ * loader. Each call issues one read-only server-side search; the search API
+ * caps a single query at {@link GH_SEARCH_RESULT_CAP} results, so the limit is
+ * pinned at that cap (the loader warns when a search returns the full cap).
+ * Pull requests are excluded by default (`--include-prs` is never passed),
+ * matching the old scan which only ever saw issues from the issues
+ * connection.
+ */
+function buildSearchIssuesRunner() {
+  return ({ owner, repo, label, matchBody, fields }) => {
+    const args = [
+      'search',
+      'issues',
+      '--repo',
+      `${owner}/${repo}`,
+      '--state',
+      'open',
+      '--limit',
+      String(GH_SEARCH_RESULT_CAP),
+      '--json',
+      fields.join(','),
+    ];
+    if (label) {
+      args.push('--label', label);
+    }
+    if (matchBody) {
+      // Restrict the free-text query to the body field, then pass the token
+      // as the positional search query.
+      args.push('--match', 'body', matchBody);
+    }
+    const raw = runGh(args).trim();
+    const parsed = raw && raw !== 'null' ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  };
+}
+/**
+ * Async GraphQL runner for the traversal sub-issue loader. Its sole caller
+ * (`buildSubIssueLoader`) is already async, so the runner uses the non-blocking
+ * `execFile` path — letting several sub-issue queries run in parallel under the
+ * prefetch crawl — while keeping the exact arg construction, error-array
+ * detection, and `gh api graphql failed: …` wrapping of the previous sync form.
+ */
+async function runGraphqlQuery(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [name, value] of Object.entries(variables)) {
+    if (value === '' || value === null || value === undefined) {
+      continue;
+    }
+    const flag = typeof value === 'number' ? '-F' : '-f';
+    args.push(flag, `${name}=${value}`);
+  }
+  try {
+    const stdout = await runGhCapture(args);
+    const parsed = JSON.parse(stdout.trim() || '{}');
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      throw new Error(formatGraphqlErrors(parsed.errors));
+    }
+    return parsed;
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    const detail = stderr || error.message;
+    throw new Error(`gh api graphql failed: ${detail}`);
+  }
+}
+// Read-and-parse failure semantics (explicit path throws; default path
+// silently falls back only on ENOENT) are converged in idd-config.mts's
+// loadPolicyConfig (#1721). The `?? {}` preserves this helper's existing
+// contract of always returning a plain object: several callers below (e.g.
+// buildClaimStateResolution, buildReadinessResolution) dereference fields
+// off the returned value without an optional-chained `policy?.`, so a bare
+// `null` on the "no config" default-path case would throw downstream.
+function loadPolicy(policyPath) {
+  return loadPolicyConfig(policyPath).config ?? {};
+}
+/**
+ * Normalize a failed-`gh` error's exit status to a number.
+ *
+ * The synchronous `execFileSync` runner exposes the process exit code on
+ * `.status`; the promisified `execFile` runner exposes it on `.code`. Read
+ * `.status` first (sync), then fall back to `.code` (async), keeping only a
+ * numeric value so a spawn-error string code (e.g. `ENOENT`) resolves to
+ * `null` exactly as the previous sync-only path did.
+ */
+function resolveGhExitStatus(error) {
+  const candidate = error;
+  const rawStatus = candidate?.status ?? candidate?.code;
+  return typeof rawStatus === 'number' ? rawStatus : null;
+}
+/**
+ * Wrap a failed-`gh` error into the canonical `{ status, stderr }` shape that
+ * the issue-lookup classifiers (`isNotFoundIssueLookupError` /
+ * `isInaccessibleIssueLookupError`) read, so the sync and async runners produce
+ * byte-identical errors. Returns `''` when the exit status is tolerated
+ * (`allowStatuses`); otherwise throws the wrapped error.
+ */
+function wrapGhFailure(error, args, allowStatuses) {
+  const status = resolveGhExitStatus(error);
+  if (status !== null && allowStatuses.includes(status)) {
+    return '';
+  }
+  const stderr = String(error?.stderr ?? '').trim();
+  const prefix = `gh ${args.join(' ')}`;
+  const wrapped = new Error(
+    stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
+  );
+  wrapped.status = status;
+  wrapped.stderr = stderr;
+  throw wrapped;
+}
+function runGh(args, options = {}) {
+  const { allowStatuses = [] } = options;
+  try {
+    return ghText(args, GH_TEXT_LOOP_OPTIONS);
+  } catch (error) {
+    return wrapGhFailure(error, args, allowStatuses);
+  }
+}
+/**
+ * Async sibling of {@link runGh} used only by the traversal hot-path loaders
+ * (`buildIssueLoader` / `buildSubIssueLoader`), so the bounded prefetch crawl
+ * can keep several `gh` subprocesses in flight. Behaviorally identical to
+ * {@link runGh}: same tolerated-status handling and the same wrapped-error
+ * shape (via {@link wrapGhFailure}).
+ */
+async function runGhAsync(args, options = {}) {
+  const { allowStatuses = [] } = options;
+  try {
+    const stdout = await runGhCapture(args);
+    return stdout;
+  } catch (error) {
+    return wrapGhFailure(error, args, allowStatuses);
+  }
+}
+function isInaccessibleIssue(value) {
+  return value?.__iddLookupStatus === 'inaccessible';
+}
+function isInaccessibleIssueLookupError(error) {
+  if (!error) {
+    return false;
+  }
+  const rawStatus = error.status;
+  const status = typeof rawStatus === 'number' ? rawStatus : null;
+  if (status !== null && INACCESSIBLE_HTTP_STATUSES.has(status)) {
+    return true;
+  }
+  const stderr = String(error.stderr ?? '');
+  return /Resource not accessible|access denied|Forbidden|Unavailable for legal reasons/i.test(
+    stderr,
+  );
+}
+function isNotFoundIssueLookupError(error) {
+  if (!error) {
+    return false;
+  }
+  const candidate = error;
+  const stderr = String(candidate.stderr ?? candidate.message ?? '');
+  return stderr.includes('HTTP 404');
+}
+function buildEdgeKey(edge) {
+  return `${edge.source}:${edge.target}:${edge.relationship}:${edge.evidence}`;
+}
+function recordReferenceDiagnostic(collection, dedupeKeys, edge, reason) {
+  const key = `${edge.source}:${edge.target}:${edge.relationship}:${reason}`;
+  if (dedupeKeys.has(key)) {
+    return;
+  }
+  dedupeKeys.add(key);
+  collection.push({
+    source: edge.source,
+    target: edge.target,
+    relationship: edge.relationship,
+    evidence: edge.evidence,
+    reason,
+  });
+}
+function compareByNumber(left, right) {
+  return left.number - right.number;
+}
+function compareEdges(left, right) {
+  return (
+    left.source - right.source ||
+    left.target - right.target ||
+    left.relationship.localeCompare(right.relationship) ||
+    left.evidence.localeCompare(right.evidence)
+  );
+}
+function comparePaths(left, right) {
+  return (
+    left.target - right.target ||
+    left.path.length - right.path.length ||
+    left.path.join('>').localeCompare(right.path.join('>'))
+  );
+}
+function compareDiagnostics(left, right) {
+  return (
+    left.source - right.source ||
+    left.target - right.target ||
+    String(left.relationship ?? '').localeCompare(
+      String(right.relationship ?? ''),
+    ) ||
+    String(left.reason ?? '').localeCompare(String(right.reason ?? ''))
+  );
+}
+function compareCycles(left, right) {
+  return (
+    left.source - right.source ||
+    left.target - right.target ||
+    left.path.length - right.path.length ||
+    left.path.join('>').localeCompare(right.path.join('>'))
+  );
+}
+function formatGraphqlErrors(errors) {
+  return errors
+    .map((error) => String(error?.message ?? 'unknown GraphQL error'))
+    .join('; ');
+}
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -1,0 +1,715 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-shared-file-overlap.mts
+//
+// The scripts/discover-shared-file-overlap.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only discovery-time evidence helper (#1019): for a set of candidate
+// issues, report the high-contention shared files each would touch (parsed
+// from its `## Candidate files` section) and whether any of those files
+// overlap an actively-claimed or open-PR issue's candidate files. It also
+// emits a soft de-prioritization order for A4 Step 2. It is the
+// file-contention companion to the #1008 `--with-claim-state` claim-eligibility
+// annotation. Evidence-only: it claims nothing and mutates no state.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseAutopilotSuitability } from './autopilot-suitability.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+} from './gh-exec.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { parseIsoDurationToMs } from './policy-helpers.mjs';
+import {
+  resolveActiveClaim,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Exported (#1484) so suitability-triage.mts's high-confidence Check 4 tier
+// can build the identical high-contention set this module uses for A4 Step 2,
+// instead of re-declaring its own copy of these defaults.
+export const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+/** F-phase bundles whose member instruction files concentrate concurrent edits. */
+export const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+/** Append-mostly shared surfaces that are not bundle members. */
+export const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
+const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+/** Upper bound on the best-effort open-PR scan (a `gh pr list --limit`). */
+const OPEN_PR_SCAN_LIMIT = 500;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `candidate:`): tests/flag-name-matrix.test.mts scans this file's
+// *compiled* .mjs source text for quoted flag literals such as the
+// --candidate spec key below. See cli-args.mts's module header for the
+// full invariant. (This comment deliberately avoids writing that key
+// inside matching quote marks, so it cannot itself satisfy the scan if
+// the real key is ever renamed -- see #1446's PR description for why
+// that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see ci-wait-policy.mts's identical note).
+const DISCOVER_SHARED_FILE_OVERLAP_FLAG_SPEC = {
+  '--candidate': { type: 'string', multiple: true },
+  '--candidates': { type: 'string', multiple: true },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--policy': { type: 'string', default: '' },
+  '--manifest': { type: 'string', default: DEFAULT_MANIFEST_PATH },
+  '--bundles': { type: 'string' },
+  '--check-overlap': { type: 'boolean', default: false },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * Normalize a candidate-file path to its contention key. Strips surrounding
+ * backticks and a leading `./`, and collapses a `idd-template/<x>` source onto
+ * its generated `<x>` mirror so the two count as one contention surface. An
+ * instruction file is keyed by its basename (`idd-merge.instructions.md`):
+ * those basenames are unique repo-wide and issues cite them in several forms
+ * (full source path, mirror path, or bare), so basename keying makes every
+ * form compare equal.
+ */
+export function normalizeContentionPath(raw) {
+  let value = String(raw ?? '').trim();
+  value = value.replace(/^`+/, '').replace(/`+$/, '').trim();
+  value = value.replace(/^\.\//, '');
+  value = value.replace(/^idd-template\//, '');
+  const instruction = value.match(/(?:^|\/)([^/]+\.instructions\.md)$/);
+  if (instruction) {
+    return instruction[1];
+  }
+  return value;
+}
+/**
+ * Parse the `## Candidate files` section of an issue body into a
+ * de-duplicated, normalized path list. The section is advisory, so parsing is
+ * lenient: it extracts every backtick-quoted path in the section — including
+ * the continuation lines of a multi-line bullet — plus the leading path-like
+ * token of any bullet that has no backticks at all. Returns `[]` when the
+ * section is absent.
+ */
+export function parseCandidateFiles(body) {
+  const text = typeof body === 'string' ? body : '';
+  const lines = text.split(/\r?\n/);
+  let start = -1;
+  let end = lines.length;
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = lines[index].match(/^\s{0,3}(#{1,6})\s+(.*)$/);
+    if (!heading) {
+      continue;
+    }
+    const title = heading[2].replace(/[*_`]/g, '').trim().toLowerCase();
+    if (start === -1) {
+      if (/^candidate files\b/.test(title)) {
+        start = index + 1;
+      }
+      continue;
+    }
+    end = index;
+    break;
+  }
+  if (start === -1) {
+    return [];
+  }
+  const section = lines.slice(start, end);
+  const sectionText = section.join('\n');
+  const files = [];
+  // Every backtick-quoted path in the section, regardless of line wrapping.
+  for (const match of sectionText.matchAll(/`([^`]+)`/g)) {
+    const normalized = normalizeContentionPath(match[1]);
+    if (looksLikePath(normalized)) {
+      files.push(normalized);
+    }
+  }
+  // Bullets that quote no path fall back to a strict leading-token scan.
+  for (const line of section) {
+    const item = line.match(/^\s*(?:[-*+]|\d+[.)])\s+(.*)$/);
+    if (!item || /`[^`]+`/.test(item[1])) {
+      continue;
+    }
+    const token = extractStandaloneToken(item[1]);
+    if (token) {
+      files.push(token);
+    }
+  }
+  return [...new Set(files)];
+}
+/** Extract a strict leading path token from a bullet that quotes no path. */
+function extractStandaloneToken(itemBody) {
+  let text = itemBody.trim();
+  text = text.split(/\s+(?:—|–|--)\s+/)[0];
+  text = text.split(/\s+\(/)[0];
+  const leading = text.split(/[\s,;]+/)[0] ?? '';
+  const normalized = normalizeContentionPath(leading);
+  return looksLikeStandalonePath(normalized) ? normalized : null;
+}
+/** A backtick-quoted token only needs a separator or extension. */
+function looksLikePath(value) {
+  return value.length > 0 && !/\s/.test(value) && /[/.]/.test(value);
+}
+/**
+ * An unquoted bullet token must look unambiguously like a file path: a final
+ * extension, a glob, or a trailing directory slash. This rejects prose such
+ * as "generated/mirrored" that merely contains a slash.
+ */
+function looksLikeStandalonePath(value) {
+  if (value.length === 0 || /\s/.test(value)) {
+    return false;
+  }
+  return (
+    /\.[a-z0-9]+$/i.test(value) || value.includes('*') || value.endsWith('/')
+  );
+}
+/**
+ * Resolve the high-contention shared-file set from the sync manifest: the
+ * union of the named bundles' member files plus any extra append-mostly
+ * surfaces. Paths are normalized so a source and its mirror collapse together.
+ */
+export function resolveHighContentionFiles(options) {
+  const bundleIds = new Set(options.bundleIds ?? DEFAULT_BUNDLE_IDS);
+  const extraFiles = options.extraFiles ?? DEFAULT_EXTRA_FILES;
+  const result = new Set();
+  const bundles = options.manifest?.bundleBudgets;
+  if (Array.isArray(bundles)) {
+    for (const bundle of bundles) {
+      const entry = bundle;
+      if (!entry || !bundleIds.has(String(entry.id))) {
+        continue;
+      }
+      if (Array.isArray(entry.files)) {
+        for (const file of entry.files) {
+          result.add(normalizeContentionPath(file));
+        }
+      }
+    }
+  }
+  for (const file of extraFiles) {
+    result.add(normalizeContentionPath(file));
+  }
+  return result;
+}
+/**
+ * Compute per-candidate high-contention overlap evidence against the active
+ * set, plus a soft de-prioritization order for A4 Step 2.
+ */
+export function analyzeSharedFileOverlap(input) {
+  const floor = input.floor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  // When the autopilot-suitability kill switch is off (A4 Step 2 ignores the
+  // score and selects by lowest issue number), equalize every effectiveScore so
+  // the recommended order is driven by overlap then issue number, not score.
+  const suitabilityEnabled = input.suitabilityEnabled !== false;
+  const highContention = new Set(input.highContentionFiles);
+  const activeTouched = input.activeIssues.map((active) => ({
+    number: active.number,
+    reason: active.reason,
+    files: intersect(active.candidateFiles, highContention),
+  }));
+  const candidates = input.candidates.map((candidate) => {
+    const score = typeof candidate.score === 'number' ? candidate.score : null;
+    const highContentionTouched = intersect(
+      candidate.candidateFiles,
+      highContention,
+    );
+    const touchedSet = new Set(highContentionTouched);
+    const overlaps = [];
+    for (const active of activeTouched) {
+      if (active.number === candidate.number) {
+        continue;
+      }
+      const shared = active.files.filter((file) => touchedSet.has(file));
+      if (shared.length > 0) {
+        overlaps.push({
+          number: active.number,
+          reason: active.reason,
+          files: shared.slice().sort(),
+        });
+      }
+    }
+    overlaps.sort((left, right) => left.number - right.number);
+    return {
+      number: candidate.number,
+      score,
+      effectiveScore: suitabilityEnabled ? (score ?? floor) : 0,
+      candidateFiles: candidate.candidateFiles,
+      highContentionTouched,
+      overlaps,
+      overlapFlag: overlaps.length > 0,
+    };
+  });
+  const preSorted = candidates
+    .slice()
+    .sort(
+      (left, right) =>
+        right.effectiveScore - left.effectiveScore ||
+        left.number - right.number,
+    );
+  const recommendedOrder = applyOverlapTieBreaker(preSorted).map(
+    (candidate) => candidate.number,
+  );
+  return {
+    candidates,
+    recommendedOrder,
+    summary: {
+      candidateCount: candidates.length,
+      flaggedCount: candidates.filter((candidate) => candidate.overlapFlag)
+        .length,
+      activeIssueCount: input.activeIssues.length,
+    },
+  };
+}
+/**
+ * Soft de-prioritization tie-breaker for A4 Step 2. The input must already be
+ * ordered by the existing rules (suitability score descending, then issue
+ * number ascending / desync). Within each equal-`effectiveScore` band this
+ * stably moves overlap-flagged candidates after the non-overlapping ones; it
+ * never crosses a score band and never drops a candidate, so a colliding
+ * candidate that is the only ready work keeps its position.
+ */
+export function applyOverlapTieBreaker(ranked) {
+  const out = [];
+  for (let index = 0; index < ranked.length; ) {
+    let end = index;
+    while (
+      end < ranked.length &&
+      ranked[end].effectiveScore === ranked[index].effectiveScore
+    ) {
+      end += 1;
+    }
+    const band = ranked.slice(index, end);
+    for (const candidate of band) {
+      if (!candidate.overlapFlag) {
+        out.push(candidate);
+      }
+    }
+    for (const candidate of band) {
+      if (candidate.overlapFlag) {
+        out.push(candidate);
+      }
+    }
+    index = end;
+  }
+  return out;
+}
+function intersect(files, highContention) {
+  const seen = new Set();
+  const result = [];
+  for (const file of files) {
+    if (highContention.has(file) && !seen.has(file)) {
+      seen.add(file);
+      result.push(file);
+    }
+  }
+  return result.sort();
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.candidates.length === 0) {
+    throw new Error('at least one --candidate <number> is required');
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repoRef = `${owner}/${repo}`;
+  const policy = loadPolicy(args.policy);
+  const now = args.now || new Date().toISOString();
+  const manifest = loadManifest(args.manifest);
+  const highContentionFiles = resolveHighContentionFiles({
+    manifest,
+    bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+    // Track the manifest actually in use so a custom --manifest is the file
+    // reported (and matched) as high-contention, not the hard-coded default.
+    extraFiles: [args.manifest],
+  });
+  const candidates = args.candidates.map((number) => {
+    const issue = fetchIssue(repoRef, number);
+    return {
+      number,
+      score: parseAutopilotSuitability(issue.body, policy.markerPrefix),
+      candidateFiles: parseCandidateFiles(issue.body),
+    };
+  });
+  let activeIssues = [];
+  if (args.checkOverlap) {
+    activeIssues = discoverActiveIssues({
+      repoRef,
+      trustedActors: policy.trustedMarkerActors,
+      staleAgeMs: policy.claimStaleAgeMs,
+      now,
+    });
+  }
+  const analysis = analyzeSharedFileOverlap({
+    candidates,
+    activeIssues,
+    highContentionFiles,
+    floor: policy.autopilotSuitabilityFloor,
+    suitabilityEnabled: policy.autopilotSuitabilityEnabled,
+  });
+  const output = {
+    repository: { owner, repo },
+    checkedOverlap: args.checkOverlap,
+    highContentionFiles: [...highContentionFiles].sort(),
+    ...analysis,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+/**
+ * Discover the concurrently-active set: every issue closed by an open PR
+ * (repo-wide), plus candidate issues that already carry a non-stale claim.
+ * Active-by-claim covers every issue with a remote `issue/<n>-*` branch (every
+ * IDD claim creates one once pushed), resolved with the standard `claimed-by`
+ * claim-state rules — not just the candidate set — so a claim held by another
+ * session is detected even though it is outside the unclaimed candidates being
+ * ranked. A claim whose branch is not yet pushed is picked up once it appears
+ * remotely. Active-by-PR is a best-effort scan of open PRs (bounded by the
+ * PR-list page cap). Both stay bounded — no repo-wide comment scan — which is
+ * the fetch cost `--check-overlap` gates; the overlap signal is an advisory A4
+ * Step 2 tie-breaker, so best-effort coverage is acceptable. Edge cases the
+ * advisory signal does not specially resolve: legacy claim-id-less markers and
+ * forced-handoff-successor adoption (the default `resolveActiveClaim` path).
+ */
+function discoverActiveIssues(options) {
+  const { repoRef, trustedActors, staleAgeMs, now } = options;
+  const active = new Map();
+  // Active-by-PR: issues closed by an open PR (best-effort across open PRs,
+  // bounded by the PR-list page cap).
+  for (const number of fetchOpenPrLinkedIssues(repoRef)) {
+    if (!active.has(number)) {
+      const body = fetchIssue(repoRef, number).body;
+      active.set(number, {
+        number,
+        reason: 'pr',
+        candidateFiles: parseCandidateFiles(body),
+      });
+    }
+  }
+  // Active-by-claim: scan the issues that have a *remote* `issue/<n>-*` branch
+  // — every IDD claim creates one, published once its branch is pushed — so a
+  // non-stale claim held by another session is detected even though it is
+  // outside the (unclaimed) candidate set the ranking operates on. Bounded by
+  // the number of active issue branches, not a repo-wide comment scan; a claim
+  // whose branch is not yet pushed is picked up once it appears remotely. The
+  // configured claim stale age drives both the supersession check inside
+  // resolveActiveClaim and the non-stale filter here.
+  const isTrusted = (login) =>
+    trustedActors.some((actor) => actor.toLowerCase() === login.toLowerCase());
+  const isStale = (activeCreatedAt, nextCreatedAt) =>
+    new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >=
+    staleAgeMs;
+  for (const number of fetchActiveClaimBranchNumbers(repoRef)) {
+    if (active.has(number)) {
+      continue;
+    }
+    const comments = fetchIssueComments(repoRef, number);
+    const claim = resolveActiveClaim(comments, {
+      isTrustedAuthor: isTrusted,
+      isStale,
+    });
+    if (claim && !isStale(claim.createdAt, now)) {
+      const body = fetchIssue(repoRef, number).body;
+      active.set(number, {
+        number,
+        reason: 'claim',
+        candidateFiles: parseCandidateFiles(body),
+      });
+    }
+  }
+  return [...active.values()].sort((left, right) => left.number - right.number);
+}
+/** Issue numbers that currently have an `issue/<n>-*` branch on the remote. */
+function fetchActiveClaimBranchNumbers(repoRef) {
+  const numbers = new Set();
+  // `--paginate` follows the Link headers to the end, so a repo with many
+  // issue branches does not silently drop branches past the first page.
+  const output = ghText(
+    [
+      'api',
+      '--paginate',
+      `repos/${repoRef}/git/matching-refs/heads/issue/`,
+      '--jq',
+      '.[].ref',
+    ],
+    {
+      ...GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+    },
+  );
+  for (const line of output.split('\n')) {
+    const match = line.match(/^refs\/heads\/issue\/(\d+)-/);
+    if (match) {
+      numbers.add(Number.parseInt(match[1], 10));
+    }
+  }
+  return [...numbers];
+}
+function fetchIssue(repoRef, number) {
+  // Fail closed: let a fetch failure surface rather than returning an empty
+  // body, which would silently suppress this issue's candidate files and emit
+  // a false "no overlap" result.
+  const body = ghText(
+    [
+      'issue',
+      'view',
+      String(number),
+      '--repo',
+      repoRef,
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+  return { body };
+}
+/**
+ * Map a REST issue-comment payload to the `CommentLike` shape
+ * `resolveActiveClaim` consumes. `resolveActiveClaim` reads the author from
+ * `author.login`, but the REST comments API returns it under `user.login`, so
+ * the login must be mapped across here (matching `discover-roadmap-graph`'s
+ * comment loader). Emitting `user` would leave the author empty and silently
+ * disable claim detection.
+ */
+export function toClaimComment(raw) {
+  const entry = raw;
+  return {
+    body: String(entry.body ?? ''),
+    createdAt: String(entry.created_at ?? ''),
+    author: { login: String(entry.user?.login ?? '') },
+  };
+}
+function fetchIssueComments(repoRef, number) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${number}/comments?per_page=${pageSize}&page=${page}`,
+    ]);
+    for (const raw of rawPage) {
+      comments.push(toClaimComment(raw));
+    }
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
+}
+function fetchOpenPrLinkedIssues(repoRef) {
+  const numbers = new Set();
+  // Best-effort: `gh pr list` caps at --limit, so a repo with more open PRs
+  // than the cap drops the overflow. Acceptable for an advisory signal.
+  const prs = ghJson([
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'open',
+    '--limit',
+    String(OPEN_PR_SCAN_LIMIT),
+    '--json',
+    'closingIssuesReferences',
+  ]);
+  for (const pr of prs) {
+    const refs = pr.closingIssuesReferences;
+    if (Array.isArray(refs)) {
+      for (const ref of refs) {
+        const value = Number.parseInt(String(ref.number ?? ''), 10);
+        if (Number.isInteger(value) && value > 0) {
+          numbers.add(value);
+        }
+      }
+    }
+  }
+  return [...numbers];
+}
+function loadManifest(manifestPath) {
+  const targetPath = resolve(
+    process.cwd(),
+    manifestPath || DEFAULT_MANIFEST_PATH,
+  );
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch (error) {
+    // Fail closed: an empty manifest would yield an empty high-contention set,
+    // making every candidate look non-overlapping. Surface the load failure.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `failed to load sync manifest at ${targetPath}: ${message}`,
+    );
+  }
+}
+function loadPolicy(policyPath) {
+  // Fail closed on an explicit --policy that cannot be loaded: silently
+  // using defaults would drop custom trusted actors / claim timing and let
+  // active claims disappear. An absent default config still falls back
+  // (idd-config.mts's loadPolicyConfig, #1721, converges this read-and-parse
+  // semantics for all nine --policy/--config-aware helpers).
+  const config = loadPolicyConfig(policyPath).config;
+  const markerPrefix =
+    typeof config?.markerPrefix === 'string' && config.markerPrefix.length > 0
+      ? config.markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const trusted = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  const floorValue = config?.autopilotSuitability?.floor;
+  const autopilotSuitabilityFloor =
+    typeof floorValue === 'number' && floorValue >= 1 && floorValue <= 5
+      ? floorValue
+      : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const autopilotSuitabilityEnabled =
+    config?.autopilotSuitability?.enabled !== false;
+  const claimStaleAgeMs =
+    parseIsoDurationToMs(config?.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
+  return {
+    markerPrefix,
+    trustedMarkerActors: trusted.actors,
+    autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled,
+    claimStaleAgeMs,
+  };
+}
+/**
+ * Walk `argv` and return every occurrence of the given long-flag literals
+ * (e.g. `--candidate`, `--candidates`) in argv order, tagged with which
+ * flag matched and its literal string value. `parseCliArgs` has already
+ * thrown on anything malformed (a missing value, a flag-shaped value, an
+ * unknown flag) by the time this runs, so this is a pure
+ * order-reconstruction pass over already-validated input, not a second
+ * parse/validation pass. Covers both the `--flag value` and `--flag=value`
+ * forms Node's `util.parseArgs` itself accepts for a long option (#1450
+ * review follow-up: grouping every `--candidate` occurrence before every
+ * `--candidates` occurrence silently reordered interleaved input, e.g.
+ * `--candidates 1,2 --candidate 3`).
+ */
+function collectOrderedOccurrences(argv, flagNames) {
+  const occurrences = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const equalsIndex = token.indexOf('=');
+    const bareFlag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+    if (!flagNames.includes(bareFlag)) {
+      continue;
+    }
+    const value =
+      equalsIndex === -1 ? argv[index + 1] : token.slice(equalsIndex + 1);
+    occurrences.push({ flag: bareFlag, value });
+  }
+  return occurrences;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    DISCOVER_SHARED_FILE_OVERLAP_FLAG_SPEC,
+  );
+  // parsePositiveInt keeps its existing throw-on-invalid contract and
+  // message shape unchanged; only the flag-syntax parsing around it (a
+  // missing/flag-shaped value, an unknown flag) is now strict. Every
+  // --candidate/--candidates occurrence is now accumulated in argv order
+  // (not just the last, and not grouped by flag name).
+  const candidates = collectOrderedOccurrences(argv, [
+    '--candidate',
+    '--candidates',
+  ]).flatMap((occurrence) => {
+    if (occurrence.flag === '--candidate') {
+      return [parsePositiveInt(occurrence.value, '--candidate')];
+    }
+    return occurrence.value
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((trimmed) => parsePositiveInt(trimmed, '--candidates'));
+  });
+  return {
+    candidates,
+    owner: values.owner,
+    repo: values.repo,
+    policy: values.policy,
+    manifest: values.manifest,
+    bundles:
+      values.bundles === undefined
+        ? null
+        : String(values.bundles)
+            .split(',')
+            .map((part) => part.trim())
+            .filter(Boolean),
+    checkOverlap: values['check-overlap'],
+    now: values.now,
+    help,
+  };
+}
+function parsePositiveInt(value, flag) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`invalid ${flag} value: ${value ?? ''}`);
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-shared-file-overlap.mjs --candidate <number> [--candidate <number> ...] [--candidates <n1,n2>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--check-overlap] [--now <ISO8601>] [--help]
+
+Reports, per candidate, the high-contention shared files it would touch (from
+its '## Candidate files' section) and — with --check-overlap — whether any
+overlap an actively-claimed or open-PR issue. recommendedOrder applies the soft
+A4 Step 2 de-prioritization tie-breaker (score desc, then non-overlapping
+first within a score band, then issue number); it does NOT apply
+discover.selectionDesync — the agent layers the overlap nudge after its own
+desync pick. Evidence-only: never a hard gate.
+
+Without --check-overlap no active-set discovery runs (no extra GitHub API
+cost); each candidate's high-contention files are still reported.
+
+--check-overlap coverage (best-effort, no repo-wide comment scan): open-PR
+overlap scans open PRs (bounded by the gh pr list page cap). Active-claim
+overlap scans the issues that have a remote issue/<n>-* branch (every IDD claim
+creates one once pushed), paginated to the end and resolved with the configured
+claim stale age, so a non-stale claim held by another session is detected even
+when it is outside the unclaimed candidate set being ranked. A claim whose
+branch is not yet pushed is picked up once it appears remotely.
+`);
+}
+// Exported (#1484) as the array-safe `gh` JSON parser: suitability-triage.mts
+// reuses it (aliased at the import site to avoid colliding with that file's
+// own object-shaped `ghJson`) instead of re-declaring an equivalent helper.
+export function ghJson(args) {
+  const parsed = JSON.parse(runGh(args).trim() || '[]');
+  return Array.isArray(parsed) ? parsed : [];
+}
+function runGh(args) {
+  try {
+    return ghText(args, GH_TEXT_LOOP_TIMEOUT_OPTIONS);
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-viability-gate.mts
+//
+// The scripts/discover-viability-gate.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { parseCliArgs } from './cli-args.mjs';
+import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+
+const CRITERIA = [
+  {
+    id: 'limited_scope',
+    name: 'Limited scope',
+    evaluate: evaluateLimitedScope,
+  },
+  {
+    id: 'clear_verification',
+    name: 'Clear verification',
+    evaluate: evaluateClearVerification,
+  },
+  {
+    id: 'autonomous_completion',
+    name: 'Autonomous completion',
+    evaluate: evaluateAutonomousCompletion,
+  },
+];
+const BROAD_SCOPE_PATTERN =
+  /\b(cross-cutting|cross cutting|across (?:many|multiple)|multiple subsystems?|repository-wide|entire repo|public interface|redesign|architecture|global refactor|large refactor)\b/i;
+const NARROW_SCOPE_PATTERN =
+  /\b(single module|single file|few files|targeted|small fix|localized|narrow scope)\b/i;
+const OBJECTIVE_VERIFICATION_PATTERN =
+  /\b(test(?:s|ing)?|lint(?:ing)?|ci|coverage|acceptance criteria|objective|measurable|deterministic|verifiable|automated)\b/i;
+const SUBJECTIVE_VERIFICATION_PATTERN =
+  /\b(feels?|looks? good|opinion|judgement?|ux call|maintainer preference|stakeholder preference|subjective)\b/i;
+const EXTERNAL_COORDINATION_PATTERN =
+  /\b(external coordination|human decision|maintainer decision|stakeholder sign-?off|manual approval|waiting for (?:maintainer|stakeholder)|external system|third-?party access|credential|production access|cross-repo dependency)\b/i;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger block calls parseArgs()
+// synchronously at module-evaluation time, and a `const` declared after
+// that point is still in the temporal dead zone when the trigger fires
+// (see ci-wait-policy.mts's identical note).
+const DISCOVER_VIABILITY_GATE_FLAG_SPEC = {
+  '--issue': { type: 'string', multiple: true },
+  '--issues': { type: 'string', multiple: true },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--csv': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.issueNumbers.length === 0) {
+    throw new Error(
+      'missing required --issue <number> (repeatable) or --issues <n1,n2,...>',
+    );
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const summary = await evaluateDiscoverViability(args.issueNumbers, {
+    loadIssue: buildIssueLoader(owner, repo),
+  });
+  if (args.csv) {
+    process.stdout.write(renderCsv(summary));
+  } else {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  }
+}
+export async function evaluateDiscoverViability(issueNumbers, options = {}) {
+  const { loadIssue } = options;
+  if (typeof loadIssue !== 'function') {
+    throw new Error(
+      'evaluateDiscoverViability requires loadIssue(issueNumber)',
+    );
+  }
+  const viable = [];
+  const discarded = [];
+  for (const issueNumber of normalizeIssueNumbers(issueNumbers)) {
+    const issue = await loadIssue(issueNumber);
+    if (!issue) {
+      discarded.push({
+        number: issueNumber,
+        title: '',
+        failedCriteria: ['issue_not_found'],
+      });
+      continue;
+    }
+    if (String(issue.state ?? '').toUpperCase() !== 'OPEN') {
+      discarded.push({
+        number: Number(issue.number ?? issueNumber),
+        title: String(issue.title ?? ''),
+        failedCriteria: ['issue_not_open'],
+      });
+      continue;
+    }
+    const result = evaluateA4Viability(issue);
+    if (result.passed) {
+      viable.push({
+        number: Number(issue.number ?? issueNumber),
+        title: String(issue.title ?? ''),
+      });
+      continue;
+    }
+    discarded.push({
+      number: Number(issue.number ?? issueNumber),
+      title: String(issue.title ?? ''),
+      failedCriteria: result.failedCriteria,
+      criteria: result.criteria,
+    });
+  }
+  return {
+    viable,
+    discarded,
+    summary: {
+      total: viable.length + discarded.length,
+      viableCount: viable.length,
+      discardedCount: discarded.length,
+      discardedByCriterion: countDiscardedCriteria(discarded),
+    },
+  };
+}
+export function evaluateA4Viability(issue) {
+  const normalizedIssue = normalizeIssue(issue);
+  const criteria = [];
+  const failedCriteria = [];
+  for (const criterion of CRITERIA) {
+    const result = criterion.evaluate(normalizedIssue);
+    criteria.push({
+      id: criterion.id,
+      name: criterion.name,
+      result: result.pass ? 'pass' : 'fail',
+      evidence: result.evidence,
+    });
+    if (!result.pass) {
+      failedCriteria.push(criterion.id);
+    }
+  }
+  return {
+    passed: failedCriteria.length === 0,
+    failedCriteria,
+    criteria,
+  };
+}
+export function evaluateLimitedScope(issue) {
+  const corpus = `${issue.title}\n${issue.body}`;
+  // Test the broad-scope signal first: a broad/A4-fail cue must fail the
+  // gate even when a narrow cue is also present (e.g. "single module change
+  // that redesigns a public interface"). Returning narrow-pass first would
+  // let that wording bypass the gate.
+  if (BROAD_SCOPE_PATTERN.test(corpus)) {
+    return {
+      pass: false,
+      evidence: 'Broad or cross-cutting scope signal detected.',
+    };
+  }
+  if (NARROW_SCOPE_PATTERN.test(corpus)) {
+    return {
+      pass: true,
+      evidence: 'Narrow-scope signal detected.',
+    };
+  }
+  return {
+    pass: true,
+    evidence: 'No broad-scope signal detected.',
+  };
+}
+export function evaluateClearVerification(issue) {
+  const corpus = `${issue.title}\n${issue.body}`;
+  if (OBJECTIVE_VERIFICATION_PATTERN.test(corpus)) {
+    return {
+      pass: true,
+      evidence: 'Objective verification signal detected.',
+    };
+  }
+  if (SUBJECTIVE_VERIFICATION_PATTERN.test(corpus)) {
+    return {
+      pass: false,
+      evidence: 'Verification appears subjective or opinion-based.',
+    };
+  }
+  return {
+    pass: false,
+    evidence: 'No objective verification signal detected.',
+  };
+}
+export function evaluateAutonomousCompletion(issue) {
+  const corpus = `${issue.title}\n${issue.body}`;
+  if (EXTERNAL_COORDINATION_PATTERN.test(corpus)) {
+    return {
+      pass: false,
+      evidence: 'External coordination or manual decision signal detected.',
+    };
+  }
+  return {
+    pass: true,
+    evidence: 'No external coordination signal detected.',
+  };
+}
+/**
+ * Walk `argv` and return every occurrence of the given long-flag literals
+ * (e.g. `--issue`, `--issues`) in argv order, tagged with which flag
+ * matched and its literal string value. `parseCliArgs` has already thrown
+ * on anything malformed (a missing value, a flag-shaped value, an unknown
+ * flag) by the time this runs, so this is a pure order-reconstruction pass
+ * over already-validated input, not a second parse/validation pass. Covers
+ * both the `--flag value` and `--flag=value` forms Node's `util.parseArgs`
+ * itself accepts for a long option (#1450 review follow-up: grouping every
+ * `--issue` occurrence before every `--issues` occurrence silently
+ * reordered interleaved input, e.g. `--issues 1,2 --issue 3`).
+ */
+function collectOrderedOccurrences(argv, flagNames) {
+  const occurrences = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const equalsIndex = token.indexOf('=');
+    const bareFlag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+    if (!flagNames.includes(bareFlag)) {
+      continue;
+    }
+    const value =
+      equalsIndex === -1 ? argv[index + 1] : token.slice(equalsIndex + 1);
+    occurrences.push({ flag: bareFlag, value });
+  }
+  return occurrences;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    DISCOVER_VIABILITY_GATE_FLAG_SPEC,
+  );
+  // Preserves the existing "collect every --issue occurrence plus every
+  // comma-split --issues entry, in argv order, then silently drop
+  // non-numeric tokens" contract (normalizeIssueNumbers) unchanged by this
+  // migration -- only the flag-syntax parsing (missing/flag-shaped values,
+  // unknown flags) is now strict.
+  const issueTokens = collectOrderedOccurrences(argv, [
+    '--issue',
+    '--issues',
+  ]).flatMap((occurrence) =>
+    occurrence.flag === '--issues'
+      ? occurrence.value.split(',')
+      : [occurrence.value],
+  );
+  return {
+    issueNumbers: normalizeIssueNumbers(issueTokens),
+    csv: values.csv,
+    owner: values.owner,
+    repo: values.repo,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-viability-gate.mjs --issue <number> [--issue <number> ...]
+  node scripts/discover-viability-gate.mjs --issues <n1,n2,...>
+    [--csv] [--owner <owner>] [--repo <repo>] [--help]
+
+Output schema (JSON mode):
+  {
+    "viable": [{ "number": 123, "title": "..." }],
+    "discarded": [{ "number": 124, "title": "...", "failedCriteria": ["..."] }],
+    "summary": {
+      "total": 2,
+      "viableCount": 1,
+      "discardedCount": 1,
+      "discardedByCriterion": { "limited_scope": 1 }
+    }
+  }
+`);
+}
+function normalizeIssueNumbers(values) {
+  const parsed = values
+    .map((value) => Number.parseInt(String(value).trim(), 10))
+    .filter(Number.isInteger);
+  return [...new Set(parsed)];
+}
+function normalizeIssue(issue) {
+  const i = issue;
+  return {
+    number: Number(i?.number ?? 0),
+    title: String(i?.title ?? ''),
+    body: String(i?.body ?? ''),
+    state: String(i?.state ?? ''),
+  };
+}
+function countDiscardedCriteria(discarded) {
+  const counts = {};
+  for (const item of discarded) {
+    for (const criterion of item.failedCriteria ?? []) {
+      counts[criterion] = (counts[criterion] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+export function renderCsv(summary) {
+  const lines = ['kind,number,title,criteria'];
+  for (const item of summary.viable) {
+    lines.push(`viable,${item.number},${escapeCsv(item.title)},`);
+  }
+  for (const item of summary.discarded) {
+    lines.push(
+      `discarded,${item.number},${escapeCsv(item.title)},${escapeCsv((item.failedCriteria ?? []).join('|'))}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+function escapeCsv(value) {
+  const text = String(value ?? '');
+  if (!/[",\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
+}
+function buildIssueLoader(owner, repo) {
+  return async function loadIssue(issueNumber) {
+    let data;
+    try {
+      data = ghJson([
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}`,
+        '--jq',
+        '.',
+      ]);
+    } catch (error) {
+      // Fail closed: only a genuine 404 means the issue is absent. Auth,
+      // rate-limit, network, and unknown failures (status null) must
+      // propagate so discovery aborts instead of marking the issue
+      // not-found. `gh` exits 1 for every HTTP error, so derive the real
+      // status from its output rather than the process exit code.
+      if (deriveGhHttpStatus(error) === 404) {
+        return null;
+      }
+      throw error;
+    }
+    if (!data) {
+      return null;
+    }
+    return {
+      number: Number(data.number),
+      title: String(data.title ?? ''),
+      body: String(data.body ?? ''),
+      state: String(data.state ?? '').toUpperCase(),
+    };
+  };
+}
+function ghJson(args) {
+  const text = ghText(args, GH_TEXT_LOOP_OPTIONS);
+  if (!text) {
+    return null;
+  }
+  return JSON.parse(text);
+}

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -1,0 +1,753 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/disposition-non-review-notices.mts
+//
+// The scripts/disposition-non-review-notices.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Auto-disposition advisory non-review notices on a PR (E6 PATH B). Every
+// autopilot PR draws advisory-bot rate-limit / usage-limit notices that are
+// dispositioned deterministically as `**Rejected** — {bot} did not review HEAD
+// {sha} ({reason}); this is not a completed review (source: #issuecomment-{id})`
+// — marker-first (#1038), one per notice (the F2/F3 gate pairs 1:1 by count),
+// naming the bot's login so the #1018 author-scoped carry-forward attributes
+// it. The trailing `(source: #issuecomment-{id})` names the source notice's
+// own comment id, so repeat notices from the same bot at the same HEAD (which
+// otherwise render byte-identical) stay distinguishable in the PR history
+// (#1482); it is a human-readable disambiguator only, never a pairing key.
+// This helper detects those notices with the single-sourced
+// `isAdvisoryNonReviewNotice` classifier and emits (dry-run) or posts
+// (`--apply`) the canonical disposition, skipping notices already
+// dispositioned so a re-run is idempotent.
+//
+// It also auto-dispositions the CodeRabbit summary walkthrough (#1122): a
+// completed-review regular comment that recurs on every autopilot PR and the
+// gate scores through its general updatedAt-aware 1:1 pairing. Unlike a notice it
+// is `**Accepted**` (not `**Rejected**`), and because CodeRabbit edits the summary
+// each re-review the helper re-dispositions the CURRENT summary per HEAD by
+// timestamp (not a count carry-forward), so a stale acceptance can never mask a
+// finding folded into a later summary body.
+//
+// It is fail-closed: only classifier-recognized notices and the exact summary
+// marker are dispositioned; real reviews and review threads are never touched.
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import {
+  advisoryBotIdentityToken,
+  compareIsoTimestamps,
+  DEFAULT_ADVISORY_BOT_LOGINS,
+  dispositionNamesAdvisoryBot,
+  effectiveRegularCommentActivityAt,
+  isAdvisoryNonReviewNotice,
+  isNonReviewNoticeDisposition,
+  isReviewSummaryComment,
+  isReviewSummaryDisposition,
+  normalizeTrustedMarkerLogins,
+  resolveActiveClaimForWriteGate,
+  resolveAdvisoryBotLogins,
+} from './protocol-helpers.mjs';
+/**
+ * Derive the short `({reason})` clause for a non-review notice from its body.
+ * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls
+ * back to a generic label so an unrecognized-but-classified notice still gets a
+ * coherent disposition.
+ */
+export function noticeReason(body) {
+  const text = String(body ?? '');
+  if (/rate limited by coderabbit\.ai|Review limit reached/i.test(text)) {
+    return 'review limit reached / rate limited';
+  }
+  if (/Codex usage limits/i.test(text)) {
+    return 'Codex usage limits for code reviews reached';
+  }
+  return 'advisory non-review notice';
+}
+/**
+ * Build the canonical E6 non-review-notice disposition body: marker-first,
+ * naming the bot's GitHub login (for the #1018 author-scoped carry-forward),
+ * the current head SHA, and the source notice's own comment id (#1482) so
+ * repeat notices from the same bot at the same HEAD and reason category still
+ * produce byte-distinguishable replies. The `(source: #issuecomment-{id})`
+ * suffix is a human-readable disambiguator only: recognition
+ * (`isDispositionComment` / `isNonReviewNoticeDisposition` /
+ * `dispositionNamesAdvisoryBot`) matches on the leading marker and the bot
+ * login substring, never on exact body equality, so this addition cannot
+ * break gate recognition; it also never becomes a machine-readable pairing
+ * key for `summarizeDispositionEvidenceForGate`'s count-based carry-forward.
+ */
+export function buildDispositionBody(botLogin, headSha, reason, noticeId) {
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`;
+}
+/**
+ * Build the canonical `**Accepted**` disposition body for a CodeRabbit summary
+ * walkthrough (#1122): marker-first, naming the bot by its GitHub **login** and
+ * the current head SHA. The login form (`coderabbitai[bot]`) is deliberate — it
+ * does not contain the standalone word "CodeRabbit", so the gate's
+ * `classifyRegularBotComment` createdAt-based RESOLVED path (which requires
+ * `/\bCodeRabbit\b/`) never permanently clears the summary; clearing happens only
+ * through the general updatedAt-aware pairing, giving the safer per-HEAD
+ * re-disposition. The `summary walkthrough` phrase is what `isReviewSummaryDisposition`
+ * keys on, so keep the two in lockstep.
+ */
+export function buildSummaryDispositionBody(botLogin, headSha) {
+  return `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`;
+}
+/**
+ * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
+ * comments and returns which advisory non-review notices need a disposition and
+ * which already have one. Per advisory bot, the count of trusted IDD non-review
+ * notice dispositions naming that bot covers that many of its notices
+ * (oldest-first); the remainder are planned. This mirrors the gate's
+ * author-scoped 1:1 carry-forward, so the helper never posts a disposition the
+ * gate would not credit and never double-posts on a re-run.
+ *
+ * It also plans an `**Accepted**` for the CodeRabbit summary walkthrough (#1122),
+ * which the gate scores through its general updatedAt-aware 1:1 pairing rather
+ * than the notice carry-forward. The summary is re-dispositioned per HEAD by
+ * timestamp: it is skipped only when a trusted summary disposition naming the bot
+ * is strictly newer than the summary's updatedAt-aware activity (and skipped
+ * outright when CodeRabbit already reports "No actionable comments were
+ * generated", which the gate classifies RESOLVED). The two paths are disjoint:
+ * notices are `**Rejected**`, summaries are `**Accepted**`, and neither
+ * disposition predicate matches the other.
+ */
+export function buildDispositionPlan(input, options = {}) {
+  // Key all advisory-bot comparisons by the suffix-insensitive identity token
+  // (`coderabbitai[bot]` and `coderabbitai` collapse to one identity, matching
+  // `dispositionNamesAdvisoryBot`), so a notice/disposition authored under
+  // either variant counts against the same bot.
+  const advisoryBotIdentities = new Set(
+    normalizeTrustedMarkerLogins(
+      options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
+    ).map(advisoryBotIdentityToken),
+  );
+  const trustedMarkerLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const headSha = String(input.headSha ?? '');
+  const comments = (Array.isArray(input.comments) ? input.comments : [])
+    .map((comment) => ({
+      id: comment.id,
+      login: String(comment.login ?? '')
+        .trim()
+        .toLowerCase(),
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? ''),
+      // Preserve updatedAt so the summary-walkthrough path can score the summary
+      // and its dispositions through `effectiveRegularCommentActivityAt`,
+      // matching the gate's updatedAt-aware pairing.
+      updatedAt: String(comment.updatedAt ?? ''),
+    }))
+    .sort((left, right) => {
+      // Oldest-first, with a deterministic tie-breaker so the oldest-first
+      // pairing is stable: comments with equal (or invalid) timestamps fall back
+      // to the monotonic comment id, and an invalid timestamp sorts last.
+      const leftTime = Date.parse(left.createdAt);
+      const rightTime = Date.parse(right.createdAt);
+      const leftValid = !Number.isNaN(leftTime);
+      const rightValid = !Number.isNaN(rightTime);
+      if (leftValid && rightValid && leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      if (leftValid !== rightValid) {
+        return leftValid ? -1 : 1;
+      }
+      return left.id - right.id;
+    });
+  // Trusted IDD non-review-notice dispositions, grouped per advisory bot
+  // identity they name (so each bot's existing dispositions only cover its own
+  // notices).
+  const dispositionCountByBot = new Map();
+  for (const comment of comments) {
+    if (
+      !trustedMarkerLogins.has(comment.login) ||
+      !isNonReviewNoticeDisposition({ body: comment.body })
+    ) {
+      continue;
+    }
+    // Count a disposition toward at most ONE bot it names. The F2/F3 gate
+    // consumes a notice disposition at most once, so a combined marker naming
+    // several bots must not be credited as covering one notice per bot (that
+    // would let the helper skip notices the gate still blocks on).
+    for (const identity of advisoryBotIdentities) {
+      if (dispositionNamesAdvisoryBot(comment.body, identity)) {
+        dispositionCountByBot.set(
+          identity,
+          (dispositionCountByBot.get(identity) ?? 0) + 1,
+        );
+        break;
+      }
+    }
+  }
+  // Every persistent advisory non-review notice needs its own `**Rejected**`
+  // disposition, EVEN when the bot also has a completed review of the current
+  // HEAD: `summarizeDispositionEvidenceForGate` keeps the notice in its
+  // outstanding set until a notice-disposition naming that bot carries it, and
+  // that disposition is consumed only by the notice (never clears the separate
+  // completed review). So the helper always plans an undispositioned notice;
+  // the completed review is accepted as its own item by the E6 flow.
+  const planned = [];
+  const skipped = [];
+  const coveredByBot = new Map();
+  for (const comment of comments) {
+    const identity = advisoryBotIdentityToken(comment.login);
+    if (
+      !advisoryBotIdentities.has(identity) ||
+      !isAdvisoryNonReviewNotice(comment.body)
+    ) {
+      continue;
+    }
+    const alreadyCovered = coveredByBot.get(identity) ?? 0;
+    if (alreadyCovered < (dispositionCountByBot.get(identity) ?? 0)) {
+      // An existing trusted disposition naming this bot already covers a notice;
+      // attribute it (oldest-first) and skip this one as idempotent.
+      coveredByBot.set(identity, alreadyCovered + 1);
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'already-dispositioned',
+      });
+      continue;
+    }
+    const reason = noticeReason(comment.body);
+    planned.push({
+      noticeId: comment.id,
+      botLogin: comment.login,
+      reason,
+      body: buildDispositionBody(comment.login, headSha, reason, comment.id),
+    });
+  }
+  // CodeRabbit summary walkthrough auto-disposition (#1122). Separate from the
+  // notice path above: the gate scores the summary through its general
+  // updatedAt-aware 1:1 timestamp pairing (not the notice carry-forward), and
+  // CodeRabbit edits the summary on each re-review, so re-disposition the CURRENT
+  // summary per HEAD by timestamp. Mirror the gate's greedy oldest-first pairing:
+  // each summary consumes at most ONE trusted summary disposition that names the
+  // bot AND is strictly newer than the summary's updatedAt-aware activity; an
+  // uncovered summary is planned. Greedy consumption (not a bare existence check)
+  // means two coexisting summaries with a single newer disposition leave the
+  // second one planned — matching the gate and erring toward posting (an extra
+  // unpaired `**Accepted**` is inert, while under-posting strands the gate).
+  const summaryDispositions = comments
+    .filter(
+      (comment) =>
+        trustedMarkerLogins.has(comment.login) &&
+        isReviewSummaryDisposition({ body: comment.body }),
+    )
+    .map((comment) => ({
+      body: comment.body,
+      activityAt: effectiveRegularCommentActivityAt(comment),
+      consumed: false,
+    }));
+  // The gate pairs greedily across the GLOBAL outstanding set, so a summary's
+  // `**Accepted**` marker can be consumed by an OLDER undispositioned non-agent
+  // comment (a human reviewer or a non-notice bot), leaving the summary still
+  // flagged. The helper only models summary↔summary-disposition pairing, so when
+  // such an older comment exists it must NOT treat the summary as covered — it
+  // errs toward posting (#1122). Notices are excluded because the gate carves
+  // them and their dispositions out of the general pool; agent-authored comments
+  // (operational markers, digests, the dispositions themselves) are excluded via
+  // `trustedMarkerLogins`; other summaries are handled by the greedy pass above.
+  const markerCouldBeStolen = (dispositionActivityAt) =>
+    comments.some(
+      (other) =>
+        !trustedMarkerLogins.has(other.login) &&
+        !isAdvisoryNonReviewNotice(other.body) &&
+        !isReviewSummaryComment(other.body) &&
+        compareIsoTimestamps(
+          effectiveRegularCommentActivityAt(other),
+          dispositionActivityAt,
+        ) < 0,
+    );
+  for (const comment of comments) {
+    const identity = advisoryBotIdentityToken(comment.login);
+    if (
+      !advisoryBotIdentities.has(identity) ||
+      !isReviewSummaryComment(comment.body) ||
+      // A notice (rate-limit / usage-limit) that also carries the summary marker
+      // is dispositioned `**Rejected**` by the notice path above; never also
+      // `**Accepted**` it here, so a comment id gets at most one disposition.
+      isAdvisoryNonReviewNotice(comment.body)
+    ) {
+      continue;
+    }
+    // The gate already classifies a "No actionable comments were generated"
+    // summary as RESOLVED, so it never enters `missingRegularComments` and needs
+    // no disposition — auto-posting one would add brand-new noise.
+    if (/No actionable comments were generated/i.test(comment.body)) {
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'summary-resolved-no-actionable-comments',
+      });
+      continue;
+    }
+    const summaryActivityAt = effectiveRegularCommentActivityAt(comment);
+    // Consume the oldest unconsumed disposition naming this bot that is strictly
+    // newer than the summary, mirroring the gate's greedy `markerCursor`.
+    const cover = summaryDispositions.find(
+      (disposition) =>
+        !disposition.consumed &&
+        dispositionNamesAdvisoryBot(disposition.body, comment.login) &&
+        compareIsoTimestamps(disposition.activityAt, summaryActivityAt) > 0,
+    );
+    // Skip only when the marker is both newer than the summary AND cannot be
+    // stolen by an older non-agent comment under the gate's global pairing.
+    if (cover && !markerCouldBeStolen(cover.activityAt)) {
+      cover.consumed = true;
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'already-dispositioned',
+      });
+      continue;
+    }
+    planned.push({
+      noticeId: comment.id,
+      botLogin: comment.login,
+      reason: 'summary walkthrough',
+      body: buildSummaryDispositionBody(comment.login, headSha),
+    });
+  }
+  return { headSha, planned, skipped };
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const DISPOSITION_NON_REVIEW_NOTICES_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--claim-issue': { type: 'string' },
+  '--claim-id': { type: 'string', default: '' },
+  '--agent-id': { type: 'string', default: '' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--advisory-bot-logins': { type: 'string', default: '' },
+  '--apply': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function splitList(value) {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+/**
+ * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
+ * absent resolves to `null` (the original `pr: null` / `claimIssue: null`
+ * default, never overwritten when the flag is absent); present feeds the
+ * raw token straight to `Number.parseInt`, which accepts trailing-garbage
+ * ("42abc" -> 42) and leading-zero ("007" -> 7) tokens the same way the
+ * original hand-rolled `Number.parseInt(next(), 10)` always did.
+ * `cli-args.mts`'s `parseCanonicalIntegerOrNull` is a poor substitute here:
+ * its canonical-pattern regex rejects those same tokens outright, which is
+ * a real contract change a CodeRabbit review on PR #1466 caught -- #1450's
+ * acceptance criteria protect the post-parse integer contract as-is, only
+ * flag *syntax* (missing/flag-shaped values, unknown flags) is meant to
+ * tighten. The downstream `!Number.isInteger(...) || (... ?? 0) <= 0`
+ * guards below already treat `NaN` (an invalid parseInt result) the same
+ * as `null`, so this restores the exact original resolved value, not just
+ * an equivalent downstream verdict.
+ */
+function parseLenientIntegerOrNull(token) {
+  return token === undefined ? null : Number.parseInt(token, 10);
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    DISPOSITION_NON_REVIEW_NOTICES_FLAG_SPEC,
+  );
+  return {
+    pr: parseLenientIntegerOrNull(values.pr),
+    owner: values.owner,
+    repo: values.repo,
+    claimIssue: parseLenientIntegerOrNull(values['claim-issue']),
+    claimId: values['claim-id'],
+    agentId: values['agent-id'],
+    trustedMarkerLogins: splitList(values['trusted-marker-logins']),
+    advisoryBotLogins: splitList(values['advisory-bot-logins']),
+    apply: values.apply,
+    help,
+  };
+}
+function ghJson(args) {
+  return JSON.parse(ghText(args));
+}
+/**
+ * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
+ * one JSON array per page, so a >1-page response is not a single JSON document;
+ * `--jq '.[]'` flattens each page to one JSON value per line (NDJSON), which we
+ * parse line-by-line. (`--slurp` would be simpler but needs gh >= 2.48.0; Ubuntu
+ * 24.04 LTS ships gh 2.45.0, so the repo standardizes on `--jq '.[]'`.)
+ */
+function ghJsonPaginated(args) {
+  const out = ghText([...args, '--paginate', '--jq', '.[]'], {
+    timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line));
+}
+const USAGE = `usage: node scripts/disposition-non-review-notices.mjs --pr <number> [options]
+
+Detect advisory non-review notices and the CodeRabbit summary walkthrough on a PR
+and emit (default) or post (--apply) the canonical E6 disposition: a marker-first
+\`**Rejected** — {bot} did not review HEAD …\` per notice, and a marker-first
+\`**Accepted** — {bot} summary walkthrough …\` per current summary (re-dispositioned
+per HEAD). Idempotent and fail-closed.
+
+  --pr <number>                  PR number (required)
+  --owner <owner>                repo owner (default: gh repo view)
+  --repo <repo>                  repo name (default: gh repo view)
+  --claim-issue <number>         issue carrying the active claim (required with --apply)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
+  --agent-id <agent-id>          current session agent id
+  --trusted-marker-logins a,b    logins whose existing dispositions count
+                                 (default: your gh login, so re-runs are idempotent)
+  --advisory-bot-logins a,b      advisory bot logins (default: flag > IDD_ADVISORY_BOT_LOGINS
+                                 > .github/idd/config.json > coderabbit + codex)
+  --apply                        post the dispositions (default: dry-run)
+  -h, --help                     show this help
+`;
+/**
+ * Re-fetch the claim issue and decide whether the supplied claim id is still the
+ * active claim. Scoped to trusted marker authors via the shared
+ * `resolveActiveClaimForWriteGate` state machine (so a copied/forged
+ * `claimed-by` marker from an untrusted author cannot satisfy the gate). A
+ * forced-handoff marker is honored only when it is an operator-approved,
+ * authorized handoff (forced-handoff mode enabled, `forced-by` is an
+ * authorized maintainer, and the comment author matches `forced-by`);
+ * otherwise the original claim stays active and an unauthorized/forged
+ * successor `--claim-id` still fails the `=== claimId` comparison. This is an
+ * issue-scoped revalidation (`expectedLinkedPrs: null`), so a legitimate
+ * issue-only handoff is accepted. Aborting on a contested claim is always
+ * safe (the manual E6 path remains).
+ */
+function claimStillActive(
+  owner,
+  repo,
+  issue,
+  claimId,
+  isTrustedAuthor,
+  forcedHandoffOptions,
+) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${issue}/comments`,
+  ]);
+  const events = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const active = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor,
+    forcedHandoffEnabled: forcedHandoffOptions.forcedHandoffEnabled,
+    // Issue-scoped revalidation: accept a legitimate issue-only handoff.
+    expectedLinkedPrs: null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      forcedHandoffOptions.isAuthorizedForcedHandoff(forcedBy),
+    requireAuthorMatchesForcedBy: true,
+  });
+  return active?.claimId === claimId;
+}
+function postDisposition(owner, repo, pr, body) {
+  // A disposition body is plain text starting with `**Rejected**` (notice) or
+  // `**Accepted**` (summary walkthrough) — not an HTML-comment-first marker — so
+  // the `-f body=` field path posts it reliably; gh sends `{"body": <value>}` to
+  // the comments API.
+  return ghJson([
+    'api',
+    '--method',
+    'POST',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+    '-f',
+    `body=${body}`,
+  ]);
+}
+/** Ids of all comments on the PR authored by `viewerLogin`. */
+function viewerCommentIds(owner, repo, pr, viewerLogin) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+  ]);
+  const ids = new Set();
+  for (const comment of comments) {
+    if ((comment.user?.login ?? '').trim().toLowerCase() === viewerLogin) {
+      ids.add(comment.id);
+    }
+  }
+  return ids;
+}
+/**
+ * After a failed create, find a viewer-authored comment with this exact body
+ * whose id is NOT in `knownIds` — i.e., one created since posting began. Before
+ * #1482, two notices from the same bot on the same HEAD shared an identical
+ * canonical body, which is why this keys on a NEW comment id rather than body
+ * uniqueness. Since #1482 each body also embeds its own source notice's
+ * comment id, so bodies are now unique per notice too — but the NEW-id guard
+ * still matters: it stops the helper from matching some other pre-existing
+ * viewer comment that happens to carry this exact text instead of the create
+ * that just ran, which would under-count the markers the F2/F3 1:1 pairing
+ * needs.
+ */
+function recoverPostedDisposition(
+  owner,
+  repo,
+  pr,
+  body,
+  viewerLogin,
+  knownIds,
+) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+  ]);
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    if (
+      !knownIds.has(comment.id) &&
+      (comment.user?.login ?? '').trim().toLowerCase() === viewerLogin &&
+      (comment.body ?? '') === body
+    ) {
+      return { id: comment.id };
+    }
+  }
+  return null;
+}
+/**
+ * Orchestrate the `--apply` write loop with injected side effects, so the
+ * per-post claim revalidation, 2-attempt retry, and post-failure recovery
+ * are testable without the network -- mirrors `applyResolveReviewThread`'s
+ * (`resolve-review-thread.mts`) injectable-deps extraction pattern for this
+ * file's sibling write loop.
+ *
+ * Re-validates the active claim before EACH post: a claim lost mid-loop
+ * stops writing immediately and fail-marks the current item plus every
+ * remaining planned item, rather than posting under a claim no longer held.
+ * A create that throws is retried once via `recoverPostedDisposition`
+ * (never a blind second POST) before falling through to a second raw
+ * attempt, so a create that actually landed server-side despite a nonzero
+ * exit is never double-posted; a recovered id is folded into the running
+ * `knownViewerCommentIds` set immediately, so a later item in the same loop
+ * can never re-attribute it.
+ */
+export function applyDispositionPlan(plan, deps) {
+  const knownViewerCommentIds = new Set(deps.knownViewerCommentIds);
+  const applied = [];
+  const failed = [];
+  let claimLost = false;
+  for (let index = 0; index < plan.planned.length; index += 1) {
+    const item = plan.planned[index];
+    if (!deps.revalidateClaim()) {
+      // Claim lost mid-loop: stop writing and surface the current AND all
+      // remaining notices as failed rather than posting them under a claim we
+      // no longer hold, so the apply report names every notice left
+      // un-dispositioned.
+      claimLost = true;
+      for (const remaining of plan.planned.slice(index)) {
+        failed.push({
+          noticeId: remaining.noticeId,
+          error: 'claim revalidation failed before post',
+        });
+      }
+      break;
+    }
+    let posted = null;
+    let lastError = null;
+    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
+      try {
+        posted = deps.postDisposition(item.body);
+      } catch (error) {
+        // A non-Error throw (a plain string/object, e.g. from a mocked or
+        // non-standard failure) must not collapse the diagnostic down to a
+        // generic 'unknown error' -- coerce it the same way the rest of this
+        // repo does (see idd-onboard.mts, discover-shared-file-overlap.mts,
+        // rerun-advisory-convergence.mts).
+        lastError = error instanceof Error ? error.message : String(error);
+        // The create may have landed server-side despite the nonzero exit;
+        // re-read (by NEW comment id) before any retry so we never
+        // double-post.
+        posted = deps.recoverPostedDisposition(
+          item.body,
+          knownViewerCommentIds,
+        );
+      }
+    }
+    if (posted) {
+      knownViewerCommentIds.add(posted.id);
+      applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    } else {
+      failed.push({
+        noticeId: item.noticeId,
+        error: lastError ?? 'unknown error',
+      });
+    }
+  }
+  return { applied, failed, claimLost, knownViewerCommentIds };
+}
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
+    process.stdout.write(USAGE);
+    process.exit(args.help ? 0 : 1);
+  }
+  // Fail closed: --apply mutates PR state, so the active-claim revalidation is
+  // mandatory. Missing/invalid claim inputs must abort before any read or write
+  // rather than silently bypassing the gate.
+  if (
+    args.apply &&
+    (!Number.isInteger(args.claimIssue) ||
+      (args.claimIssue ?? 0) <= 0 ||
+      !args.claimId)
+  ) {
+    process.stderr.write(
+      '--apply requires --claim-issue and --claim-id for the mandatory claim revalidation\n',
+    );
+    process.exit(1);
+  }
+  const pr = args.pr;
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  // Default the trusted disposition authors to this gh login. Existing
+  // dispositions only count toward idempotency when their author is trusted, so
+  // without this default a re-run would not recognize its own prior posts and
+  // would double-post. The same trusted set scopes claim revalidation below.
+  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const trustedMarkerLogins =
+    args.trustedMarkerLogins.length > 0
+      ? args.trustedMarkerLogins
+      : [viewerLogin];
+  // Resolve advisory bot logins from flag > env > config (the same sources the
+  // sibling helpers use), falling back to the CodeRabbit/Codex defaults so a
+  // repo that configures custom advisory bots is not silently omitted.
+  const resolvedAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: loadIddConfig(),
+  }).logins;
+  const advisoryBotLogins =
+    resolvedAdvisoryBotLogins.length > 0
+      ? resolvedAdvisoryBotLogins
+      : DEFAULT_ADVISORY_BOT_LOGINS;
+  // Build a plan from a fresh read of the PR's HEAD and comments. Called once
+  // for dry-run and again immediately before --apply posts, so a HEAD advance or
+  // a disposition another session raced in is reflected just-in-time (the apply
+  // path never reuses the dry-run snapshot).
+  const planNow = () => {
+    const headSha = ghText([
+      'api',
+      `repos/${owner}/${repo}/pulls/${pr}`,
+      '--jq',
+      '.head.sha',
+    ]);
+    const rawComments = ghJsonPaginated([
+      'api',
+      `repos/${owner}/${repo}/issues/${pr}/comments`,
+    ]);
+    const comments = rawComments.map((comment) => ({
+      id: comment.id,
+      login: comment.user?.login ?? '',
+      body: comment.body ?? '',
+      createdAt: comment.created_at ?? '',
+      // The issues-comments API returns updated_at (bumped when CodeRabbit edits
+      // its summary); the summary path scores it through the gate's
+      // updatedAt-aware activity.
+      updatedAt: comment.updated_at ?? '',
+    }));
+    return buildDispositionPlan(
+      { headSha, comments },
+      { advisoryBotLogins, trustedMarkerLogins },
+    );
+  };
+  if (!args.apply) {
+    process.stdout.write(
+      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...planNow() }, null, 2)}\n`,
+    );
+    process.exit(0);
+  }
+  // --apply: revalidate the active claim immediately before EACH post, scoped to
+  // trusted marker authors and failing closed on a forced handoff. Re-checking
+  // per post means a claim released, superseded, or handed off mid-loop stops
+  // the remaining writes instead of posting under a lost claim.
+  const claimIssue = args.claimIssue;
+  const trustedAuthors = new Set(
+    trustedMarkerLogins.map((login) => login.toLowerCase()),
+  );
+  const isTrustedAuthor = (login) =>
+    trustedAuthors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  // Resolve the forced-handoff policy and build the collaborator-permission
+  // cache ONCE per CLI invocation (not per revalidation loop): re-reading
+  // .github/idd/config.json and re-hitting the collaborators API on every
+  // post would be a needless I/O hot path. Mirrors force-handoff.mjs and the
+  // audit-pr-cleanup readActiveClaim comment.
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffPermissionCache = new Map();
+  const forcedHandoffOptions = {
+    forcedHandoffEnabled,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        forcedHandoffPermissionCache,
+      ),
+  };
+  const revalidateClaim = () =>
+    claimStillActive(
+      owner,
+      repo,
+      claimIssue,
+      args.claimId,
+      isTrustedAuthor,
+      forcedHandoffOptions,
+    );
+  if (!revalidateClaim()) {
+    process.stderr.write(
+      `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${claimIssue}\n`,
+    );
+    process.exit(1);
+  }
+  // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
+  // re-posts a disposition that raced in since the dry-run.
+  const plan = planNow();
+  // Seed the viewer-authored comment ids known before this run (pre-existing
+  // plus, once applyDispositionPlan runs, the ones it posts), so a
+  // post-failure recovery attributes a NEW comment to the current notice's
+  // own post instead of some other pre-existing comment that happens to
+  // carry the identical (now per-notice-unique, #1482) body text.
+  const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
+  const { applied, failed, claimLost } = applyDispositionPlan(plan, {
+    revalidateClaim,
+    postDisposition: (body) => postDisposition(owner, repo, pr, body),
+    recoverPostedDisposition: (body, knownIds) =>
+      recoverPostedDisposition(owner, repo, pr, body, viewerLogin, knownIds),
+    knownViewerCommentIds,
+  });
+  const status = failed.length > 0 ? 'failed' : 'applied';
+  process.stdout.write(
+    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha: plan.headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
+  );
+  process.exit(claimLost || failed.length > 0 ? 1 : 0);
+}

--- a/scripts/effort.mjs
+++ b/scripts/effort.mjs
@@ -1,0 +1,112 @@
+// idd-generated-from: src/scripts/effort.mts
+//
+// The scripts/effort.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Shared author-recorded effort-hint parsing for discovery selection.
+// Consumed by:
+//
+// - scripts/discover-roadmap-graph.mjs (A2 node enumeration / union rank)
+// - scripts/discover-orphan-filter.mjs (A0-O orphan candidate ranking)
+//
+// The effort hint is the authored `S | M | L` size estimate defined in
+// skills/issue-authoring/references/contract.md. It is a **soft**
+// selection tie-breaker only (A4 Step 2, after the suitability score and
+// optional desync, before the lowest-issue-number tie-break): it never
+// skips, gates, or reorders candidates across suitability score bands,
+// and a large issue stays fully claimable when it is the only ready work.
+// Like the suitability score it is fail-safe on absence — a missing or
+// invalid marker means "no effort hint" and selection behaves exactly as
+// it does today.
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+/** The authored effort bands, smallest to largest. */
+export const EFFORT_HINTS = ['S', 'M', 'L'];
+// Ordinal used by the soft tie-breaker (lower = smaller = preferred). A
+// missing or invalid hint resolves to the **neutral** middle ordinal so an
+// issue with no coherent effort hint is neither preferred over nor
+// de-preferred against an equally-ranked `M` issue; this keeps a band with no
+// effort hints ordered exactly as today (by lowest issue number).
+const EFFORT_ORDINALS = { S: 1, M: 2, L: 3 };
+export const NEUTRAL_EFFORT_ORDINAL = 2;
+/**
+ * Canonical parser for the authored `<!-- {prefix}-effort: S|M|L -->`
+ * marker.
+ *
+ * Returns `{ present, value, malformed }`:
+ * - `present` is true when a marker carrying a non-whitespace token after
+ *   `-effort:` appears. Like the suitability marker, the detection regex
+ *   requires that token (`[^\s>]+`), so a value-less `<!-- {prefix}-effort:
+ *   -->` does not match and reads as `present: false` rather than a present
+ *   malformed marker.
+ * - `value` is the single coherent band (`S`, `M`, or `L`, upper-cased),
+ *   or null (fail-safe = "no effort hint") when the marker is absent, not
+ *   one of the bands, or repeated with disagreeing values.
+ * - `malformed` is true when a detected marker's value is not a single
+ *   coherent band (e.g. `XL`, `2`, or conflicting duplicates).
+ *
+ * Mirrors `parseAutopilotSuitabilityMarker` so the regex and fail-safe
+ * rules stay aligned between the two authored footers.
+ */
+export function parseEffortMarker(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  const prefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-effort:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  const text = String(body ?? '');
+  // Stream matches with regex.exec so an untrusted, marker-heavy body stays
+  // O(1) memory, and fail fast on the first invalid token or first value
+  // that conflicts with an earlier one.
+  let present = false;
+  let value = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const normalized = match[1].toUpperCase();
+    // Fail-safe: any invalid token, or a value disagreeing with an earlier
+    // coherent one, yields no hint.
+    if (!isEffortHint(normalized) || (value !== null && normalized !== value)) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = normalized;
+    match = regex.exec(text);
+  }
+  if (!present) {
+    return { present: false, value: null, malformed: false };
+  }
+  return { present: true, value, malformed: false };
+}
+/**
+ * Parse the authored effort hint from an issue body.
+ *
+ * Returns `S | M | L` when the body carries a single coherent
+ * `<!-- {prefix}-effort: … -->` marker, or null (fail-safe = "no effort
+ * hint") when the marker is absent, not one of the bands, or present more
+ * than once with disagreeing values. A null hint must never cause an issue
+ * to be skipped; the caller selects it the normal way. Thin value-only
+ * view over {@link parseEffortMarker}.
+ */
+export function parseEffort(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  return parseEffortMarker(body, markerPrefix).value;
+}
+/**
+ * The soft-tie-break ordinal for an effort hint: `S` → 1, `M` → 2,
+ * `L` → 3, and any non-hint (null / invalid) → the neutral middle ordinal
+ * (2). Lower sorts first, so the A4 Step 2 tie-breaker prefers smaller
+ * issues while leaving un-hinted ones in the middle and never excluding any
+ * candidate.
+ */
+export function effortOrdinal(value) {
+  return isEffortHint(value) ? EFFORT_ORDINALS[value] : NEUTRAL_EFFORT_ORDINAL;
+}
+/** True when `value` is one of the authored effort bands `S | M | L`. */
+export function isEffortHint(value) {
+  return typeof value === 'string' && EFFORT_HINTS.includes(value);
+}
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/emit-marker.mjs
+++ b/scripts/emit-marker.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/emit-marker.mts
+//
+// The scripts/emit-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Emit-only CLI for the three per-cycle operational marker bodies
+// (claimed-by / review-watermark / review-baseline). It prints the
+// ready-to-post body string to stdout and performs NO network write; the
+// agent posts it via the documented HTTP path. The render logic lives in
+// protocol-helpers; this is the thin CLI surface.
+import { requireFlag } from './cli-args.mjs';
+import {
+  renderClaimedByMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+} from './protocol-helpers.mjs';
+
+const MARKER_TYPES = ['claimed-by', 'review-watermark', 'review-baseline'];
+if (import.meta.main) {
+  runCli();
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const type = args.type;
+  if (!type || !MARKER_TYPES.includes(type)) {
+    throw new Error(
+      `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
+    );
+  }
+  // #1722: validate every flag THIS marker type requires, by name, before
+  // the renderer ever sees the payload -- previously only --type was
+  // checked here, so a missing per-type flag (e.g. --timestamp for
+  // claimed-by) fell through to the renderer's own aggregate guard, which
+  // reports only an unattributed "invalid ... marker payload" with no
+  // indication of which flag was absent. requireFlag (cli-args.mts) reports
+  // the exact missing flag, matching the shape the --type check above
+  // already uses. --supersedes / --max-activity-at / --ci-completed-at are
+  // deliberately NOT required here: the renderers themselves default an
+  // absent or empty value to the `none` sentinel, so requiring them here
+  // would reject input the renderer accepts. The renderer's own aggregate
+  // guard stays in place as defense-in-depth for any other direct caller of
+  // renderClaimedByMarker / renderReviewWatermarkMarker /
+  // renderReviewBaselineMarker (e.g. protocol-helpers.mts consumers outside
+  // this CLI).
+  let body;
+  if (type === 'claimed-by') {
+    body = renderClaimedByMarker({
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      supersedes: args.supersedes,
+      timestamp: requireFlag(args.timestamp, '--timestamp'),
+      branch: requireFlag(args.branch, '--branch'),
+    });
+  } else if (type === 'review-watermark') {
+    body = renderReviewWatermarkMarker({
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      headSha: requireFlag(args['head-sha'], '--head-sha'),
+      maxActivityAt: args['max-activity-at'],
+      totalItemCount: requireFlag(
+        args['total-item-count'],
+        '--total-item-count',
+      ),
+      ciCompletedAt: args['ci-completed-at'],
+    });
+  } else {
+    body = renderReviewBaselineMarker({
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      sha: requireFlag(args.sha, '--sha'),
+    });
+  }
+  process.stdout.write(`${body}\n`);
+}
+// Excluded from the #1446 cli-args.mts wrapper: this parser collects
+// dynamic, marker-type-dependent keys into an index-signature bag
+// (`[key: string]: string | boolean` above) rather than a fixed set of
+// declared flags. `util.parseArgs`'s `strict: true` rejects any option not
+// named in its static spec, and `strict: false` would instead coerce every
+// unrecognized flag to `true` -- neither matches this file's "accept
+// whatever field this marker type needs" contract.
+function parseArgs(argv) {
+  const parsed = { type: '', help: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      throw new Error(`unknown argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/emit-marker.mjs --type claimed-by --agent-id <id> --claim-id <id> --supersedes <id|none> --timestamp <ISO8601> --branch <name>
+  node scripts/emit-marker.mjs --type review-watermark --agent-id <id> --claim-id <id> --head-sha <sha> --max-activity-at <ISO8601|none> --total-item-count <n> --ci-completed-at <ISO8601|none>
+  node scripts/emit-marker.mjs --type review-baseline --agent-id <id> --claim-id <id> --sha <sha>
+
+Prints the exact ready-to-post marker body (HTML token + visible note) to
+stdout. Emit-only: performs no network write. Post it via the documented
+HTTP path. The written marker formats remain the canonical fallback.
+`);
+}

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -1,0 +1,975 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/external-check-waiver.mts
+//
+// The scripts/external-check-waiver.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { parseCliArgs } from './cli-args.mjs';
+import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mjs';
+import { resolveHelperActiveClaim } from './forced-handoff-marker.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghText,
+  safeGhText,
+} from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import {
+  normalizePolicyConfig,
+  parseIsoDurationToMs,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mjs';
+import {
+  parsePaginatedGhNdjson,
+  renderExternalCheckWaiverComment,
+} from './protocol-helpers.mjs';
+import { makeReadlinePrompt } from './readline-prompt.mjs';
+
+const APPROVAL_ACTOR_POLICIES = new Set([
+  'owners-and-maintainers-only',
+  'all-write-permission-actors',
+]);
+const APPROVAL_ACTOR_POLICY_DEFAULT = 'owners-and-maintainers-only';
+const EXTERNAL_CHECK_WAIVER_MODE = 'maintainer-authorized';
+const EXTERNAL_CHECK_WAIVER_MODE_DISABLED = 'disabled';
+const SUCCESS_LIKE_CHECK_STATES = new Set([
+  'success',
+  'neutral',
+  'skipped',
+  'not_applicable',
+]);
+const PENDING_CHECK_STATES = new Set([
+  'queued',
+  'in_progress',
+  'waiting',
+  'pending',
+  'expected',
+]);
+export const NON_TTY_APPLY_ERROR =
+  'operator interaction is required; rerun in a TTY or pass --yes after reviewing dry-run output';
+export function matchCheckSelector(name, selector, matchMode = 'exact') {
+  const normalizedName = String(name ?? '').trim();
+  const normalizedSelector = String(selector ?? '').trim();
+  if (!normalizedName || !normalizedSelector) {
+    return false;
+  }
+  if (matchMode === 'glob') {
+    const source = normalizedSelector
+      .replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+      .replace(/\*/g, '.*');
+    return new RegExp(`^${source}$`).test(normalizedName);
+  }
+  return normalizedName === normalizedSelector;
+}
+export function planExternalCheckWaiver(input, options = {}) {
+  const pr = input?.pr ?? {};
+  const issueCandidates = Array.isArray(input?.issueCandidates)
+    ? input.issueCandidates
+    : [];
+  const policy = input?.policy ?? normalizePolicyConfig({});
+  const requestedSelector = String(input?.requestedSelector ?? '').trim();
+  const reason = String(input?.reason ?? '').trim();
+  const expiresAt = String(input?.expiresAt ?? '').trim();
+  const actor = String(input?.actor ?? '')
+    .trim()
+    .toLowerCase();
+  const authority = normalizeAuthorityEvidence(
+    input?.authority,
+    actor,
+    String(options.repoOwner ?? input?.repoOwner ?? '').trim(),
+    policy?.ciGate?.externalCheckWaivers?.authorityPolicy,
+  );
+  const requestedMatchMode = selectorRequestsGlob(requestedSelector)
+    ? 'glob'
+    : 'exact';
+  const normalizedChecks = normalizeChecks(pr.statusCheckRollup);
+  const matchedChecks = normalizedChecks.filter((check) => {
+    return matchCheckSelector(
+      check.name,
+      requestedSelector,
+      requestedMatchMode,
+    );
+  });
+  const waivableSelectors = policy?.ciGate?.externalChecks?.waivable ?? [];
+  const matchedSelectors = waivableSelectors.filter((selector) => {
+    return matchedChecks.some((check) => {
+      return matchCheckSelector(
+        check.name,
+        selector.selector,
+        selector.matchMode,
+      );
+    });
+  });
+  const uncoveredChecks = matchedChecks.filter((check) => {
+    return !waivableSelectors.some((selector) => {
+      return matchCheckSelector(
+        check.name,
+        selector.selector,
+        selector.matchMode,
+      );
+    });
+  });
+  const maxValidity = parseIsoDurationToMs(
+    policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
+  );
+  const now = options.now instanceof Date ? options.now : new Date();
+  const expiresDate = expiresAt ? new Date(expiresAt) : null;
+  const expiresKnown =
+    expiresDate instanceof Date && Number.isFinite(expiresDate.getTime());
+  const expiresInFuture = expiresKnown && expiresDate.getTime() > now.getTime();
+  const withinMaxValidity =
+    expiresKnown && Number.isFinite(maxValidity)
+      ? expiresDate.getTime() - now.getTime() <= (maxValidity ?? 0)
+      : false;
+  // #1905: still resolved even under --claimless -- not to gate on it (a
+  // claimless waiver never requires a linked-issue claim), but so a
+  // resolvable active claim can be surfaced as a blocking diagnostic below:
+  // a `none`-claim-id waiver only ever satisfies
+  // `summarizeExternalCheckWaivers` on a PR with NO active claim, so
+  // rendering one against a claimed PR would just be rejected `wrongClaim`
+  // at the merge gate -- better to block it here with a clear reason than
+  // let the operator post a waiver that can never take effect.
+  const linkedIssue = selectLinkedIssueCandidate(issueCandidates, {
+    issueNumber: input?.issueNumber,
+    expectedClaimId: input?.expectedClaimId,
+    headRefName: String(pr.headRefName ?? '').trim(),
+  });
+  const claimless = Boolean(input?.claimless);
+  const blockingReasons = [];
+  if (String(pr.state ?? 'OPEN').toUpperCase() !== 'OPEN') {
+    blockingReasons.push(`PR #${pr.number ?? '?'} is not open`);
+  }
+  if (
+    (policy?.ciGate?.externalCheckWaivers?.mode ??
+      EXTERNAL_CHECK_WAIVER_MODE_DISABLED) !== EXTERNAL_CHECK_WAIVER_MODE
+  ) {
+    blockingReasons.push('external-check waiver mode is disabled');
+  }
+  if (claimless) {
+    if (linkedIssue.ok) {
+      blockingReasons.push(
+        'PR has a resolvable active IDD claim on a linked issue; a claimless (none) waiver only applies when no claim resolves -- use --issue/--claim-id instead',
+      );
+    }
+    // The normal path's agentId comes from the resolved claim, independent
+    // of `actor`; --claimless has no claim to fall back on, so an empty
+    // actor must surface here as a blocking reason like every other invalid
+    // input in this function, rather than reaching
+    // renderExternalCheckWaiverComment's own throw-on-empty-agentId guard.
+    if (!actor) {
+      blockingReasons.push('actor is empty');
+    }
+  } else if (!linkedIssue.ok) {
+    blockingReasons.push(linkedIssue.reason);
+  }
+  if (!requestedSelector) {
+    blockingReasons.push('requested check selector is empty');
+  }
+  if (!reason) {
+    blockingReasons.push('reason is empty');
+  }
+  if (!expiresKnown) {
+    blockingReasons.push('expiry is not a valid ISO-8601 timestamp');
+  } else {
+    if (!expiresInFuture) {
+      blockingReasons.push('expiry must be in the future');
+    }
+    if (!withinMaxValidity) {
+      blockingReasons.push(
+        `expiry exceeds configured maxValidity ${policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H'}`,
+      );
+    }
+  }
+  if (!authority.known) {
+    blockingReasons.push(
+      authority.error || 'actor authority could not be proven',
+    );
+  } else if (!authority.authorized) {
+    blockingReasons.push(
+      `${actor || 'actor'} is not authorized under ${authority.policy}`,
+    );
+  }
+  if (matchedChecks.length === 0) {
+    blockingReasons.push(
+      `requested selector ${requestedSelector || '<empty>'} did not match any current PR checks`,
+    );
+  }
+  if (
+    matchedChecks.length > 0 &&
+    matchedChecks.every((check) => check.successLike)
+  ) {
+    blockingReasons.push('matched checks are already passing');
+  }
+  if (matchedChecks.length > 0 && uncoveredChecks.length > 0) {
+    blockingReasons.push(
+      'one or more matched checks are not configured as waivable external checks',
+    );
+  }
+  // #1905: --claimless binds the marker to the sentinel claim-id `none` and
+  // the acting maintainer's own identity as agentId (there is no
+  // issue-claim agentId to reuse when the PR carries no active claim by
+  // design); the normal path binds to the linked issue's active claim, same
+  // as before this change.
+  const claimBinding = claimless
+    ? actor
+      ? { agentId: actor, claimId: 'none' }
+      : null
+    : linkedIssue.ok
+      ? {
+          agentId: linkedIssue.issue.activeClaim.agentId,
+          claimId: linkedIssue.issue.activeClaim.claimId,
+        }
+      : null;
+  const body =
+    claimBinding &&
+    requestedSelector &&
+    reason &&
+    expiresKnown &&
+    String(pr.headRefOid ?? '').match(/^[0-9a-f]{40}$/i)
+      ? renderExternalCheckWaiverComment({
+          actor,
+          agentId: claimBinding.agentId,
+          claimId: claimBinding.claimId,
+          headSha: String(pr.headRefOid ?? '').toLowerCase(),
+          checkSelector: requestedSelector,
+          reason,
+          expiresAt,
+        })
+      : '';
+  return {
+    mode: input?.mode === 'apply' ? 'apply' : 'dry-run',
+    action: input?.mode === 'apply' ? 'create' : 'plan',
+    canApply: blockingReasons.length === 0,
+    repository: input?.repository ?? '',
+    policy: {
+      source: input?.policySource ?? '.github/idd/config.json',
+      waiverMode:
+        policy?.ciGate?.externalCheckWaivers?.mode ??
+        EXTERNAL_CHECK_WAIVER_MODE_DISABLED,
+      authorityPolicy:
+        policy?.ciGate?.externalCheckWaivers?.authorityPolicy ??
+        APPROVAL_ACTOR_POLICY_DEFAULT,
+      maxValidity: policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
+    },
+    actor: authority,
+    pr: {
+      number: pr.number ?? 0,
+      url: pr.url ?? '',
+      state: String(pr.state ?? ''),
+      headRefName: pr.headRefName ?? '',
+      headRefOid: pr.headRefOid ?? '',
+    },
+    linkedIssue: linkedIssue.ok
+      ? {
+          number: linkedIssue.issue.number,
+          url: linkedIssue.issue.url,
+          activeClaim: linkedIssue.issue.activeClaim,
+        }
+      : null,
+    requested: {
+      selector: requestedSelector,
+      matchMode: requestedMatchMode,
+      reason,
+      expiresAt,
+    },
+    checks: {
+      total: normalizedChecks.length,
+      matched: matchedChecks,
+      matchedSelectors,
+      uncoveredChecks,
+    },
+    blockingReasons,
+    body,
+  };
+}
+export async function runExternalCheckWaiver(options = {}) {
+  const args = options.args ?? parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return { exitCode: 0 };
+  }
+  const repository =
+    args.repo ||
+    ghText([
+      'repo',
+      'view',
+      '--json',
+      'nameWithOwner',
+      '--jq',
+      '.nameWithOwner',
+    ]);
+  const { owner, name } = parseOwnerRepo(repository);
+  const rawConfig = readJsonFile('.github/idd/config.json');
+  const policy = normalizePolicyConfig(rawConfig);
+  const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
+    .trim()
+    .toLowerCase();
+  const actor = String(options.actor ?? args.actor ?? viewerLogin)
+    .trim()
+    .toLowerCase();
+  if (!actor) {
+    throw new Error(
+      'could not determine current GitHub user; ensure gh is authenticated',
+    );
+  }
+  if (args.apply && args.actor && actor !== viewerLogin && viewerLogin) {
+    throw new Error(
+      `--actor ${args.actor} does not match the authenticated user ${viewerLogin}; omit --actor to use the authenticated identity`,
+    );
+  }
+  const authority =
+    options.authority ??
+    resolveCollaboratorAuthority({ owner, repo: name, actor });
+  const pr =
+    options.pr ??
+    fetchPullRequest({ owner, repo: name, prNumber: args.prNumber });
+  const issueCandidates =
+    options.issueCandidates ??
+    resolveLinkedIssueCandidates({
+      owner,
+      repo: name,
+      rawConfig,
+      viewerLogin: actor,
+      linkedIssues: pr.closingIssuesReferences,
+      issueNumber: args.issueNumber,
+      expectedClaimId: args.claimId,
+      headRefName: pr.headRefName,
+      prNumber: args.prNumber,
+    });
+  const report = planExternalCheckWaiver(
+    {
+      mode: args.apply ? 'apply' : 'dry-run',
+      repository: `${owner}/${name}`,
+      policy,
+      policySource: '.github/idd/config.json',
+      actor,
+      authority,
+      pr,
+      issueCandidates,
+      issueNumber: args.issueNumber,
+      expectedClaimId: args.claimId,
+      requestedSelector: args.checkSelector,
+      reason: args.reason,
+      expiresAt: resolveExpiryAt({
+        expiresAt: args.expiresAt,
+        expiresIn: args.expiresIn,
+        now: options.now instanceof Date ? options.now : new Date(),
+      }),
+      repoOwner: owner,
+      claimless: args.claimless,
+    },
+    { now: options.now, repoOwner: owner },
+  );
+  if (!args.apply) {
+    renderReport(report, args.format);
+    return { exitCode: 0, report };
+  }
+  if (!report.canApply) {
+    renderReport(report, args.format);
+    throw new Error(
+      `external-check waiver apply blocked: ${report.blockingReasons.join('; ')}`,
+    );
+  }
+  if (!report.body) {
+    throw new Error(
+      'external-check waiver apply blocked: canonical comment body is empty',
+    );
+  }
+  const isTTY =
+    options.isTTY ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!args.yes && !isTTY) {
+    throw new Error(NON_TTY_APPLY_ERROR);
+  }
+  if (!args.yes) {
+    renderReport(report, args.format);
+    const ask = options.prompt ?? makeReadlinePrompt();
+    const answer = await ask('Post external-check waiver comment? [y/N] ');
+    ask.close?.();
+    if (
+      String(answer ?? '')
+        .trim()
+        .toLowerCase() !== 'y'
+    ) {
+      process.stdout.write('Aborted. No changes made.\n');
+      return { exitCode: 0, report: { ...report, applied: false } };
+    }
+  }
+  const result = options.postComment
+    ? await options.postComment(args.prNumber, report.body)
+    : ghJson([
+        'api',
+        `repos/${owner}/${name}/issues/${args.prNumber}/comments`,
+        '--method',
+        'POST',
+        '-f',
+        `body=${report.body}`,
+      ]);
+  const appliedReport = {
+    ...report,
+    applied: true,
+    commentUrl: String(result.html_url ?? result.url ?? ''),
+  };
+  renderReport(appliedReport, args.format);
+  return { exitCode: 0, report: appliedReport };
+}
+function selectorRequestsGlob(selector) {
+  return /[*]/.test(String(selector ?? ''));
+}
+function selectLinkedIssueCandidate(issueCandidates, options = {}) {
+  const filtered = issueCandidates.filter((candidate) => {
+    if (options.issueNumber && candidate.number !== options.issueNumber) {
+      return false;
+    }
+    if (candidate.activeClaim?.branch !== options.headRefName) {
+      return false;
+    }
+    if (
+      options.expectedClaimId &&
+      candidate.activeClaim?.claimId !== options.expectedClaimId
+    ) {
+      return false;
+    }
+    return Boolean(candidate.activeClaim);
+  });
+  if (filtered.length === 1) {
+    return {
+      ok: true,
+      issue: filtered[0],
+      reason: '',
+    };
+  }
+  if (filtered.length === 0) {
+    return {
+      ok: false,
+      issue: null,
+      reason:
+        'could not resolve a single active linked issue claim on the PR branch',
+    };
+  }
+  return {
+    ok: false,
+    issue: null,
+    reason:
+      'multiple linked issues expose active claims on the PR branch; rerun with --issue and --claim-id',
+  };
+}
+function normalizeChecks(statusCheckRollup = []) {
+  return (statusCheckRollup ?? [])
+    .map((entry) => {
+      if (entry?.__typename === 'StatusContext') {
+        const rawState = String(entry.state ?? '')
+          .trim()
+          .toLowerCase();
+        return {
+          type: 'status-context',
+          name: String(entry.context ?? '').trim(),
+          state: rawState,
+          successLike: SUCCESS_LIKE_CHECK_STATES.has(rawState),
+          pending: PENDING_CHECK_STATES.has(rawState),
+          url: String(entry.targetUrl ?? ''),
+        };
+      }
+      const status = String(entry?.status ?? '')
+        .trim()
+        .toLowerCase();
+      const conclusion = String(entry?.conclusion ?? '')
+        .trim()
+        .toLowerCase();
+      const state =
+        status === 'completed' ? conclusion || 'unknown' : status || 'unknown';
+      return {
+        type: 'check-run',
+        name: String(entry?.name ?? '').trim(),
+        state,
+        successLike: SUCCESS_LIKE_CHECK_STATES.has(state),
+        pending: PENDING_CHECK_STATES.has(state),
+        url: String(entry?.detailsUrl ?? ''),
+        workflowName: String(entry?.workflowName ?? ''),
+      };
+    })
+    .filter((entry) => entry.name);
+}
+function normalizeAuthorityEvidence(evidence, actor, repoOwner, policy) {
+  const normalizedPolicy = APPROVAL_ACTOR_POLICIES.has(policy)
+    ? policy
+    : APPROVAL_ACTOR_POLICY_DEFAULT;
+  const roleName = String(
+    evidence?.roleName ??
+      evidence?.role_name ??
+      evidence?.user?.role_name ??
+      '',
+  )
+    .trim()
+    .toLowerCase();
+  const permission = String(evidence?.permission ?? evidence?.permissions ?? '')
+    .trim()
+    .toLowerCase();
+  const known =
+    evidence?.known !== false &&
+    (roleName.length > 0 ||
+      permission.length > 0 ||
+      actor === repoOwner.toLowerCase());
+  const isOwner = actor === repoOwner.toLowerCase();
+  let authorized = false;
+  if (isOwner) {
+    authorized = true;
+  } else if (normalizedPolicy === 'all-write-permission-actors') {
+    authorized =
+      roleName === 'admin' ||
+      roleName === 'maintain' ||
+      roleName === 'write' ||
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write';
+  } else {
+    authorized =
+      roleName === 'admin' ||
+      roleName === 'maintain' ||
+      permission === 'admin' ||
+      permission === 'maintain';
+  }
+  const error = known
+    ? ''
+    : String(
+        evidence?.error ??
+          'authority lookup did not return role-aware permission evidence',
+      );
+  return {
+    actor,
+    policy: normalizedPolicy,
+    known,
+    authorized,
+    isOwner,
+    permission,
+    roleName,
+    error,
+  };
+}
+function resolveExpiryAt({ expiresAt, expiresIn, now }) {
+  const hasExpiresAt = Boolean(String(expiresAt ?? '').trim());
+  const hasExpiresIn = Boolean(String(expiresIn ?? '').trim());
+  if (hasExpiresAt === hasExpiresIn) {
+    throw new Error('specify exactly one of --expires or --expires-in');
+  }
+  if (hasExpiresAt) {
+    const parsed = new Date(String(expiresAt).trim());
+    if (!Number.isFinite(parsed.getTime())) {
+      throw new Error(`invalid --expires value: ${expiresAt}`);
+    }
+    return parsed.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  }
+  const durationMs = parseIsoDurationToMs(String(expiresIn).trim());
+  if (!Number.isFinite(durationMs) || (durationMs ?? 0) <= 0) {
+    throw new Error(`invalid --expires-in value: ${expiresIn}`);
+  }
+  return new Date(now.getTime() + (durationMs ?? 0)).toISOString();
+}
+function resolveLinkedIssueCandidates({
+  owner,
+  repo,
+  rawConfig,
+  viewerLogin,
+  linkedIssues,
+  issueNumber,
+  expectedClaimId,
+  headRefName,
+  prNumber,
+}) {
+  const issueRefs = (linkedIssues ?? []).filter((issue) => {
+    return !issueNumber || Number(issue.number) === issueNumber;
+  });
+  const results = [];
+  for (const issue of issueRefs) {
+    const comments = ghJson(
+      [
+        'api',
+        '--paginate',
+        `repos/${owner}/${repo}/issues/${issue.number}/comments`,
+      ],
+      true,
+    );
+    const trustedMarkerLogins = buildTrustedMarkerLogins({
+      owner,
+      repo,
+      rawConfig,
+      viewerLogin,
+      issueComments: comments,
+    });
+    const forcedHandoffAuthorityPolicy =
+      normalizePolicyConfig(rawConfig).forcedHandoff.authorityPolicy;
+    const expectedLinkedPrs = prNumber ? [String(prNumber)] : [];
+    const activeClaim = resolveHelperActiveClaim(
+      comments,
+      [...trustedMarkerLogins],
+      {
+        expectedLinkedPrs,
+        isAuthorizedForcedHandoff: (fhActor) => {
+          const auth = resolveCollaboratorAuthority({
+            owner,
+            repo,
+            actor: fhActor,
+          });
+          if (forcedHandoffAuthorityPolicy === 'all-write-permission-actors') {
+            return (
+              auth.permission === 'admin' ||
+              auth.permission === 'maintain' ||
+              auth.permission === 'write'
+            );
+          }
+          return auth.permission === 'admin' || auth.permission === 'maintain';
+        },
+      },
+    );
+    if (!activeClaim) {
+      results.push({
+        number: issue.number,
+        url: issue.url,
+        activeClaim: null,
+      });
+      continue;
+    }
+    if (expectedClaimId && activeClaim.claimId !== expectedClaimId) {
+      results.push({
+        number: issue.number,
+        url: issue.url,
+        activeClaim: null,
+      });
+      continue;
+    }
+    if (headRefName && activeClaim.branch !== headRefName) {
+      results.push({
+        number: issue.number,
+        url: issue.url,
+        activeClaim: null,
+      });
+      continue;
+    }
+    results.push({
+      number: issue.number,
+      url: issue.url,
+      activeClaim,
+    });
+  }
+  return results;
+}
+function fetchPullRequest({ owner, repo, prNumber }) {
+  return ghJson([
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    `${owner}/${repo}`,
+    '--json',
+    'number,state,url,headRefName,headRefOid,statusCheckRollup,closingIssuesReferences',
+  ]);
+}
+function resolveCollaboratorAuthority({ owner, repo, actor }) {
+  const normalized = String(actor ?? '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) {
+    return {
+      known: false,
+      authorized: false,
+      permission: '',
+      roleName: '',
+      error: 'empty actor',
+    };
+  }
+  const result = ghApiJsonWithStatus(
+    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalized)}/permission`,
+  );
+  if (result.status === 404) {
+    return {
+      known: true,
+      authorized: false,
+      permission: 'none',
+      roleName: '',
+      error: '',
+    };
+  }
+  if (result.status !== 200) {
+    return {
+      known: false,
+      authorized: false,
+      permission: '',
+      roleName: '',
+      error: `authority lookup failed: ${result.status}`,
+    };
+  }
+  return {
+    known: true,
+    authorized: false,
+    permission: String(result.body?.permission ?? '')
+      .trim()
+      .toLowerCase(),
+    roleName: String(
+      result.body?.role_name ?? result.body?.user?.role_name ?? '',
+    )
+      .trim()
+      .toLowerCase(),
+    error: '',
+  };
+}
+export function buildTrustedMarkerLogins({
+  owner,
+  repo,
+  rawConfig,
+  viewerLogin,
+  issueComments,
+}) {
+  const trusted = new Set(
+    [
+      owner,
+      viewerLogin,
+      ...readTrustedMarkerActors(rawConfig),
+      ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
+    ]
+      .filter(Boolean)
+      .map((login) => login.toLowerCase()),
+  );
+  if (
+    !resolveCollaboratorMarkerTrust(
+      rawConfig,
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    )
+  ) {
+    return trusted;
+  }
+  // #1693: marker-authors-first -- only comment authors whose comment is
+  // itself operational-marker-shaped are permission-checked, matching
+  // pre-merge-readiness.mts / advisory-convergence.mts /
+  // advisory-wait-state.mts (and force-handoff.mts as of this change).
+  // Checking every unique comment author (the prior local loop here)
+  // over-trusted ordinary commenters.
+  for (const login of resolveTrustedCollaboratorMarkerLogins(
+    owner,
+    repo,
+    issueComments ?? [],
+  )) {
+    trusted.add(login);
+  }
+  return trusted;
+}
+function readTrustedMarkerActors(rawConfig) {
+  const actors = rawConfig?.trustedMarkerActors;
+  if (!Array.isArray(actors)) {
+    return [];
+  }
+  return actors
+    .map(String)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+function readJsonFile(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+function ghJson(args, slurp = false) {
+  const finalArgs = [...args];
+  if (slurp) {
+    finalArgs.splice(1, 0, '--jq', '.[]');
+    return parsePaginatedGhNdjson(
+      ghText(finalArgs, { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }),
+    );
+  }
+  return JSON.parse(ghText(finalArgs));
+}
+/**
+ * Pure derivation step for {@link ghApiJsonWithStatus}'s catch branch,
+ * exported so tests can inject an error shape directly instead of shelling
+ * out to a real `gh` invocation (matching the mock-free-subprocess
+ * convention documented in `tests/collaborator-permission.test.mts`).
+ *
+ * #1693: derives the real HTTP status via the shared gh-http-status.mts
+ * helpers (stderr `(HTTP NNN)` pattern, then a JSON-body `"status"` field
+ * fallback across stderr/stdout/message) instead of the prior local
+ * `extractGhHttpStatus`, which fell back to the child-process exit code
+ * when no HTTP-status text was found -- `gh` exits 1 for 401/403/404
+ * alike, so that fallback could misreport a 404 or an auth failure as
+ * "status 1". `deriveGhHttpStatus` returns null (not 0) when no status can
+ * be determined at all; 500 preserves this function's existing
+ * "definitely not 200, not 404" fail-closed fallback for that case.
+ */
+export function deriveGhApiStatusFromError(error) {
+  const status = deriveGhHttpStatus(error);
+  return {
+    status: status ?? 500,
+    body: {},
+  };
+}
+function ghApiJsonWithStatus(path) {
+  try {
+    return {
+      status: 200,
+      body: JSON.parse(ghText(['api', path])),
+    };
+  } catch (error) {
+    return deriveGhApiStatusFromError(error);
+  }
+}
+function renderReport(report, format) {
+  if (format === 'text') {
+    process.stdout.write(renderTextReport(report));
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+function renderTextReport(report) {
+  const matchedChecks =
+    report.checks.matched
+      .map((check) => `${check.name}=${check.state}`)
+      .join(', ') || 'none';
+  const blockers =
+    report.blockingReasons.length > 0
+      ? report.blockingReasons.map((reason) => `- ${reason}`).join('\n')
+      : '- none';
+  return [
+    `mode: ${report.mode}`,
+    `canApply: ${report.canApply}`,
+    `pr: #${report.pr.number} ${report.pr.url}`,
+    `head: ${report.pr.headRefOid}`,
+    `linkedIssue: ${report.linkedIssue ? `#${report.linkedIssue.number}` : 'none'}`,
+    `claim: ${report.linkedIssue?.activeClaim ? `${report.linkedIssue.activeClaim.agentId} / ${report.linkedIssue.activeClaim.claimId}` : 'none'}`,
+    `actor: ${report.actor.actor} (${report.actor.roleName || report.actor.permission || 'unknown'})`,
+    `requestedCheck: ${report.requested.selector}`,
+    `matchedChecks: ${matchedChecks}`,
+    `expiresAt: ${report.requested.expiresAt}`,
+    'blockingReasons:',
+    blockers,
+    '',
+    'body:',
+    report.body || '<none>',
+    '',
+  ].join('\n');
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const EXTERNAL_CHECK_WAIVER_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--issue': { type: 'string' },
+  '--claim-id': { type: 'string', default: '' },
+  '--check': { type: 'string', default: '' },
+  '--reason': { type: 'string', default: '' },
+  '--expires': { type: 'string', default: '' },
+  '--expires-in': { type: 'string', default: '' },
+  '--actor': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--apply': { type: 'boolean', default: false },
+  '--yes': { type: 'boolean', default: false },
+  '--format': { type: 'string', default: 'json' },
+  '--claimless': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, EXTERNAL_CHECK_WAIVER_FLAG_SPEC);
+  const format = values.format.trim();
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`unsupported --format value: ${format}`);
+  }
+  const parsed = {
+    // parsePositiveInteger keeps its existing throw-on-invalid contract
+    // and message shape unchanged; only called when the flag is actually
+    // present, matching the original "absent --pr/--issue stays 0,
+    // untouched" behavior (checked below via the "missing required"
+    // guard, same as before this migration).
+    prNumber:
+      values.pr === undefined ? 0 : parsePositiveInteger(values.pr, '--pr'),
+    issueNumber:
+      values.issue === undefined
+        ? 0
+        : parsePositiveInteger(values.issue, '--issue'),
+    claimId: values['claim-id'].trim(),
+    checkSelector: values.check.trim(),
+    reason: values.reason.trim(),
+    expiresAt: values.expires.trim(),
+    expiresIn: values['expires-in'].trim(),
+    actor: values.actor.trim(),
+    repo: values.repo.trim(),
+    apply: values.apply,
+    yes: values.yes,
+    format,
+    claimless: values.claimless,
+    help,
+  };
+  if (!parsed.help) {
+    if (!parsed.prNumber) {
+      throw new Error('missing required --pr <number> argument');
+    }
+    if (!parsed.checkSelector) {
+      throw new Error('missing required --check <selector> argument');
+    }
+    if (!parsed.reason) {
+      throw new Error('missing required --reason <text> argument');
+    }
+    // #1905: --claimless renders claim-id `none` directly -- it never
+    // resolves a linked issue's active claim, so combining it with --issue
+    // or --claim-id is contradictory and almost certainly an operator
+    // mistake (one flag says "there is no claim", the other says "resolve
+    // this specific one").
+    if (parsed.claimless && parsed.issueNumber) {
+      throw new Error('--claimless cannot be combined with --issue');
+    }
+    if (parsed.claimless && parsed.claimId) {
+      throw new Error('--claimless cannot be combined with --claim-id');
+    }
+  }
+  return parsed;
+}
+function parseOwnerRepo(value) {
+  const repo = String(value ?? '').trim();
+  const match = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (!match) {
+    throw new Error(`invalid --repo value: ${value} (expected owner/name)`);
+  }
+  return { owner: match[1], name: match[2] };
+}
+function parsePositiveInteger(value, flag) {
+  const raw = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${value}`);
+  }
+  return Number(raw);
+}
+function splitCsv(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+function printUsage() {
+  process.stdout.write(`usage: node scripts/external-check-waiver.mjs --pr <number> --check <selector> --reason <text> (--expires <iso8601> | --expires-in <duration>) [options]
+
+Options:
+  --issue <number>                  linked issue to use for active claim resolution
+  --claim-id <id>                   require the resolved active claim to match this claim id
+  --claimless                       render a claimless waiver (claim-id "none") instead of
+                                     resolving a linked issue's active claim; for a PR with
+                                     no IDD claim at all (e.g. Dependabot). Cannot combine
+                                     with --issue or --claim-id.
+  --actor <login>                   override the GitHub actor used for authority evaluation
+  --repo <owner/name>               repository override
+  --apply                           post the canonical waiver comment after validation
+  --yes                             skip the interactive apply confirmation
+  --format <json|text>              output format (default: json)
+  --help                            show this message
+`);
+}
+export async function main(argv = process.argv.slice(2)) {
+  const result = await runExternalCheckWaiver({ args: parseArgs(argv) });
+  process.exit(result.exitCode);
+}
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(`Error: ${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/force-handoff.mts
+//
+// The scripts/force-handoff.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+  resolveTrustedCollaboratorMarkerLogins,
+} from './collaborator-permission.mjs';
+import { planHandoff } from './forced-handoff-marker.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghText,
+  safeGhText,
+} from './gh-exec.mjs';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+import { makeReadlinePrompt } from './readline-prompt.mjs';
+export const NON_TTY_ERROR =
+  'operator interaction is required; run idd-force-handoff in an interactive TTY';
+export async function runHandoff(options = {}) {
+  const {
+    isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    prompt: promptFn,
+    repo,
+    forcedBy: givenForcedBy,
+    reason = 'operator-approved-recovery',
+    trustedMarkerLogins: givenTrustedLogins,
+    isAuthorizedForcedHandoff: givenAuthPredicate,
+    fetchIssueComments,
+    fetchLinkedPrs,
+    postComment,
+    mode,
+  } = options;
+  if (!isTTY) {
+    throw new Error(NON_TTY_ERROR);
+  }
+  if ((mode ?? readForcedHandoffMode()) !== 'human-gated') {
+    throw new Error(
+      "forced-handoff mode is not human-gated; idd-force-handoff is only available when forcedHandoff.mode is 'human-gated'",
+    );
+  }
+  const ask = promptFn ?? makeReadlinePrompt();
+  const rawIssue = await ask('Issue number: ');
+  const issueNumber = parsePositiveInteger(rawIssue, '--issue');
+  const repoRef =
+    repo ??
+    ghText([
+      'repo',
+      'view',
+      '--json',
+      'nameWithOwner',
+      '--jq',
+      '.nameWithOwner',
+    ]);
+  const { owner, name } = parseOwnerRepo(repoRef);
+  const forcedBy =
+    givenForcedBy ??
+    safeGhText(['api', 'user', '--jq', '.login']).toLowerCase();
+  if (!forcedBy) {
+    throw new Error(
+      'could not determine current GitHub user; ensure gh is authenticated',
+    );
+  }
+  const issueComments = fetchIssueComments
+    ? await fetchIssueComments(issueNumber)
+    : ghJson(
+        [
+          'api',
+          '--paginate',
+          `repos/${owner}/${name}/issues/${issueNumber}/comments`,
+        ],
+        true,
+      );
+  const trustedMarkerLogins =
+    givenTrustedLogins ??
+    buildTrustedMarkerLogins(owner, name, forcedBy, issueComments);
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const permissionCache = new Map();
+  const isAuthorizedForcedHandoff =
+    givenAuthPredicate ??
+    ((actor) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        name,
+        actor,
+        forcedHandoffAuthorityPolicy,
+        permissionCache,
+      ));
+  const resolveOpts = {
+    trustedMarkerLogins,
+    isAuthorizedForcedHandoff,
+    forcedBy,
+    reason,
+  };
+  const firstPass = planHandoff(issueComments, [], resolveOpts);
+  const linkedPrs = fetchLinkedPrs
+    ? await fetchLinkedPrs(firstPass.branch)
+    : ghJson([
+        'pr',
+        'list',
+        '--repo',
+        `${owner}/${name}`,
+        '--head',
+        firstPass.branch,
+        '--state',
+        'open',
+        '--json',
+        'number,headRefName',
+      ]);
+  let plan = planHandoff(issueComments, linkedPrs, resolveOpts);
+  let resolvedPrNumber;
+  if (plan.contextScope === 'issue-plus-pr') {
+    const prList = plan.prReferences.join(', ');
+    const rawPr = await ask(`Open PR on branch (${prList}). Enter PR number: `);
+    const prNumber = parsePositiveInteger(rawPr, '--pr');
+    plan = planHandoff(issueComments, linkedPrs, { ...resolveOpts, prNumber });
+    resolvedPrNumber = prNumber;
+  }
+  if (!plan.markerBody) {
+    throw new Error(
+      'cannot generate forced-handoff marker: check that forced-handoff mode is human-gated and the actor is authorized',
+    );
+  }
+  const { newAgentId, newClaimId } = plan.successorIds;
+  const lines = [
+    '',
+    `Forced-handoff plan for issue #${issueNumber}:`,
+    `  Context:   ${plan.contextScope}`,
+    `  Branch:    ${plan.branch}`,
+    `  Old claim: ${plan.activeClaim.agentId} / ${plan.activeClaim.claimId}`,
+    `  Successor: ${newAgentId} / ${newClaimId}`,
+    ...(resolvedPrNumber ? [`  PR:        #${resolvedPrNumber}`] : []),
+    '',
+    'Marker preview:',
+    plan.markerBody,
+    '',
+  ];
+  process.stdout.write(`${lines.join('\n')}\n`);
+  const confirm = await ask('Confirm forced handoff? [y/N] ');
+  ask.close?.();
+  if (confirm.trim().toLowerCase() !== 'y') {
+    process.stdout.write('Aborted. No changes made.\n');
+    return { posted: false };
+  }
+  const result = postComment
+    ? await postComment(issueNumber, plan.markerBody)
+    : ghJson([
+        'api',
+        `repos/${owner}/${name}/issues/${issueNumber}/comments`,
+        '--method',
+        'POST',
+        '-f',
+        `body=${plan.markerBody}`,
+      ]);
+  const commentUrl = String(result.html_url ?? result.url ?? '');
+  process.stdout.write(
+    [
+      '',
+      `Forced handoff posted: ${commentUrl}`,
+      `  Successor agent-id:  ${newAgentId}`,
+      `  Successor claim-id:  ${newClaimId}`,
+      '',
+    ].join('\n'),
+  );
+  return {
+    posted: true,
+    commentUrl,
+    successorIds: { newAgentId, newClaimId },
+    contextScope: plan.contextScope,
+  };
+}
+export function main() {
+  runHandoff().catch((err) => {
+    process.stderr.write(`Error: ${err.message}\n`);
+    process.exit(1);
+  });
+}
+function parsePositiveInteger(value, flag) {
+  const raw = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${raw}`);
+  }
+  return Number(raw);
+}
+function parseOwnerRepo(value) {
+  const repo = String(value ?? '').trim();
+  const match = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (!match) {
+    throw new Error(`invalid repo value: ${value} (expected owner/name)`);
+  }
+  return { owner: match[1], name: match[2] };
+}
+function ghJson(args, slurp = false) {
+  const finalArgs = [...args];
+  if (slurp) {
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    finalArgs.splice(1, 0, '--jq', '.[]');
+    return parsePaginatedGhNdjson(
+      ghText(finalArgs, { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }),
+    );
+  }
+  return JSON.parse(ghText(finalArgs));
+}
+export function buildTrustedMarkerLogins(
+  owner,
+  repo,
+  viewerLogin,
+  issueComments,
+  cache,
+) {
+  const configuredActors = readTrustedMarkerActorsFromConfig();
+  const configured = [
+    viewerLogin,
+    ...configuredActors,
+    ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
+  ];
+  const trusted = new Set(
+    configured.filter(Boolean).map((l) => l.toLowerCase()),
+  );
+  if (!readCollaboratorTrustEnabled()) {
+    return trusted;
+  }
+  // #1693: marker-authors-first -- only comment authors whose comment is
+  // itself operational-marker-shaped are permission-checked, matching
+  // pre-merge-readiness.mts / advisory-convergence.mts /
+  // advisory-wait-state.mts. Checking every unique comment author (the
+  // prior local loop here) over-trusted ordinary commenters.
+  for (const login of resolveTrustedCollaboratorMarkerLogins(
+    owner,
+    repo,
+    issueComments,
+    { cache },
+  )) {
+    trusted.add(login);
+  }
+  return trusted;
+}
+function readTrustedMarkerActorsFromConfig() {
+  try {
+    const config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+    const actors = config?.trustedMarkerActors;
+    if (Array.isArray(actors)) {
+      return actors.map(String).filter(Boolean);
+    }
+  } catch {
+    // config absent or unreadable
+  }
+  return [];
+}
+function readCollaboratorTrustEnabled() {
+  try {
+    const config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+    const nested = config?.markerTrust?.allowCollaboratorMarkers;
+    const topLevel =
+      config?.markerTrustAllowCollaboratorMarkers ??
+      config?.allowCollaboratorMarkers;
+    const value = nested ?? topLevel;
+    if (typeof value === 'boolean') {
+      return value;
+    }
+  } catch {
+    // Fall through to env-var fallback.
+  }
+  return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
+}
+function splitCsv(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+if (import.meta.main) {
+  main();
+}

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -1,0 +1,619 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/forced-handoff-marker.mts
+//
+// The scripts/forced-handoff-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghText,
+  safeGhText,
+} from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
+import {
+  parsePaginatedGhNdjson,
+  renderForcedHandoffComment,
+  summarizeClaimValidation,
+  unionTrustedMarkerActorSources,
+} from './protocol-helpers.mjs';
+export function generateSuccessorIds(baseAgentId) {
+  return {
+    newAgentId: String(baseAgentId || 'idd-agent'),
+    newClaimId: `claim-${randomUUID().replace(/-/g, '').slice(0, 16)}`,
+  };
+}
+export function planHandoff(issueComments, linkedPrs, options = {}) {
+  const {
+    newAgentId,
+    newClaimId,
+    prNumber,
+    forcedBy,
+    reason,
+    timestamp,
+    trustedMarkerLogins,
+    isAuthorizedForcedHandoff,
+  } = options;
+  const resolveOpts = {
+    isAuthorizedForcedHandoff:
+      typeof isAuthorizedForcedHandoff === 'function'
+        ? isAuthorizedForcedHandoff
+        : () => false,
+  };
+  // First pass: resolve without PR filter to obtain the claim branch.
+  const firstPassClaim = resolveHelperActiveClaim(
+    issueComments,
+    trustedMarkerLogins ?? [],
+    resolveOpts,
+  );
+  if (!firstPassClaim) {
+    throw new Error('issue has no active trusted claim');
+  }
+  const matchingPrs = (linkedPrs ?? []).filter(
+    (pr) => String(pr.headRefName ?? '') === firstPassClaim.branch,
+  );
+  const contextScope = matchingPrs.length > 0 ? 'issue-plus-pr' : 'issue-only';
+  const prReferences = matchingPrs.map((pr) => String(pr.number));
+  if (prNumber !== undefined) {
+    const prRef = String(prNumber);
+    if (!prReferences.includes(prRef)) {
+      throw new Error(
+        `PR #${prNumber} does not match any open PR on claim branch ${firstPassClaim.branch}` +
+          (prReferences.length > 0
+            ? `; expected one of: ${prReferences.join(', ')}`
+            : ''),
+      );
+    }
+  }
+  // Second pass: when an open PR is part of the plan, re-resolve with an
+  // expectedLinkedPrs filter so that prior issue-only forced-handoff markers
+  // are correctly rejected for PR-scoped claim replay.
+  let activeClaim = firstPassClaim;
+  if (contextScope === 'issue-plus-pr') {
+    const expectedLinkedPrs =
+      prNumber !== undefined ? [String(prNumber)] : prReferences;
+    const filteredClaim = resolveHelperActiveClaim(
+      issueComments,
+      trustedMarkerLogins ?? [],
+      { ...resolveOpts, expectedLinkedPrs },
+    );
+    if (filteredClaim) {
+      activeClaim = filteredClaim;
+    }
+  }
+  const generated = generateSuccessorIds(activeClaim.agentId);
+  const successorIds = {
+    newAgentId: newAgentId ?? generated.newAgentId,
+    newClaimId: newClaimId ?? generated.newClaimId,
+  };
+  let markerBody = null;
+  if (forcedBy && reason) {
+    // Validate the approving actor before rendering the marker body so that
+    // plan output cannot preview a marker that claim resolution would reject.
+    // Reuse the fail-closed-defaulted callback so a missing authorizer is
+    // unauthorized here exactly as it is during claim resolution.
+    const authorized = resolveOpts.isAuthorizedForcedHandoff(forcedBy);
+    if (authorized) {
+      const resolvedLinkedPr =
+        prNumber !== undefined ? String(prNumber) : prReferences[0];
+      const payload = {
+        oldAgentId: activeClaim.agentId,
+        oldClaimId: activeClaim.claimId,
+        newAgentId: successorIds.newAgentId,
+        newClaimId: successorIds.newClaimId,
+        branch: activeClaim.branch,
+        ...(contextScope === 'issue-plus-pr' && resolvedLinkedPr
+          ? { linkedPr: resolvedLinkedPr }
+          : {}),
+        forcedBy,
+        reason,
+        timestamp: timestamp ?? currentIsoTimestamp(),
+        contextScope,
+      };
+      markerBody = renderForcedHandoffComment(payload);
+    }
+  }
+  return {
+    activeClaim,
+    branch: activeClaim.branch,
+    contextScope,
+    prReferences,
+    markerBody,
+    successorIds,
+  };
+}
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printUsage();
+    return;
+  }
+  if (!args.issueNumber) {
+    throw new Error('missing required --issue <number> argument');
+  }
+  if (!args.forcedBy) {
+    throw new Error('missing required --forced-by <actor> argument');
+  }
+  if (!args.reason) {
+    throw new Error('missing required --reason <text> argument');
+  }
+  if (args.plan) {
+    const repoRef =
+      args.repo ??
+      ghText([
+        'repo',
+        'view',
+        '--json',
+        'nameWithOwner',
+        '--jq',
+        '.nameWithOwner',
+      ]);
+    const { owner, name } = parseOwnerRepo(repoRef);
+    const issueComments = ghJson(
+      [
+        'api',
+        '--paginate',
+        `repos/${owner}/${name}/issues/${args.issueNumber}/comments`,
+      ],
+      true,
+    );
+    const viewerLogin = safeGhText([
+      'api',
+      'user',
+      '--jq',
+      '.login',
+    ]).toLowerCase();
+    const { logins: trustedMarkerLogins, sources: trustedMarkerActorsSources } =
+      buildTrustedMarkerLogins(
+        owner,
+        name,
+        viewerLogin,
+        args.trustedMarkerLogins,
+        issueComments,
+      );
+    const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+    const permissionCache = new Map();
+    const tempClaim = resolveHelperActiveClaim(
+      issueComments,
+      trustedMarkerLogins,
+      {
+        isAuthorizedForcedHandoff: (forcedBy) =>
+          isAuthorizedForcedHandoffActor(
+            owner,
+            name,
+            forcedBy,
+            forcedHandoffAuthorityPolicy,
+            permissionCache,
+          ),
+      },
+    );
+    let linkedPrs = [];
+    if (tempClaim) {
+      linkedPrs = ghJson([
+        'pr',
+        'list',
+        '--repo',
+        `${owner}/${name}`,
+        '--head',
+        tempClaim.branch,
+        '--state',
+        'open',
+        '--json',
+        'number,headRefName',
+      ]);
+    }
+    const modeEnabled = readForcedHandoffMode() === 'human-gated';
+    const plan = planHandoff(issueComments, linkedPrs, {
+      newAgentId: args.newAgentId,
+      newClaimId: args.newClaimId,
+      prNumber: args.prNumber,
+      forcedBy: modeEnabled ? args.forcedBy : undefined,
+      reason: modeEnabled ? args.reason : undefined,
+      timestamp: args.timestamp,
+      trustedMarkerLogins,
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          name,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          permissionCache,
+        ),
+    });
+    console.log(
+      JSON.stringify(
+        {
+          repository: `${owner}/${name}`,
+          issueNumber: args.issueNumber,
+          modeEnabled,
+          trustedMarkerActors: [...trustedMarkerLogins].sort(),
+          trustedMarkerActorsSources,
+          ...plan,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  if (!args.newAgentId) {
+    throw new Error('missing required --new-agent-id <id> argument');
+  }
+  if (!args.newClaimId) {
+    throw new Error('missing required --new-claim-id <id> argument');
+  }
+  const repoRef =
+    args.repo ??
+    ghText([
+      'repo',
+      'view',
+      '--json',
+      'nameWithOwner',
+      '--jq',
+      '.nameWithOwner',
+    ]);
+  const { owner, name } = parseOwnerRepo(repoRef);
+  if (readForcedHandoffMode() !== 'human-gated') {
+    throw new Error(
+      'forced-handoff mode is not human-gated; marker generation is disabled',
+    );
+  }
+  const issueComments = ghJson(
+    [
+      'api',
+      '--paginate',
+      `repos/${owner}/${name}/issues/${args.issueNumber}/comments`,
+    ],
+    true,
+  );
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const { logins: trustedMarkerLogins, sources: trustedMarkerActorsSources } =
+    buildTrustedMarkerLogins(
+      owner,
+      name,
+      viewerLogin,
+      args.trustedMarkerLogins,
+      issueComments,
+    );
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const permissionCache = new Map();
+  const activeClaim = resolveHelperActiveClaim(
+    issueComments,
+    trustedMarkerLogins,
+    {
+      expectedLinkedPrs: args.prNumber
+        ? [
+            String(args.prNumber),
+            `https://github.com/${owner}/${name}/pull/${args.prNumber}`,
+          ]
+        : [],
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          name,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          permissionCache,
+        ),
+    },
+  );
+  if (!activeClaim) {
+    throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
+  }
+  if (
+    !isAuthorizedForcedHandoffActor(
+      owner,
+      name,
+      args.forcedBy,
+      forcedHandoffAuthorityPolicy,
+      permissionCache,
+    )
+  ) {
+    throw new Error(
+      `--forced-by actor ${args.forcedBy} is not authorized under ${forcedHandoffAuthorityPolicy}`,
+    );
+  }
+  let linkedPr = '';
+  if (args.prNumber) {
+    const pr = ghJson([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      `${owner}/${name}`,
+      '--json',
+      'headRefName,url',
+      '--jq',
+      '.',
+    ]);
+    const headRefName = String(pr.headRefName ?? '');
+    if (headRefName !== activeClaim.branch) {
+      throw new Error(
+        `PR #${args.prNumber} head branch ${headRefName} does not match active claim branch ${activeClaim.branch}`,
+      );
+    }
+    linkedPr = String(args.prNumber);
+  }
+  const payload = {
+    oldAgentId: activeClaim.agentId,
+    oldClaimId: activeClaim.claimId,
+    newAgentId: args.newAgentId,
+    newClaimId: args.newClaimId,
+    branch: activeClaim.branch,
+    ...(linkedPr ? { linkedPr } : {}),
+    forcedBy: args.forcedBy,
+    reason: args.reason,
+    timestamp: args.timestamp ?? currentIsoTimestamp(),
+    contextScope: linkedPr ? 'issue-plus-pr' : 'issue-only',
+  };
+  const commentBody = renderForcedHandoffComment(payload);
+  if (args.format === 'json') {
+    console.log(
+      JSON.stringify(
+        {
+          repository: `${owner}/${name}`,
+          issueNumber: args.issueNumber,
+          trustedMarkerActors: [...trustedMarkerLogins].sort(),
+          trustedMarkerActorsSources,
+          activeClaim,
+          payload,
+          commentBody,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(commentBody);
+  }
+}
+export function resolveHelperActiveClaim(
+  issueComments,
+  trustedMarkerLogins,
+  options = {},
+) {
+  const trustedSources = Array.isArray(trustedMarkerLogins)
+    ? trustedMarkerLogins
+    : trustedMarkerLogins instanceof Set
+      ? [...trustedMarkerLogins]
+      : splitCsv(trustedMarkerLogins);
+  const trustedLogins = new Set(
+    trustedSources
+      .map((login) =>
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  const summary = summarizeClaimValidation(
+    issueComments.map(normalizeIssueComment),
+    {
+      trustedMarkerLogins: [...trustedLogins],
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+      isAuthorizedForcedHandoff:
+        typeof options.isAuthorizedForcedHandoff === 'function'
+          ? options.isAuthorizedForcedHandoff
+          : () => false,
+    },
+  );
+  return summary.activeClaimPresent ? summary.activeClaim : null;
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const FORCED_HANDOFF_MARKER_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--pr': { type: 'string' },
+  '--new-agent-id': { type: 'string' },
+  '--new-claim-id': { type: 'string' },
+  '--forced-by': { type: 'string' },
+  '--reason': { type: 'string' },
+  '--timestamp': { type: 'string' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--repo': { type: 'string' },
+  '--format': { type: 'string', default: 'text' },
+  '--plan': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, FORCED_HANDOFF_MARKER_FLAG_SPEC);
+  const format = values.format;
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`unsupported --format value: ${format}`);
+  }
+  return {
+    format,
+    trustedMarkerLogins: values['trusted-marker-logins'],
+    // parsePositiveInteger keeps its existing throw-on-invalid contract
+    // unchanged; only called when the flag is actually present, so an
+    // absent --issue/--pr still resolves to undefined (this file's own
+    // "not requested" sentinel -- see the `!== undefined` checks
+    // elsewhere in this module) rather than throwing.
+    issueNumber:
+      values.issue === undefined
+        ? undefined
+        : parsePositiveInteger(values.issue, '--issue'),
+    prNumber:
+      values.pr === undefined
+        ? undefined
+        : parsePositiveInteger(values.pr, '--pr'),
+    newAgentId: values['new-agent-id'],
+    newClaimId: values['new-claim-id'],
+    forcedBy: values['forced-by'],
+    reason: values.reason,
+    timestamp: values.timestamp,
+    repo: values.repo,
+    plan: values.plan,
+    help,
+  };
+}
+function buildTrustedMarkerLogins(
+  owner,
+  repo,
+  viewerLogin,
+  cliLogins,
+  issueComments,
+) {
+  // Parse the config once and share it between the actor union and the
+  // collaborator-trust toggle.
+  const config = loadIddConfig();
+  const sources = [];
+  if (String(viewerLogin ?? '').trim()) {
+    sources.push('viewer');
+  }
+  const flagActors = splitCsv(cliLogins);
+  if (flagActors.length > 0) {
+    sources.push('flag');
+  }
+  const union = unionTrustedMarkerActorSources({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config,
+    extraActors: [viewerLogin, ...flagActors],
+  });
+  sources.push(...union.sources);
+  const trusted = new Set(union.actors);
+  if (!readCollaboratorTrustEnabled(config)) {
+    return { logins: trusted, sources };
+  }
+  const permissionCache = new Map();
+  const uniqueLogins = new Set(
+    issueComments
+      .map((comment) => String(comment.user?.login ?? '').toLowerCase())
+      .filter(Boolean),
+  );
+  let collaboratorAdded = false;
+  for (const login of uniqueLogins) {
+    if (trusted.has(login)) {
+      continue;
+    }
+    const permission =
+      permissionCache.get(login) ??
+      safeGhText([
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ]).toLowerCase();
+    permissionCache.set(login, permission);
+    if (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    ) {
+      trusted.add(login);
+      collaboratorAdded = true;
+    }
+  }
+  if (collaboratorAdded) {
+    sources.push('collaborators');
+  }
+  return { logins: trusted, sources };
+}
+function normalizeIssueComment(comment) {
+  return {
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: {
+      login: comment.user?.login ?? '',
+    },
+  };
+}
+function splitCsv(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
+}
+export function parsePositiveInteger(value, flag) {
+  const raw = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${value}`);
+  }
+  return Number(raw);
+}
+function parseOwnerRepo(value) {
+  const repo = String(value ?? '').trim();
+  const match = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (!match) {
+    throw new Error(`invalid --repo value: ${value} (expected owner/name)`);
+  }
+  return {
+    owner: match[1],
+    name: match[2],
+  };
+}
+function ghJson(args, slurp = false) {
+  const finalArgs = [...args];
+  if (slurp) {
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    finalArgs.splice(1, 0, '--jq', '.[]');
+    return parsePaginatedGhNdjson(
+      ghText(finalArgs, { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }),
+    );
+  }
+  return JSON.parse(ghText(finalArgs));
+}
+function readCollaboratorTrustEnabled(config = null) {
+  try {
+    return resolveCollaboratorMarkerTrust(
+      config ?? JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
+  } catch {
+    // Fall through to env-var fallback.
+  }
+  return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+export function currentIsoTimestamp() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+function printUsage() {
+  console.log(`usage: node scripts/forced-handoff-marker.mjs --issue <number> [options]
+
+Options:
+  --plan                           derive live PR context and emit a structured execution plan;
+                                   --new-agent-id and --new-claim-id become optional (auto-generated)
+  --pr <number>                    optional PR number for issue-plus-pr context
+  --new-agent-id <id>              successor session agent id (required without --plan)
+  --new-claim-id <id>              successor claim id (required without --plan)
+  --forced-by <actor>              approving human actor recorded in the marker
+  --reason <text>                  why the prior session is considered unavailable
+  --timestamp <ISO8601>            override the marker payload timestamp (default: current UTC)
+  --trusted-marker-logins <csv>    additional trusted marker authors for claim reconstruction
+  --repo <owner/name>              repository override
+  --format <text|json>             output format for marker mode (default: text)
+  --help                           show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS        comma-separated trusted bot/app logins
+                                   (combined with config.json trustedMarkerActors)
+  IDD_TRUST_COLLABORATOR_MARKERS   set true to trust Write/Maintain/Admin collaborators
+`);
+}
+if (import.meta.main) {
+  main();
+}

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -1,0 +1,231 @@
+// idd-generated-from: src/scripts/gh-exec.mts
+//
+// The scripts/gh-exec.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Shared `gh` CLI execution helpers, extracted from ~22 per-helper copies
+// of a synchronous `execFileSync('gh', ...) + trim` wrapper (see #1208).
+// Also carries the CLI-entry-point detection helper: both concerns are
+// about this process's relationship to its execution context (shelling
+// out to `gh`, and recognizing whether this module *is* the invoked
+// entry point) rather than any one helper's domain logic, so they share
+// this module instead of splitting into a third small file.
+//
+// Consumed by the `src/scripts/*.mts` helpers that shell out to `gh` or
+// need the CLI-entry-point guard.
+import { execFile, execFileSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { promisify } from 'node:util';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+/**
+ * Default `execFileSync`/`execFile` timeout (ms) applied when a caller
+ * supplies none — the existing 30s convention already used at 54+
+ * `GH_TEXT_LOOP_TIMEOUT_OPTIONS` call sites (#1675). Without this, a
+ * stalled or credential-prompting `gh` invocation (rate limiting, network
+ * stall, an unexpected interactive re-auth prompt) hangs the calling
+ * helper indefinitely instead of failing closed into IDD's recovery
+ * routing. An explicit caller-supplied `timeout` (including `0`, which
+ * Node treats as "no timeout") always wins over this default.
+ */
+export const DEFAULT_GH_TIMEOUT_MS = 30_000;
+/**
+ * Default timeout (ms) for a **paginated** `gh api --paginate` call
+ * (`{@link ghApiJson}` with `paginate: true`) when the caller supplies
+ * none. `--paginate` makes `gh` walk every page of a list endpoint as
+ * sequential HTTP round-trips inside one subprocess invocation, so the
+ * single-request {@link DEFAULT_GH_TIMEOUT_MS} bound is too tight by
+ * default for a response spanning more than a couple of pages. This
+ * repo's paginated callers are PR/issue-scoped (review threads, comments,
+ * timeline events — bounded in practice to a few pages), so a flat 4x
+ * multiplier is a deliberately generous but still-bounded default rather
+ * than an unbounded pass-through; callers with a legitimately different
+ * bound (e.g. a large graph traversal) pass an explicit `timeout` to
+ * override it. Recorded here so this default isn't re-litigated later.
+ */
+export const DEFAULT_GH_PAGINATED_TIMEOUT_MS = 120_000;
+const execFileAsync = promisify(execFile);
+/**
+ * Shared `{ stdio }` override for callers that invoke `gh` in a tight or
+ * high-volume loop and want to avoid an open-but-unwritten stdin pipe, but
+ * did not previously pair it with a timeout.
+ */
+export const GH_TEXT_LOOP_OPTIONS = {
+  stdio: ['ignore', 'pipe', 'pipe'],
+};
+/**
+ * Shared `{ stdio, timeout }` override for callers that invoke `gh` in a
+ * tight or high-volume loop and previously paired the stdin-ignoring
+ * override with a 30s timeout so a stalled `gh` invocation fails closed.
+ */
+export const GH_TEXT_LOOP_TIMEOUT_OPTIONS = {
+  stdio: ['ignore', 'pipe', 'pipe'],
+  timeout: 30_000,
+};
+/**
+ * Run `gh` synchronously and return its trimmed stdout.
+ *
+ * Applies {@link DEFAULT_GH_TIMEOUT_MS} when the caller supplies no
+ * `timeout` (#1675) — a caller-supplied value, including `0`, always
+ * wins.
+ *
+ * Throws (propagating the child-process error) on any non-zero exit —
+ * callers that need to tolerate specific failures use {@link safeGhText}
+ * or {@link ghApiJson}'s `allowStatuses` option instead.
+ */
+export function ghText(args, options = {}) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    timeout: options.timeout ?? DEFAULT_GH_TIMEOUT_MS,
+    ...(options.stdio ? { stdio: options.stdio } : {}),
+    ...(options.input !== undefined ? { input: options.input } : {}),
+  }).trim();
+}
+/** {@link ghText}, swallowing any failure and returning `''` instead. */
+export function safeGhText(args, options = {}) {
+  try {
+    return ghText(args, options);
+  } catch {
+    return '';
+  }
+}
+/**
+ * Async sibling of {@link ghText}, for callers that need several `gh`
+ * subprocesses running concurrently (`execFileSync` serializes even
+ * concurrent `await`s because it holds the event loop). Extracted from
+ * `discover-roadmap-graph.mts`'s traversal hot-path loader (#1675) so
+ * that file no longer needs its own direct `execFile('gh', ...)` call.
+ *
+ * `execFile` has no `stdio` option, so its default stdio does not ignore
+ * stdin the way {@link GH_TEXT_LOOP_OPTIONS} does for the sync API. None
+ * of this module's own callers pass `--input` or an `@-` field value (the
+ * only ways `gh api` reads stdin), so `gh` itself never blocks on stdin
+ * here — this still closes the child's stdin defensively so a future
+ * caller can't silently reintroduce a stdin hang (mirrors the pattern
+ * `discover-roadmap-graph.mts` used before this extraction).
+ *
+ * Trims stdout, matching {@link ghText}'s convention.
+ */
+export async function ghTextAsync(args, options = {}) {
+  const run = execFileAsync('gh', args, {
+    encoding: 'utf8',
+    timeout: options.timeout ?? DEFAULT_GH_TIMEOUT_MS,
+    ...(options.maxBuffer !== undefined
+      ? { maxBuffer: options.maxBuffer }
+      : {}),
+  });
+  run.child.stdin?.end();
+  const { stdout } = await run;
+  return stdout.trim();
+}
+/**
+ * Run `gh api <path>` and parse its output as JSON, optionally paginating
+ * (NDJSON-compatible) and/or tolerating specific failure statuses.
+ *
+ * Generalizes the two strictest existing per-helper variants this module
+ * replaces: `advisory-wait-state.mts`'s NDJSON-pagination handling and
+ * `review-activity-snapshot.mts`'s `allowStatuses` tolerated-failure
+ * fallback.
+ */
+export function ghApiJson(path, options = {}) {
+  const { paginate = false, extraArgs = [], allowStatuses = [] } = options;
+  const args = ['api', path, ...extraArgs];
+  if (paginate) {
+    args.push('--paginate', '--jq', '.[]');
+  }
+  const timeout =
+    options.timeout ??
+    (paginate ? DEFAULT_GH_PAGINATED_TIMEOUT_MS : DEFAULT_GH_TIMEOUT_MS);
+  let raw;
+  try {
+    raw = execFileSync('gh', args, { encoding: 'utf8', timeout });
+  } catch (error) {
+    const failure = error;
+    const status = Number(failure?.status ?? -1);
+    if (!allowStatuses.includes(status)) {
+      throw error;
+    }
+    const stdout = String(failure?.stdout ?? '');
+    if (!/^\s*[[{]/.test(stdout)) {
+      throw error;
+    }
+    raw = stdout;
+  }
+  if (paginate) {
+    // parsePaginatedGhNdjson already trims and returns [] on empty input.
+    return parsePaginatedGhNdjson(raw);
+  }
+  // JSON.parse itself ignores surrounding whitespace, so only trim to
+  // decide whether the output was empty.
+  return JSON.parse(raw.trim() || '{}');
+}
+/**
+ * Run a `gh api graphql` query with variables, returning the parsed JSON
+ * response. Extracted from `advisory-convergence.mts` (#1806) so
+ * `review-clause.mts` (and any other future GraphQL caller) can reuse the
+ * same query-execution wrapper instead of a second copy, matching this
+ * file's existing role as the shared `gh`-execution module for `ghText` /
+ * `ghApiJson`. Uses `ghText`'s own default timeout (no explicit override
+ * here, unchanged from this function's pre-extraction behavior).
+ */
+export function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(ghText(args).trim() || '{}');
+}
+const DEFAULT_BOUNDED_RETRY_ATTEMPTS = 3;
+const DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS = 200;
+/**
+ * Run `task`, retrying a bounded number of times on a retryable failure
+ * (#1394): a transient `gh`/API hiccup (e.g. truncated captured stdout under
+ * heavy concurrent load) no longer has to abort a whole caller-side
+ * traversal when an immediate retry would have succeeded in isolation.
+ *
+ * Fail-closed is preserved: once the bounded attempts are exhausted, the
+ * final attempt's error is rethrown unchanged — the exact same error
+ * instance, never re-wrapped — so an existing caller-side classifier (e.g.
+ * this module's own `allowStatuses` consumers, or a 404/access-style
+ * predicate) still reads the identical shape it read before this wrapper
+ * existed.
+ */
+export async function withBoundedRetry(task, options = {}) {
+  const {
+    attempts = DEFAULT_BOUNDED_RETRY_ATTEMPTS,
+    baseDelayMs = DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS,
+    isRetryable = () => true,
+  } = options;
+  // A non-finite `attempts` (`NaN` from a failed parse, or `Infinity`)
+  // would otherwise survive `Math.max`/`Math.trunc` unchanged (both are
+  // no-ops on non-finite input) and make `attempt >= totalAttempts` never
+  // true, defeating the whole bounded-attempt contract with an unbounded
+  // retry loop (Copilot + Codex review, #1394). Fall back to the default
+  // whenever the caller-supplied value is not a finite number. The same
+  // guard applies to `baseDelayMs` for consistency: a non-finite backoff
+  // would not break the bound (attempts still caps the loop), but would
+  // silently skip the intended backoff/jitter delay between attempts.
+  const totalAttempts = Number.isFinite(attempts)
+    ? Math.max(1, Math.trunc(attempts))
+    : DEFAULT_BOUNDED_RETRY_ATTEMPTS;
+  const effectiveBaseDelayMs = Number.isFinite(baseDelayMs)
+    ? baseDelayMs
+    : DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await task();
+    } catch (error) {
+      if (attempt >= totalAttempts || !isRetryable(error)) {
+        throw error;
+      }
+      await sleep(
+        effectiveBaseDelayMs * attempt + Math.random() * effectiveBaseDelayMs,
+      );
+    }
+  }
+}

--- a/scripts/gh-http-status.mjs
+++ b/scripts/gh-http-status.mjs
@@ -1,0 +1,66 @@
+// idd-generated-from: src/scripts/gh-http-status.mts
+//
+// The scripts/gh-http-status.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Shared HTTP-status derivation for failed `gh api` invocations.
+//
+// `gh` exits with process code 1 for 401, 403, and 404 alike, so the
+// child-process exit status is useless for HTTP classification. The real
+// status appears in gh's stderr as `(HTTP NNN)`, or in a JSON error body's
+// `"status"` field. Discovery helpers use this to fail closed on auth /
+// rate-limit / network failures instead of misreading them as a genuine
+// 404. Consumed by:
+//
+// - scripts/discover-viability-gate.mjs (A4 viability gate)
+// - scripts/discover-readiness-check.mjs (A3 readiness check)
+/**
+ * Derive the real HTTP status code from a failed `gh` invocation error.
+ *
+ * Inspects the error's `stderr`, `stdout`, and `message` text for either
+ * gh's `(HTTP NNN)` suffix or a JSON error body carrying a `"status"`
+ * field. Returns the numeric status, or null when no status can be
+ * determined — callers must fail closed on null (treat it as a tool
+ * failure, not a genuine 404).
+ */
+export function deriveGhHttpStatus(error) {
+  const text = ghErrorText(error);
+  if (!text) {
+    return null;
+  }
+  // Primary signal: gh prints the real status as `(HTTP NNN)` on stderr.
+  const httpMatch = text.match(/\(HTTP (\d{3})\)/);
+  if (httpMatch) {
+    return Number.parseInt(httpMatch[1], 10);
+  }
+  // Fallback: a JSON error body may carry a "status" field, as a string
+  // (e.g. {"message":"Not Found","status":"404"}) or a number.
+  const jsonMatch = text.match(/"status"\s*:\s*"?(\d{3})"?/);
+  if (jsonMatch) {
+    return Number.parseInt(jsonMatch[1], 10);
+  }
+  return null;
+}
+/**
+ * Extract the most useful diagnostic text from a failed `gh` invocation (an
+ * `execFileSync`-shaped error): stderr first (where `gh` writes most error
+ * explanations), then stdout, then the generic Error message, joined so a
+ * caller's pattern match sees every available detail regardless of which
+ * stream `gh` used. Coerces any non-null value via `String(...)` (not a
+ * strict `typeof === 'string'` check) so a `Buffer`-valued stream — e.g. an
+ * `execFileSync` call made without `{ encoding: 'utf8' }` — still yields
+ * readable text instead of being silently dropped. Exported for reuse by
+ * other `gh`-invoking helpers (e.g. `idd-merge-execute.mts`'s solo-CODEOWNER
+ * `--admin` fallback, #1521) instead of each hand-rolling its own copy.
+ */
+export function ghErrorText(error) {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+  const candidate = error;
+  return [candidate.stderr, candidate.stdout, candidate.message]
+    .map((value) => (value == null ? '' : String(value)))
+    .filter((value) => value.length > 0)
+    .join('\n');
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -1,0 +1,1007 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/helper-runtime-manifest.mts
+//
+// The scripts/helper-runtime-manifest.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+import { inspectHelperRuntimeConfig } from './policy-helpers.mjs';
+
+// Resolve the package root by walking up to the nearest package.json.
+// This is location-independent, so it returns the same root whether this
+// module runs as the emitted scripts/helper-runtime-manifest.mjs (one
+// level deep), the src/scripts/helper-runtime-manifest.mts source under
+// Node type-stripping (two levels deep), or is imported by another
+// module — a fixed `..` from import.meta.dirname would resolve to src/
+// for the source.
+function resolveRepoRoot(fromDir) {
+  let dir = fromDir;
+  for (let depth = 0; depth < 16; depth += 1) {
+    if (existsSync(resolve(dir, 'package.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return dir;
+}
+const PACKAGE_ROOT = resolveRepoRoot(import.meta.dirname);
+const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn'];
+// Exported so other onboarding-stage CLIs (e.g. idd-onboard.mts's --import
+// mode) can validate a --profile flag against the same canonical set
+// instead of hand-maintaining a second copy of these four names.
+export const PROFILE_NAMES = [
+  'package-manager',
+  'vendored-node',
+  'ephemeral-npx',
+  'instructions-only',
+];
+const PACKAGE_NAME = '@kurone-kito/idd-skill';
+const DEFAULT_PACKAGE_SPEC =
+  'https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main';
+const SOURCE_REPOSITORY = 'github:kurone-kito/idd-skill';
+const PACKAGE_SPEC_PIN_HINT =
+  'Pass --package-spec with a pinned tarball URL or reviewed commit archive when you need reproducible helper imports.';
+// Same two candidate filenames and first-present-wins precedence as
+// idd-doctor.mts's LIVE_CONFIG_CANDIDATE_FILES / resolveConfiguredHelperRuntime
+// (idd-skill#1731): `.github/idd/config.json` is canonical, `idd-policy.json`
+// is the legacy top-level name a repository may still use. Kept as a small,
+// self-contained local read here rather than importing idd-doctor.mts, which
+// would pull the whole doctor tool into this file's own vendored-node
+// managedFiles import-graph walk (collectVendoredFiles below) for every
+// profile that resolves this command's entry path.
+const LIVE_CONFIG_CANDIDATE_FILES = [
+  '.github/idd/config.json',
+  'idd-policy.json',
+];
+const NODE_ENGINES = '^22.22.2 || >=24.2.0';
+const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
+// Runtime data files a helper reads at execution time (not via `import`),
+// so the import-graph walk cannot discover them. A consumer that vendors
+// exactly `managedFiles` must still receive these or the helper crashes on a
+// missing path. The drift guard in tests/helper-runtime-manifest.test.mts
+// asserts the vendored-node managedFiles include every data path
+// validate-schemas references, so this list must stay complete.
+const EXTRA_RUNTIME_FILES = new Map([
+  ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
+  // validate-schemas validates every schema/fixture pair in its CLI `cases`
+  // table by reading the files directly; none of them are imported.
+  [
+    'scripts/validate-schemas.mjs',
+    [
+      'schemas/advisory-wait-state.schema.json',
+      'schemas/claim-marker.schema.json',
+      'schemas/forced-handoff-marker.schema.json',
+      'schemas/idd-merge-execute.schema.json',
+      'schemas/live-status-digest.schema.json',
+      'schemas/phase-graph.json',
+      'schemas/phase-graph.schema.json',
+      'schemas/policy.schema.json',
+      'schemas/pre-merge-readiness.schema.json',
+      'fixtures/schemas/advisory-wait-state.invalid.json',
+      'fixtures/schemas/advisory-wait-state.valid.json',
+      'fixtures/schemas/claim-marker.invalid.json',
+      'fixtures/schemas/claim-marker.valid.json',
+      'fixtures/schemas/forced-handoff-marker.invalid.json',
+      'fixtures/schemas/forced-handoff-marker.valid.json',
+      'fixtures/schemas/idd-merge-execute.invalid.json',
+      'fixtures/schemas/idd-merge-execute.valid.json',
+      'fixtures/schemas/live-status-digest.invalid.json',
+      'fixtures/schemas/live-status-digest.valid.json',
+      'fixtures/schemas/phase-graph.invalid.json',
+      'fixtures/schemas/phase-graph.valid.json',
+      'fixtures/schemas/policy.invalid.json',
+      'fixtures/schemas/policy.valid.json',
+      'fixtures/schemas/pre-merge-readiness.invalid.json',
+      'fixtures/schemas/pre-merge-readiness.valid.json',
+    ],
+  ],
+]);
+const HELPER_COMMANDS = [
+  {
+    id: 'advisory-convergence',
+    scriptName: 'idd:advisory-convergence',
+    binName: 'idd-advisory-convergence',
+    entryPath: 'scripts/advisory-convergence.mjs',
+    vendoredCommand: 'node scripts/advisory-convergence.mjs',
+    description:
+      'Assert whether the primary advisory bot has converged on the current PR HEAD, with an exit-code contract via --assert.',
+    contractPaths: ['schemas/advisory-convergence.schema.json'],
+  },
+  {
+    id: 'advisory-wait-state',
+    scriptName: 'idd:advisory-wait-state',
+    binName: 'idd-advisory-wait-state',
+    entryPath: 'scripts/advisory-wait-state.mjs',
+    vendoredCommand: 'node scripts/advisory-wait-state.mjs',
+    description:
+      'Collect advisory-wait state without mutating PR review state.',
+    contractPaths: ['schemas/advisory-wait-state.schema.json'],
+  },
+  {
+    id: 'audit-authored-issue',
+    scriptName: 'idd:audit-authored-issue',
+    binName: 'idd-audit-authored-issue',
+    entryPath: 'scripts/audit-authored-issue.mjs',
+    vendoredCommand: 'node scripts/audit-authored-issue.mjs',
+    description:
+      'Mechanically audit a drafted issue body against the issue-authoring contract: the autopilot-suitability marker, its blocked-by-human cross-field rule, markerPrefix consistency, required headings, dependency-marker rules, and visible/hidden footer agreement.',
+  },
+  {
+    id: 'audit-pr-cleanup',
+    scriptName: 'idd:audit-pr-cleanup',
+    binName: 'idd-audit-pr-cleanup',
+    entryPath: 'scripts/audit-pr-cleanup.mjs',
+    vendoredCommand: 'node scripts/audit-pr-cleanup.mjs',
+    description: 'Audit or apply post-merge comment cleanup.',
+  },
+  {
+    id: 'branch-conflict-state',
+    scriptName: 'idd:branch-conflict-state',
+    binName: 'idd-branch-conflict-state',
+    entryPath: 'scripts/branch-conflict-state.mjs',
+    vendoredCommand: 'node scripts/branch-conflict-state.mjs',
+    description:
+      'Collect read-only branch conflict and synchronization state evidence for a PR.',
+    contractPaths: ['schemas/branch-conflict-state.schema.json'],
+  },
+  {
+    id: 'branch-name',
+    scriptName: 'idd:branch-name',
+    binName: 'idd-branch-name',
+    entryPath: 'scripts/branch-name.mjs',
+    vendoredCommand: 'node scripts/branch-name.mjs',
+    description:
+      'Compute the canonical A5(e) issue/<number>-<slug> branch name from an issue number and title.',
+  },
+  {
+    id: 'ci-wait-policy',
+    scriptName: 'idd:ci-wait-policy',
+    binName: 'idd-ci-wait-policy',
+    entryPath: 'scripts/ci-wait-policy.mjs',
+    vendoredCommand: 'node scripts/ci-wait-policy.mjs',
+    description:
+      'Resolve shared ciWait defaults and deterministic rerun-budget decisions.',
+    contractPaths: ['schemas/policy.schema.json'],
+  },
+  {
+    id: 'ci-wait-state',
+    scriptName: 'idd:ci-wait-state',
+    binName: 'idd-ci-wait-state',
+    entryPath: 'scripts/ci-wait-state.mjs',
+    vendoredCommand: 'node scripts/ci-wait-state.mjs',
+    description:
+      'Collect a read-only D-phase CI snapshot: per-check status keyed by (checkName, workflowName), the live headRefOid, and a required-checks rollup.',
+  },
+  {
+    id: 'claim-approval-gate',
+    scriptName: 'idd:claim-approval-gate',
+    binName: 'idd-claim-approval-gate',
+    entryPath: 'scripts/claim-approval-gate.mjs',
+    vendoredCommand: 'node scripts/claim-approval-gate.mjs',
+    description:
+      'Evaluate the A5(a) issue-author approval gate against issue state.',
+  },
+  {
+    id: 'claim-lock',
+    scriptName: 'idd:claim-lock',
+    binName: 'idd-claim-lock',
+    entryPath: 'scripts/claim-lock.mjs',
+    vendoredCommand: 'node scripts/claim-lock.mjs',
+    description:
+      'Acquire, reacquire, or inspect a worktree-local same-machine claim lock.',
+  },
+  {
+    id: 'discover-orphan-filter',
+    scriptName: 'idd:discover-orphan-filter',
+    binName: 'idd-discover-orphan-filter',
+    entryPath: 'scripts/discover-orphan-filter.mjs',
+    vendoredCommand: 'node scripts/discover-orphan-filter.mjs',
+    description:
+      'Classify open issues into orphan candidates and filtered buckets.',
+  },
+  {
+    id: 'discover-readiness-check',
+    scriptName: 'idd:discover-readiness-check',
+    binName: 'idd-discover-readiness-check',
+    entryPath: 'scripts/discover-readiness-check.mjs',
+    vendoredCommand: 'node scripts/discover-readiness-check.mjs',
+    description:
+      'Collect read-only A3 readiness filtering evidence for candidate issues.',
+  },
+  {
+    id: 'discover-roadmap-graph',
+    scriptName: 'idd:discover-roadmap-graph',
+    binName: 'idd-discover-roadmap-graph',
+    entryPath: 'scripts/discover-roadmap-graph.mjs',
+    vendoredCommand: 'node scripts/discover-roadmap-graph.mjs',
+    description: 'Collect read-only A1.5/A2 recursive roadmap graph evidence.',
+  },
+  {
+    id: 'discover-shared-file-overlap',
+    scriptName: 'idd:discover-shared-file-overlap',
+    binName: 'idd-discover-shared-file-overlap',
+    entryPath: 'scripts/discover-shared-file-overlap.mjs',
+    vendoredCommand: 'node scripts/discover-shared-file-overlap.mjs',
+    description:
+      'Flag high-contention shared-file overlap between candidate issues and actively-claimed / open-PR work.',
+  },
+  {
+    id: 'discover-viability-gate',
+    scriptName: 'idd:discover-viability-gate',
+    binName: 'idd-discover-viability-gate',
+    entryPath: 'scripts/discover-viability-gate.mjs',
+    vendoredCommand: 'node scripts/discover-viability-gate.mjs',
+    description:
+      'Collect read-only A4 viability filtering evidence for candidate issues.',
+  },
+  {
+    id: 'disposition-non-review-notices',
+    scriptName: 'idd:disposition-non-review-notices',
+    binName: 'idd-disposition-non-review-notices',
+    entryPath: 'scripts/disposition-non-review-notices.mjs',
+    vendoredCommand: 'node scripts/disposition-non-review-notices.mjs',
+    description:
+      'Detect advisory non-review notices on a PR and emit or post their canonical E6 dispositions.',
+    contractPaths: ['schemas/disposition-non-review-notices.schema.json'],
+  },
+  {
+    id: 'doctor',
+    scriptName: 'idd:doctor',
+    binName: 'idd-doctor',
+    entryPath: 'scripts/idd-doctor.mjs',
+    vendoredCommand: 'node scripts/idd-doctor.mjs',
+    description:
+      'Run IDD onboarding drift checks against the local repository.',
+  },
+  {
+    id: 'emit-marker',
+    scriptName: 'idd:emit-marker',
+    binName: 'idd-emit-marker',
+    entryPath: 'scripts/emit-marker.mjs',
+    vendoredCommand: 'node scripts/emit-marker.mjs',
+    description:
+      'Emit a per-cycle claimed-by / review-watermark / review-baseline marker body (emit-only, no network write).',
+  },
+  {
+    id: 'external-check-waiver',
+    scriptName: 'idd:external-check-waiver',
+    binName: 'idd-external-check-waiver',
+    entryPath: 'scripts/external-check-waiver.mjs',
+    vendoredCommand: 'node scripts/external-check-waiver.mjs',
+    description:
+      'Dry-run or apply a maintainer-authorized external-check waiver comment for an active PR claim.',
+  },
+  {
+    id: 'force-handoff',
+    scriptName: 'idd:force-handoff',
+    binName: 'idd-force-handoff',
+    entryPath: 'scripts/force-handoff.mjs',
+    vendoredCommand: 'node scripts/force-handoff.mjs',
+    description:
+      'Interactive TTY-only operator facade for forced handoff: issue → optional PR → y/N confirmation.',
+  },
+  {
+    id: 'forced-handoff-marker',
+    scriptName: 'idd:forced-handoff-marker',
+    binName: 'idd-forced-handoff-marker',
+    entryPath: 'scripts/forced-handoff-marker.mjs',
+    vendoredCommand: 'node scripts/forced-handoff-marker.mjs',
+    description:
+      'Render a maintainer-approved forced-handoff marker body for an active claim.',
+    contractPaths: ['schemas/forced-handoff-marker.schema.json'],
+  },
+  {
+    id: 'helper-bundle-manifest',
+    scriptName: 'idd:helper-bundle-manifest',
+    binName: 'idd-helper-bundle-manifest',
+    entryPath: 'scripts/helper-runtime-manifest.mjs',
+    vendoredCommand: 'node scripts/helper-runtime-manifest.mjs',
+    description:
+      'Print the canonical helper bundle import plan for each runtime profile.',
+  },
+  {
+    id: 'live-status-digest',
+    scriptName: 'idd:live-status-digest',
+    binName: 'idd-live-status-digest',
+    entryPath: 'scripts/live-status-digest.mjs',
+    vendoredCommand: 'node scripts/live-status-digest.mjs',
+    description: 'Render or apply the optional live status digest.',
+  },
+  {
+    id: 'merge-execute',
+    scriptName: 'idd:merge-execute',
+    binName: 'idd-merge-execute',
+    entryPath: 'scripts/idd-merge-execute.mjs',
+    vendoredCommand: 'node scripts/idd-merge-execute.mjs',
+    description:
+      'Evaluate the F3 merge gate (dry-run) and execute the bound merge with --apply.',
+    contractPaths: ['schemas/idd-merge-execute.schema.json'],
+  },
+  {
+    id: 'minimize-superseded-markers',
+    scriptName: 'idd:minimize-superseded-markers',
+    binName: 'idd-minimize-superseded-markers',
+    entryPath: 'scripts/minimize-superseded-markers.mjs',
+    vendoredCommand: 'node scripts/minimize-superseded-markers.mjs',
+    description:
+      'Minimize superseded claim-chain or resolved review markers as OUTDATED/RESOLVED, gated by trusted marker author.',
+  },
+  {
+    id: 'phase-id-resolver',
+    scriptName: 'idd:phase-id-resolver',
+    binName: 'idd-phase-id-resolver',
+    entryPath: 'scripts/phase-id-resolver.mjs',
+    vendoredCommand: 'node scripts/phase-id-resolver.mjs',
+    description: 'Resolve canonical phase IDs with legacy alias compatibility.',
+  },
+  {
+    id: 'post-idd-marker',
+    scriptName: 'idd:post-idd-marker',
+    binName: 'idd-post-idd-marker',
+    entryPath: 'scripts/post-idd-marker.mjs',
+    vendoredCommand: 'node scripts/post-idd-marker.mjs',
+    description:
+      'Render and POST a canonical IDD operational marker (claim / unclaim / watermark / baseline / advisory / advisory-recovery) via the reliable JSON path.',
+    contractPaths: ['schemas/post-idd-marker.schema.json'],
+  },
+  {
+    id: 'pre-merge-readiness',
+    scriptName: 'idd:pre-merge-readiness',
+    binName: 'idd-pre-merge-readiness',
+    entryPath: 'scripts/pre-merge-readiness.mjs',
+    vendoredCommand: 'node scripts/pre-merge-readiness.mjs',
+    description: 'Collect read-only F2/F3 merge-gate evidence.',
+    contractPaths: ['schemas/pre-merge-readiness.schema.json'],
+  },
+  {
+    id: 'rerun-advisory-convergence',
+    scriptName: 'idd:rerun-advisory-convergence',
+    binName: 'idd-rerun-advisory-convergence',
+    entryPath: 'scripts/rerun-advisory-convergence.mjs',
+    vendoredCommand: 'node scripts/rerun-advisory-convergence.mjs',
+    description:
+      'Read-only: diagnose every idd-advisory-convergence check-run instance for a PR HEAD and print the ordered gh run rerun recovery plan.',
+  },
+  {
+    id: 'resolve-review-thread',
+    scriptName: 'idd:resolve-review-thread',
+    binName: 'idd-resolve-review-thread',
+    entryPath: 'scripts/resolve-review-thread.mjs',
+    vendoredCommand: 'node scripts/resolve-review-thread.mjs',
+    description:
+      'Post the E13 reply and resolve the owning review thread in one invocation (dry-run by default; --apply mutates).',
+    contractPaths: ['schemas/resolve-review-thread.schema.json'],
+  },
+  {
+    id: 'resume-claim-routing',
+    scriptName: 'idd:resume-claim-routing',
+    binName: 'idd-resume-claim-routing',
+    entryPath: 'scripts/resume-claim-routing.mjs',
+    vendoredCommand: 'node scripts/resume-claim-routing.mjs',
+    description:
+      'Evaluate Resume Step 1 claim routing outcomes from claim marker history.',
+  },
+  {
+    id: 'resume-route-selection',
+    scriptName: 'idd:resume-route-selection',
+    binName: 'idd-resume-route-selection',
+    entryPath: 'scripts/resume-route-selection.mjs',
+    vendoredCommand: 'node scripts/resume-route-selection.mjs',
+    description:
+      'Evaluate Resume Step 3 route selection from PR, CI, and review state.',
+  },
+  {
+    id: 'review-activity-snapshot',
+    scriptName: 'idd:review-activity-snapshot',
+    binName: 'idd-review-activity-snapshot',
+    entryPath: 'scripts/review-activity-snapshot.mjs',
+    vendoredCommand: 'node scripts/review-activity-snapshot.mjs',
+    description: 'Collect read-only review activity and CI snapshot evidence.',
+  },
+  {
+    id: 'review-disposition-verify',
+    scriptName: 'idd:review-disposition-verify',
+    binName: 'idd-review-disposition-verify',
+    entryPath: 'scripts/review-disposition-verify.mjs',
+    vendoredCommand: 'node scripts/review-disposition-verify.mjs',
+    description:
+      'Verify disposition marker presence on review items for E7 meta-check.',
+  },
+  {
+    id: 'roadmap-audit-execute',
+    scriptName: 'idd:roadmap-audit-execute',
+    binName: 'idd-roadmap-audit-execute',
+    entryPath: 'scripts/idd-roadmap-audit-execute.mjs',
+    vendoredCommand: 'node scripts/idd-roadmap-audit-execute.mjs',
+    description:
+      'Evaluate the A1.5 roadmap completion audit (dry-run) and, with --apply, post the evidence comment, close the roadmap, and release the claim.',
+    contractPaths: ['schemas/idd-roadmap-audit-execute.schema.json'],
+  },
+  {
+    id: 'select-desynced-index',
+    scriptName: 'idd:select-desynced-index',
+    binName: 'idd-select-desynced-index',
+    entryPath: 'scripts/select-desynced-index.mjs',
+    vendoredCommand: 'node scripts/select-desynced-index.mjs',
+    description:
+      'Compute the deterministic A4 Step 2 concurrent-selection desync band index for a session token and band size.',
+  },
+  {
+    id: 'stalled-session-quiet-check',
+    scriptName: 'idd:stalled-session-quiet-check',
+    binName: 'idd-stalled-session-quiet-check',
+    entryPath: 'scripts/stalled-session-quiet-check.mjs',
+    vendoredCommand: 'node scripts/stalled-session-quiet-check.mjs',
+    description: 'Detect quiet windows for Resume/S2 stalled-session recovery.',
+    contractPaths: ['schemas/stalled-session-quiet-check.schema.json'],
+  },
+  {
+    id: 'suitability-triage',
+    scriptName: 'idd:suitability-triage',
+    binName: 'idd-suitability-triage',
+    entryPath: 'scripts/suitability-triage.mjs',
+    vendoredCommand: 'node scripts/suitability-triage.mjs',
+    description:
+      'Evaluate A4.5 suitability checks and map deterministic outcomes.',
+  },
+];
+/**
+ * Resolve the invocation string for one helper command under one
+ * `helperRuntime.profile`, so a helper-emitted remediation hint (for
+ * example idd-doctor's post-merge-cleanup-backlog warning) never
+ * hard-codes a single profile's command form. Mirrors
+ * `buildProfileCatalog`'s per-profile command mapping for a single helper
+ * id instead of building the full multi-helper catalog, so callers that
+ * only need one command avoid the catalog's package-manager
+ * detection / vendored-file filesystem walk.
+ *
+ * Returns `null` for `instructions-only` (no runnable command exists),
+ * an unrecognized helper `id`, or an unrecognized `profile` -- callers
+ * fall back to a documentation pointer alone in all three cases.
+ */
+export function resolveHelperCommandForProfile({
+  helperId,
+  profile,
+  packageSpec = '',
+}) {
+  const command = HELPER_COMMANDS.find((entry) => entry.id === helperId);
+  if (!command) {
+    return null;
+  }
+  switch (profile) {
+    case 'vendored-node':
+      return command.vendoredCommand;
+    case 'package-manager':
+      // The bare bin name -- matches `buildProfileCatalog`'s own
+      // `package-manager` `commands` value, not a `<manager> run
+      // <scriptName>` form: argument forwarding after `run` differs
+      // across managers (npm requires a literal `--` before flags; pnpm
+      // and yarn do not), so a manager-agnostic emitted string would be
+      // wrong for at least one manager, which is worse than the bug this
+      // resolver exists to fix.
+      return command.binName;
+    case 'ephemeral-npx':
+      return `npx --yes --package ${normalizePackageSpec(packageSpec)} ${command.binName}`;
+    default:
+      return null;
+  }
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `profile:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --profile spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls parseArgs()
+// synchronously at module-evaluation time, and a `const` declared after
+// that point is still in the temporal dead zone when the trigger fires.
+const HELPER_RUNTIME_MANIFEST_FLAG_SPEC = {
+  '--help': { type: 'boolean', short: 'h' },
+  '--profile': { type: 'string' },
+  '--from-profile': { type: 'string' },
+  '--package-manager': { type: 'string' },
+  '--package-spec': { type: 'string' },
+  '--target-root': { type: 'string' },
+};
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const manifest = buildHelperRuntimeManifest({
+    profile: args.profile,
+    fromProfile: args.fromProfile,
+    packageManager: args.packageManager,
+    packageSpec: args.packageSpec,
+    targetRoot: args.targetRoot,
+  });
+  process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+}
+/**
+ * Resolve `targetRoot`'s configured `helperRuntime.packageSpec`
+ * (idd-skill#1731), so `buildHelperRuntimeManifest` can reflect a
+ * repository-pinned tarball/mirror in its `ephemeral-npx` (and
+ * `package-manager`) command catalog even when the caller passes no
+ * explicit `--package-spec`. Returns `''` (meaning: fall back to
+ * `DEFAULT_PACKAGE_SPEC`) when no candidate config file exists, the first
+ * present one is not valid JSON, `helperRuntime` is absent/invalid, or no
+ * `packageSpec` is configured -- the same fail-closed default as an
+ * unrecognized `helperRuntime.profile`.
+ */
+function resolveConfiguredPackageSpec(targetRoot) {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = resolve(targetRoot, file);
+    if (!existsSync(absolutePath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      return '';
+    }
+    const helperRuntime = inspectHelperRuntimeConfig(config);
+    return helperRuntime.status === 'ok'
+      ? (helperRuntime.packageSpec ?? '')
+      : '';
+  }
+  return '';
+}
+export function buildHelperRuntimeManifest({
+  profile = '',
+  fromProfile = '',
+  packageManager = '',
+  packageSpec = '',
+  targetRoot = process.cwd(),
+} = {}) {
+  const packageRoot = PACKAGE_ROOT;
+  const packageMetadata = resolveSourcePackageMetadata(packageRoot);
+  const normalizedProfile = normalizeProfile(profile);
+  const normalizedFromProfile = normalizeOptionalProfile(fromProfile);
+  const normalizedTargetRoot = targetRoot || process.cwd();
+  // Precedence: explicit --package-spec > configured helperRuntime.packageSpec
+  // > DEFAULT_PACKAGE_SPEC (idd-skill#1731). normalizePackageSpec's own `||
+  // DEFAULT_PACKAGE_SPEC` fallback is unchanged; this only widens what feeds
+  // its left-hand side before that fallback applies.
+  const normalizedPackageSpec = normalizePackageSpec(
+    packageSpec || resolveConfiguredPackageSpec(normalizedTargetRoot),
+  );
+  const recommendation = recommendHelperRuntimeProfile(normalizedTargetRoot);
+  const normalizedPackageManager = normalizePackageManager(
+    packageManager || detectPackageManager(normalizedTargetRoot),
+    normalizedProfile,
+  );
+  const managedFiles = collectVendoredFiles(packageRoot);
+  const commandCatalog = buildCommandCatalog();
+  const profileCatalog = buildProfileCatalog({
+    packageMetadata,
+    managedFiles,
+    packageManager: normalizedPackageManager,
+    packageSpec: normalizedPackageSpec,
+  });
+  const selectedProfiles = normalizedProfile
+    ? { [normalizedProfile]: profileCatalog[normalizedProfile] }
+    : profileCatalog;
+  return {
+    version: 1,
+    sourceRepository: packageMetadata.repository,
+    packageName: packageMetadata.name,
+    packageSpec: normalizedPackageSpec,
+    packageSpecPinHint: PACKAGE_SPEC_PIN_HINT,
+    nodeEngines: packageMetadata.nodeEngines,
+    packageManager: normalizedPackageManager,
+    recommendation,
+    availableProfiles: [...PROFILE_NAMES],
+    commandCatalog,
+    profiles: selectedProfiles,
+    switching:
+      normalizedProfile && normalizedFromProfile
+        ? buildSwitchPlan({
+            fromProfile: normalizedFromProfile,
+            toProfile: normalizedProfile,
+            profileCatalog,
+          })
+        : null,
+  };
+}
+export function collectVendoredFiles(packageRoot = PACKAGE_ROOT) {
+  const queue = HELPER_COMMANDS.map((command) => command.entryPath).map(
+    (entryPath) => resolve(packageRoot, entryPath),
+  );
+  const visited = new Set();
+  const managedFiles = new Set();
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const currentPath = relativePath(packageRoot, current);
+    managedFiles.add(currentPath);
+    for (const extraFile of EXTRA_RUNTIME_FILES.get(currentPath) ?? []) {
+      managedFiles.add(
+        relativePath(packageRoot, resolve(packageRoot, extraFile)),
+      );
+    }
+    const source = readFileSync(current, 'utf8');
+    for (const specifier of findRelativeImports(source)) {
+      const dependency = resolveRelativeImport(current, specifier);
+      if (!dependency) {
+        continue;
+      }
+      queue.push(dependency);
+    }
+  }
+  for (const command of HELPER_COMMANDS) {
+    for (const contractPath of command.contractPaths ?? []) {
+      managedFiles.add(
+        relativePath(packageRoot, resolve(packageRoot, contractPath)),
+      );
+    }
+  }
+  return [...managedFiles].sort().map((targetPath) => ({
+    sourcePath: targetPath,
+    targetPath,
+  }));
+}
+export function detectPackageManager(root = process.cwd()) {
+  return collectHelperRuntimeEvidence(root).detectedPackageManager;
+}
+export function collectHelperRuntimeEvidence(root = process.cwd()) {
+  const packageJsonPath = resolve(root, 'package.json');
+  let declaredPackageManager = '';
+  let hasPackageJson = false;
+  if (existsSync(packageJsonPath)) {
+    hasPackageJson = true;
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      const declared = String(packageJson.packageManager ?? '');
+      for (const manager of PACKAGE_MANAGERS) {
+        if (declared.startsWith(`${manager}@`)) {
+          declaredPackageManager = manager;
+          break;
+        }
+      }
+    } catch {
+      // Ignore parse errors here and fall back to lockfile detection.
+    }
+  }
+  const lockfileMatches = [
+    { filename: 'pnpm-lock.yaml', manager: 'pnpm' },
+    { filename: 'package-lock.json', manager: 'npm' },
+    { filename: 'yarn.lock', manager: 'yarn' },
+  ].filter(({ filename }) => existsSync(resolve(root, filename)));
+  const detectedPackageManager =
+    declaredPackageManager ||
+    (lockfileMatches.length === 1 ? lockfileMatches[0].manager : '');
+  return {
+    hasPackageJson,
+    declaredPackageManager,
+    lockfileMatches,
+    detectedPackageManager,
+    packageJsonOnly:
+      hasPackageJson && !declaredPackageManager && lockfileMatches.length === 0,
+    ambiguousPackageManager:
+      !declaredPackageManager && lockfileMatches.length > 1,
+  };
+}
+export function recommendHelperRuntimeProfile(root = process.cwd()) {
+  const evidence = collectHelperRuntimeEvidence(root);
+  if (evidence.detectedPackageManager) {
+    return {
+      profile: 'package-manager',
+      packageManager: evidence.detectedPackageManager,
+      reason: evidence.declaredPackageManager
+        ? 'Detected supported packageManager metadata.'
+        : 'Detected exactly one supported package-manager lockfile.',
+      evidence,
+    };
+  }
+  if (evidence.ambiguousPackageManager) {
+    return {
+      profile: 'vendored-node',
+      packageManager: '',
+      reason:
+        'Multiple supported package-manager signals were detected; do not guess an install path. Prefer vendored-node before ephemeral-npx when helper support is still desired.',
+      evidence,
+    };
+  }
+  let reason = 'No supported package-manager evidence was detected.';
+  if (evidence.packageJsonOnly) {
+    reason =
+      'package.json alone is not enough evidence to assume npm, another package manager, or a real Node.js helper path.';
+  }
+  return {
+    profile: 'instructions-only',
+    packageManager: '',
+    reason: `${reason} Keep instructions-only unless separate repository evidence confirms a real Node.js helper path; if helper support is still desired then, prefer vendored-node before ephemeral-npx.`,
+    evidence,
+  };
+}
+function buildCommandCatalog() {
+  return HELPER_COMMANDS.map((command) => ({
+    id: command.id,
+    scriptName: command.scriptName,
+    binName: command.binName,
+    entryPath: command.entryPath,
+    vendoredCommand: command.vendoredCommand,
+    description: command.description,
+    contractPaths: command.contractPaths ?? [],
+  }));
+}
+export function resolveSourcePackageMetadata(packageRoot = PACKAGE_ROOT) {
+  const fallback = {
+    name: PACKAGE_NAME,
+    repository: SOURCE_REPOSITORY,
+    nodeEngines: NODE_ENGINES,
+  };
+  const packageJsonPath = resolve(packageRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return fallback;
+  }
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    if (packageJson.name !== PACKAGE_NAME) {
+      return fallback;
+    }
+    return {
+      name: PACKAGE_NAME,
+      repository: normalizeRepository(packageJson.repository),
+      nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
+    };
+  } catch {
+    return fallback;
+  }
+}
+function normalizeRepository(repository) {
+  if (typeof repository === 'string' && repository) {
+    return repository;
+  }
+  if (
+    repository &&
+    typeof repository === 'object' &&
+    typeof repository.url === 'string' &&
+    repository.url
+  ) {
+    return repository.url;
+  }
+  return SOURCE_REPOSITORY;
+}
+function buildProfileCatalog({
+  packageMetadata,
+  managedFiles,
+  packageManager,
+  packageSpec,
+}) {
+  const packageManagerScripts = Object.fromEntries(
+    HELPER_COMMANDS.map((command) => [command.scriptName, command.binName]),
+  );
+  const vendoredCommands = Object.fromEntries(
+    HELPER_COMMANDS.map((command) => [
+      command.scriptName,
+      command.vendoredCommand,
+    ]),
+  );
+  const ephemeralCommands = Object.fromEntries(
+    HELPER_COMMANDS.map((command) => [
+      command.scriptName,
+      `npx --yes --package ${packageSpec} ${command.binName}`,
+    ]),
+  );
+  return {
+    'package-manager': {
+      profile: 'package-manager',
+      description:
+        "Install the helper bundle through the repository's existing package manager and invoke helper bins through package.json scripts.",
+      packageManager,
+      installCommand: packageManager
+        ? buildPackageManagerInstallCommand(packageManager, packageSpec)
+        : '',
+      managedDependencies: {
+        devDependencies: {
+          [packageMetadata.name]: packageSpec,
+        },
+      },
+      managedPackageJsonScripts: packageManagerScripts,
+      managedFiles: [],
+      commands: packageManagerScripts,
+      notes: [
+        "Use the repository's existing package manager instead of assuming pnpm.",
+        PACKAGE_SPEC_PIN_HINT,
+      ],
+    },
+    'vendored-node': {
+      profile: 'vendored-node',
+      description:
+        'Copy the helper bundle into the target repository and invoke helpers through local node scripts.',
+      packageManager: '',
+      installCommand: '',
+      managedDependencies: {
+        devDependencies: {},
+      },
+      managedPackageJsonScripts: {},
+      managedFiles,
+      commands: vendoredCommands,
+      notes: [
+        'Copy the listed files into matching paths in the target repository.',
+        'The managed file list is derived from the helper entrypoint import graph to avoid hand-maintained drift.',
+        "Append the recommendedGitattributes lines to the adopter's .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).",
+      ],
+      recommendedGitattributes: managedFiles.map(
+        (file) => `${file.targetPath} linguist-vendored`,
+      ),
+    },
+    'ephemeral-npx': {
+      profile: 'ephemeral-npx',
+      description:
+        'Resolve helper commands one-shot through npx without copying files into the repository.',
+      packageManager: '',
+      installCommand: '',
+      managedDependencies: {
+        devDependencies: {},
+      },
+      managedPackageJsonScripts: {},
+      managedFiles: [],
+      commands: ephemeralCommands,
+      notes: [
+        'This profile requires Node.js and npm with npx available at execution time.',
+        PACKAGE_SPEC_PIN_HINT,
+      ],
+    },
+    'instructions-only': {
+      profile: 'instructions-only',
+      description:
+        'Keep the portable Markdown workflow only and omit helper dependencies entirely.',
+      packageManager: '',
+      installCommand: '',
+      managedDependencies: {
+        devDependencies: {},
+      },
+      managedPackageJsonScripts: {},
+      managedFiles: [],
+      commands: {},
+      notes: [
+        'No helper files, helper package dependencies, or helper wrapper scripts are required.',
+      ],
+    },
+  };
+}
+function buildSwitchPlan({ fromProfile, toProfile, profileCatalog }) {
+  const from = profileCatalog[fromProfile];
+  const to = profileCatalog[toProfile];
+  return {
+    fromProfile,
+    toProfile,
+    removeFiles: subtractPaths(from.managedFiles, to.managedFiles),
+    addFiles: subtractPaths(to.managedFiles, from.managedFiles),
+    removePackageJsonScripts: Object.keys(from.managedPackageJsonScripts)
+      .filter((name) => !(name in to.managedPackageJsonScripts))
+      .sort(),
+    addPackageJsonScripts: Object.fromEntries(
+      Object.entries(to.managedPackageJsonScripts)
+        .filter(
+          ([name, command]) => from.managedPackageJsonScripts[name] !== command,
+        )
+        .sort(([left], [right]) => left.localeCompare(right)),
+    ),
+    removeDevDependencies: Object.keys(from.managedDependencies.devDependencies)
+      .filter((name) => !(name in to.managedDependencies.devDependencies))
+      .sort(),
+    addDevDependencies: Object.fromEntries(
+      Object.entries(to.managedDependencies.devDependencies)
+        .filter(
+          ([name, spec]) =>
+            from.managedDependencies.devDependencies[name] !== spec,
+        )
+        .sort(([left], [right]) => left.localeCompare(right)),
+    ),
+  };
+}
+function subtractPaths(leftFiles, rightFiles) {
+  const right = new Set(rightFiles.map((file) => file.targetPath));
+  return leftFiles
+    .filter((file) => !right.has(file.targetPath))
+    .map((file) => file.targetPath)
+    .sort();
+}
+function buildPackageManagerInstallCommand(packageManager, packageSpec) {
+  if (packageManager === 'npm') {
+    return `npm install --save-dev ${packageSpec}`;
+  }
+  if (packageManager === 'pnpm') {
+    return `pnpm add -D ${packageSpec}`;
+  }
+  if (packageManager === 'yarn') {
+    return `yarn add --dev ${packageSpec}`;
+  }
+  throw new Error(`unsupported package manager: ${packageManager}`);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    HELPER_RUNTIME_MANIFEST_FLAG_SPEC,
+  );
+  return {
+    help,
+    profile: values.profile ?? '',
+    fromProfile: values['from-profile'] ?? '',
+    packageManager: values['package-manager'] ?? '',
+    packageSpec: values['package-spec'] ?? '',
+    targetRoot: values['target-root'] ?? '',
+  };
+}
+function printHelp() {
+  process.stdout.write(`usage: node scripts/helper-runtime-manifest.mjs [options]
+
+Options:
+  --profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
+  --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
+  --package-manager <npm|pnpm|yarn>
+  --package-spec <npm-spec-or-tarball-url>
+  --target-root <path>
+  --help
+`);
+}
+function normalizePackageSpec(packageSpec) {
+  return packageSpec || DEFAULT_PACKAGE_SPEC;
+}
+function normalizeProfile(profile) {
+  if (!profile) {
+    return '';
+  }
+  if (!PROFILE_NAMES.includes(profile)) {
+    throw new Error(`unsupported profile: ${profile}`);
+  }
+  return profile;
+}
+function normalizeOptionalProfile(profile) {
+  if (!profile) {
+    return '';
+  }
+  return normalizeProfile(profile);
+}
+function normalizePackageManager(packageManager, profile) {
+  if (!packageManager) {
+    if (profile === 'package-manager') {
+      throw new Error(
+        'package-manager profile requires --package-manager <npm|pnpm|yarn> or a detectable package manager in --target-root',
+      );
+    }
+    return '';
+  }
+  if (!PACKAGE_MANAGERS.includes(packageManager)) {
+    throw new Error(`unsupported package manager: ${packageManager}`);
+  }
+  return packageManager;
+}
+function findRelativeImports(source) {
+  const specifiers = new Set();
+  const patterns = [
+    /\b(?:import|export)\s+(?:[^"'`]+\s+from\s+)?["'](\.[^"']+)["']/g,
+    /\bimport\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+  return [...specifiers];
+}
+function resolveRelativeImport(fromFile, specifier) {
+  const directory = dirname(fromFile);
+  const basePath = resolve(directory, specifier);
+  const candidates = existsSync(basePath)
+    ? [basePath]
+    : SCRIPT_FILE_EXTENSIONS.map((extension) => `${basePath}${extension}`);
+  return candidates.find((candidate) => existsSync(candidate)) ?? '';
+}
+function relativePath(root, target) {
+  return relative(root, target).replaceAll('\\', '/');
+}

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -1,0 +1,126 @@
+// idd-generated-from: src/scripts/idd-config.mts
+//
+// The scripts/idd-config.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Shared `.github/idd/config.json` loader, extracted from 7 per-helper
+// copies of a `readFileSync + JSON.parse`, null-on-any-error wrapper (see
+// #1208).
+//
+// No memoization: an earlier revision of this module cached the parsed
+// result per resolved config path, but `idd-merge-execute.mts` calls
+// `collectPreMergeReadiness` (which reads this config) twice in the same
+// process — once for the initial gate, once to deliberately re-validate
+// "immediately before merging" and fail closed on drift (see that file's
+// `runMergeExecute` doc comment). A memoized second read would silently
+// reuse the first call's config even if `.github/idd/config.json` changed
+// (e.g. a trusted-marker-actor login revoked) between the two calls,
+// defeating exactly the drift this re-validation exists to catch. Every
+// production call site reads this file at most once per process anyway,
+// so memoization had no real payoff to justify that risk.
+//
+// `loadIddConfig()` below only covers the default, no-path case (#1208's
+// original scope). #1721 adds `loadPolicyConfig()` beside it for the nine
+// helpers that also accept an explicit `--policy`/`--config` path, with
+// stricter failure semantics (see that function's doc comment).
+// `loadIddConfig()`'s own null-on-any-error contract is deliberately left
+// unchanged here: it has 11 existing callers that already rely on "missing,
+// unreadable, or malformed config all collapse to null", and widening its
+// blast radius to match `loadPolicyConfig()`'s stricter rules is a separate,
+// wider-review change #1721 does not attempt. A later session may pick that
+// residual up knowingly.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+/**
+ * Read and parse `.github/idd/config.json` from the current working
+ * directory, returning `null` when the file is missing, unreadable, or
+ * not valid JSON — the existing fail-safe every per-helper copy already
+ * implements: treat a missing or malformed config the same as "no policy
+ * configured". Always re-reads the file; see the module header for why
+ * this does not memoize.
+ */
+export function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
+}
+/** Default `.github/idd/config.json` path, relative to the process cwd. */
+export const DEFAULT_POLICY_CONFIG_PATH = '.github/idd/config.json';
+/**
+ * Read and parse a policy config file for the nine `--policy`/`--config`
+ * aware helpers (#1721), converging the read-and-parse failure semantics
+ * `discover-shared-file-overlap.mts` originally documented on its own:
+ *
+ * - An explicitly-supplied `policyPath` (non-empty) throws on **any**
+ *   failure — missing, unreadable, or malformed — naming the resolved path
+ *   and the underlying message. An operator who passes `--policy` has
+ *   stated that the file matters; silently falling back to defaults would
+ *   discard that intent.
+ * - The default path (`policyPath` empty or omitted) returns `{ config:
+ *   null }` only when the file does not exist (`ENOENT`) — the legitimate
+ *   "repository has no IDD config" case. A syntax error, permission error,
+ *   or any other read failure on the default path still throws: an
+ *   existing-but-broken config is never silently equivalent to "absent".
+ * - A file that parses as valid JSON but whose top-level value is not a
+ *   plain object (`null`, an array, a string, a number, a boolean) is
+ *   rejected the same way as a syntax error, for both the explicit and
+ *   default path. `JSON.parse('null')` succeeds and returns `null`, which
+ *   — left unchecked — would be indistinguishable from this function's own
+ *   "absent" sentinel and silently re-open exactly the fail-open gap this
+ *   function exists to close.
+ *
+ * Callers keep their own shape normalization (field extraction, defaults
+ * for individual fields, etc.) on top of the raw `config` this returns —
+ * this function converges only the read-and-parse step, not per-helper
+ * field semantics. `loadIddConfig()` above is intentionally not reused
+ * here: its null-on-any-error contract does not distinguish "absent" from
+ * "malformed", which is exactly the distinction this function exists to
+ * make.
+ */
+export function loadPolicyConfig(policyPath) {
+  const explicit = typeof policyPath === 'string' && policyPath.length > 0;
+  const path = resolve(
+    process.cwd(),
+    explicit ? policyPath : DEFAULT_POLICY_CONFIG_PATH,
+  );
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isPlainObject(parsed)) {
+      // A syntactically-valid top-level scalar/array/`null` is still a
+      // malformed *policy config* -- reject it the same way a syntax error
+      // is rejected below, rather than letting `JSON.parse('null')` in
+      // particular masquerade as this function's own "absent" sentinel.
+      throw new Error(
+        `expected a JSON object at the top level, got ${describeJsonValueKind(parsed)}`,
+      );
+    }
+    return { path, config: parsed };
+  } catch (error) {
+    if (!explicit && isEnoentError(error)) {
+      return { path, config: null };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to load policy from ${path}: ${message}`);
+  }
+}
+/** True when `value` is a non-null, non-array JSON object. */
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+/** Short human-readable description of a non-object parsed JSON value. */
+function describeJsonValueKind(value) {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'an array';
+  }
+  return `a ${typeof value}`;
+}
+/** True when `error` is a Node.js filesystem error with `code: 'ENOENT'`. */
+function isEnoentError(error) {
+  return typeof error === 'object' && error !== null && error.code === 'ENOENT';
+}

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1,0 +1,2889 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-doctor.mts
+//
+// The scripts/idd-doctor.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitabilityMarker,
+} from './autopilot-suitability.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import { resolveHelperCommandForProfile } from './helper-runtime-manifest.mjs';
+import {
+  inspectHelperRuntimeConfig,
+  POLICY_DEFAULTS,
+  parseProjectCommandRows,
+} from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
+import { loadJson, validate } from './validate-schemas.mjs';
+
+const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
+const WORKSHOP_REL_PATH = 'docs/workshop';
+const WORKSHOP_LINK_TARGET_PATTERNS = [
+  /(?:^|\/)docs\/workshop(?:\/|$)/,
+  /(?:^|\/)workshop(?:\/|$)/,
+];
+const BASE64_PATTERN = /^[A-Za-z0-9+/=\s]+$/;
+
+export { parseProjectCommandRows };
+export function runDoctor({
+  root,
+  requireGithub,
+  cleanupBacklogWindowDays,
+  cleanupBacklogWarnThreshold,
+  workshopCrossRefAllowMissing,
+  strict,
+}) {
+  const files = listFiles(root);
+  const textFiles = files.filter(isTextLikeFile);
+  const report = {
+    root,
+    errors: [],
+    warnings: [],
+    passes: [],
+  };
+  checkRequiredFiles(files, report);
+  checkPlaceholders(root, textFiles, report);
+  const markerPrefix = checkMarkerPrefixes(root, report);
+  const projectCommands = checkProjectCommands(root, report);
+  checkCommandResidueAndConsistency(
+    root,
+    markerPrefix,
+    projectCommands,
+    report,
+  );
+  checkPolicySignals(root, report);
+  checkHelperRuntimeConfig(root, report);
+  checkLiveConfigSchema(root, report);
+  checkClaimTimingConsistency(root, report);
+  checkDependencyVersionDrift(root, report);
+  checkAgentEntryFiles(root, report);
+  checkTemplateVersionSignal(root, report);
+  const worktreeGuardEnforced =
+    strict === true || readWorktreeGuardEnabled(root);
+  checkPrimaryWorktreeHead(root, report, { enforce: worktreeGuardEnforced });
+  checkWorktreeGuardActive(root, report);
+  checkWorktreeHardeningPresence(root, report);
+  checkPostMergeCleanupBacklog(
+    root,
+    {
+      windowDays: cleanupBacklogWindowDays ?? 14,
+      warnThreshold: cleanupBacklogWarnThreshold ?? 2,
+      requireGithub,
+    },
+    report,
+  );
+  checkReleaseTagDrift(root, report);
+  checkWorkshopCrossReferences(
+    root,
+    { allowMissing: workshopCrossRefAllowMissing ?? [] },
+    report,
+  );
+  checkWorkshopExampleRepoBackLink(root, { requireGithub }, report);
+  checkGithubReadiness(root, requireGithub, report);
+  checkAutopilotSuitabilityConsistency(
+    root,
+    { requireGithub, markerPrefix },
+    report,
+  );
+  return report;
+}
+/**
+ * Classify each open issue's authored autopilot-suitability marker and
+ * emit warning strings for contradictions, without any I/O. Exported
+ * for unit testing. Issues are `{ number, body, labels }` where labels
+ * are strings or `{ name }` objects.
+ */
+export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor);
+  const prefix =
+    typeof options.markerPrefix === 'string' && options.markerPrefix.length > 0
+      ? options.markerPrefix
+      : 'idd-skill';
+  const blockedByHumanLabelName =
+    typeof options.blockedByHumanLabelName === 'string' &&
+    options.blockedByHumanLabelName.length > 0
+      ? options.blockedByHumanLabelName
+      : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+  const warnings = [];
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    const labelNames = new Set(
+      (issue?.labels ?? []).map((label) =>
+        typeof label === 'string' ? label : (label?.name ?? ''),
+      ),
+    );
+    const blockedByHuman = labelNames.has(blockedByHumanLabelName);
+    const marker = parseAutopilotSuitabilityMarker(issue?.body, prefix);
+    if (!marker.present) {
+      continue;
+    }
+    const number = issue?.number;
+    if (marker.malformed) {
+      warnings.push(
+        `autopilot-suitability: issue #${number} has a malformed or out-of-range score marker (expected a single integer 1-5)`,
+      );
+      continue;
+    }
+    if (marker.value === 1 && !blockedByHuman) {
+      warnings.push(
+        `autopilot-suitability: issue #${number} is scored 1 (human-only) but is missing the ${blockedByHumanLabelName} label`,
+      );
+    } else if (
+      marker.value !== null &&
+      marker.value > 1 &&
+      marker.value >= floor &&
+      blockedByHuman
+    ) {
+      warnings.push(
+        `autopilot-suitability: issue #${number} is scored ${marker.value} (>= floor ${floor}) but carries ${blockedByHumanLabelName}; the score and label disagree`,
+      );
+    }
+  }
+  return { warnings };
+}
+function checkAutopilotSuitabilityConsistency(root, options, report) {
+  const requireGithub = options.requireGithub === true;
+  const recordGhFailure = (message) => {
+    if (requireGithub) {
+      report.errors.push(`autopilot-suitability consistency check: ${message}`);
+    }
+  };
+  const list = runCommand(
+    'gh',
+    [
+      'issue',
+      'list',
+      '--state',
+      'open',
+      '--json',
+      'number,labels,body',
+      '--limit',
+      '1000',
+    ],
+    root,
+  );
+  if (!list.ok) {
+    recordGhFailure('gh issue list unavailable');
+    return;
+  }
+  let issues;
+  try {
+    issues = JSON.parse(list.stdout);
+  } catch {
+    recordGhFailure('gh issue list returned invalid JSON');
+    return;
+  }
+  if (!Array.isArray(issues) || issues.length === 0) {
+    return;
+  }
+  let floor;
+  let blockedByHumanLabelName;
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    );
+    floor = config?.autopilotSuitability?.floor;
+    blockedByHumanLabelName = config?.labels?.blockedByHumanLabelName;
+  } catch {
+    floor = undefined;
+    blockedByHumanLabelName = undefined;
+  }
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
+    floor,
+    markerPrefix: options.markerPrefix,
+    blockedByHumanLabelName,
+  });
+  for (const warning of warnings) {
+    report.warnings.push(warning);
+  }
+}
+export function parsePrimaryWorktreePath(porcelain) {
+  if (typeof porcelain !== 'string') {
+    return null;
+  }
+  // Split on CRLF or LF so a CRLF porcelain line parses (a `\r` is not
+  // matched by `.` and `$` does not anchor before a trailing `\r`); this
+  // matches the `/\r?\n/` splitting used by the sibling helpers in this
+  // file.
+  const lines = porcelain.split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^worktree (.+)$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+export const DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS = [
+  'issue/*',
+  'roadmap-audit/*',
+];
+/**
+ * Convert a shell-style branch glob to an anchored RegExp, matching the
+ * core.hooksPath hook's POSIX `case` semantics: `*` (any run), `?` (any
+ * one character), and bracket expressions (`[...]`, `[!...]`/`[^...]`).
+ * A malformed glob yields a never-matching RegExp rather than throwing.
+ */
+function branchGlobToRegExp(pattern) {
+  let out = '^';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '*') {
+      out += '.*';
+      i += 1;
+    } else if (ch === '?') {
+      out += '.';
+      i += 1;
+    } else if (ch === '[') {
+      // POSIX glob bracket expression, matching the hook's `case`
+      // semantics. A `]` immediately after `[`, `[!`, or `[^` is a
+      // literal member rather than the terminator.
+      let j = i + 1;
+      if (pattern[j] === '!' || pattern[j] === '^') j += 1;
+      if (pattern[j] === ']') j += 1;
+      while (j < pattern.length && pattern[j] !== ']') j += 1;
+      if (j >= pattern.length) {
+        out += '\\['; // unterminated — treat the `[` as a literal
+        i += 1;
+      } else {
+        const body = pattern.slice(i + 1, j);
+        const negated = body[0] === '!' || body[0] === '^';
+        const members = (negated ? body.slice(1) : body)
+          .replace(/\\/g, '\\\\')
+          .replace(/\]/g, '\\]');
+        out += `[${negated ? '^' : ''}${members}]`;
+        i = j + 1;
+      }
+    } else {
+      out += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+      i += 1;
+    }
+  }
+  try {
+    return new RegExp(`${out}$`);
+  } catch {
+    return /(?!)/; // malformed glob: never matches, never crashes
+  }
+}
+export function classifyPrimaryHead(
+  branch,
+  patterns = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+) {
+  if (typeof branch !== 'string' || branch.length === 0) {
+    return { isB1Violation: false, kind: 'unknown' };
+  }
+  const matchedPattern = patterns.find((pattern) =>
+    branchGlobToRegExp(pattern).test(branch),
+  );
+  if (matchedPattern === undefined) {
+    return { isB1Violation: false, kind: 'other' };
+  }
+  // Derive the kind from the matched pattern, not the branch name, so a
+  // custom glob (e.g. "*") is reported as a generic implementation
+  // branch even when the branch happens to start with issue/.
+  if (matchedPattern === 'issue/*') {
+    return { isB1Violation: true, kind: 'issue' };
+  }
+  if (matchedPattern === 'roadmap-audit/*') {
+    return { isB1Violation: true, kind: 'roadmap-audit' };
+  }
+  return { isB1Violation: true, kind: 'implementation' };
+}
+export function findPlaceholders(text) {
+  return [...text.matchAll(/\{\{\s*[A-Za-z0-9_-]+\s*\}\}/g)].map(
+    (match) => match[0],
+  );
+}
+/**
+ * Find unresolved `{{…}}` placeholders in one file's text. Markdown docs
+ * under `docs/` legitimately *document* placeholder names inside code
+ * spans, so those are stripped first to avoid false positives. Every
+ * other file (including `.github/instructions/*.md`, whose marker
+ * examples may contain unsubstituted placeholders inside inline code or
+ * HTML comments) is scanned raw, so a real leftover is still detected.
+ */
+export function scanFileForPlaceholders(file, text) {
+  const documentsPlaceholders =
+    file.startsWith('docs/') && file.endsWith('.md');
+  return findPlaceholders(
+    documentsPlaceholders ? stripMarkdownNonText(text) : text,
+  );
+}
+export function extractMarkerPrefixes(text) {
+  // The negative lookahead keeps each match to a complete marker token
+  // (e.g. `idd-skill-blocked-by:` or `idd-skill-roadmap-id`), so a
+  // prose/heading slug such as
+  // `diagnostic-all-candidates-blocked-by-an-open-roadmap` is not
+  // mis-read as a marker prefix.
+  const roadmap = [
+    ...text.matchAll(
+      /([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)-roadmap-id(?![A-Za-z0-9-])/g,
+    ),
+  ].map((match) => match[1]);
+  const blockedBy = [
+    ...text.matchAll(
+      /([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)-blocked-by(?![A-Za-z0-9-])/g,
+    ),
+  ].map((match) => match[1]);
+  return {
+    roadmap: unique(roadmap),
+    blockedBy: unique(blockedBy),
+  };
+}
+function checkRequiredFiles(_files, report) {
+  const required = [
+    '.github/instructions/idd-overview-core.instructions.md',
+    '.github/instructions/idd-discover.instructions.md',
+    '.github/instructions/idd-suitability.instructions.md',
+    '.github/instructions/idd-claim.instructions.md',
+    '.github/instructions/idd-work.instructions.md',
+    '.github/instructions/idd-pr-submit.instructions.md',
+    '.github/instructions/idd-ci.instructions.md',
+    '.github/instructions/idd-review-snapshot.instructions.md',
+    '.github/instructions/idd-review-triage.instructions.md',
+    '.github/instructions/idd-review-fix.instructions.md',
+    '.github/instructions/idd-pre-merge.instructions.md',
+    '.github/instructions/idd-merge-handoff.instructions.md',
+    '.github/instructions/idd-merge.instructions.md',
+    '.github/instructions/idd-resume.instructions.md',
+    '.github/instructions/idd-resume-stall.instructions.md',
+    '.github/instructions/idd-advisory-wait.instructions.md',
+    'docs/getting-started.md',
+    'docs/concepts.md',
+    'docs/customization.md',
+    'docs/reference.md',
+    'docs/idd-workflow.md',
+    'docs/idd-review-policy-profiles.md',
+    'docs/idd-helper-scripts.md',
+    'docs/idd-comment-minimization.md',
+    'docs/permissions.md',
+    'docs/policy-constants.md',
+  ];
+  const profileFiles = [
+    'profiles/README.md',
+    'profiles/human-required/README.md',
+    'profiles/no-advisory/README.md',
+    'profiles/external-bot/README.md',
+  ];
+  const missingRequired = required.filter(
+    (file) => !exists(join(report.root, file)),
+  );
+  const missingProfiles = profileFiles.filter(
+    (file) => !exists(join(report.root, file)),
+  );
+  if (missingRequired.length > 0) {
+    report.errors.push(
+      `missing required IDD files: ${missingRequired.join(', ')}`,
+    );
+  } else {
+    report.passes.push('required instruction and reference files are present');
+  }
+  if (missingProfiles.length > 0) {
+    report.warnings.push(
+      `missing non-default profile files (expected for adopters): ${missingProfiles.join(', ')}`,
+    );
+  } else {
+    report.passes.push('profile artifacts are present');
+  }
+}
+function checkPlaceholders(root, files, report) {
+  const distributionSource =
+    exists(join(root, 'idd-template/ONBOARDING.md')) &&
+    exists(join(root, 'audit/sync-manifest.json'));
+  const excludedPrefixes = [
+    'idd-template/',
+    'fixtures/',
+    'tests/fixtures/',
+    'tests/',
+    '.git/',
+  ];
+  if (distributionSource) {
+    excludedPrefixes.push('.github/instructions/', 'audit/');
+  }
+  const hits = [];
+  for (const file of files) {
+    if (excludedPrefixes.some((prefix) => file.startsWith(prefix))) {
+      continue;
+    }
+    const absolutePath = join(root, file);
+    let text = '';
+    try {
+      text = readFileSync(absolutePath, 'utf8');
+    } catch {
+      continue;
+    }
+    const placeholders = scanFileForPlaceholders(file, text);
+    if (placeholders.length === 0) {
+      continue;
+    }
+    hits.push(`${file}: ${unique(placeholders).join(', ')}`);
+  }
+  if (hits.length > 0) {
+    report.errors.push(
+      `unresolved placeholders found: ${hits.slice(0, 10).join(' | ')}`,
+    );
+    return;
+  }
+  report.passes.push('no unresolved {{...}} placeholders in IDD-managed files');
+}
+function checkMarkerPrefixes(root, report) {
+  const discoverPath = join(
+    root,
+    '.github/instructions/idd-discover.instructions.md',
+  );
+  const overviewPath = join(
+    root,
+    '.github/instructions/idd-overview-core.instructions.md',
+  );
+  let discover = '';
+  let overview = '';
+  try {
+    discover = readFileSync(discoverPath, 'utf8');
+    overview = readFileSync(overviewPath, 'utf8');
+  } catch {
+    report.warnings.push(
+      'marker-prefix checks skipped because discover/overview files are missing',
+    );
+    return null;
+  }
+  const result = evaluateMarkerPrefixConsistency(
+    extractMarkerPrefixes(discover),
+    extractMarkerPrefixes(overview),
+  );
+  if (result.skip) {
+    report.warnings.push(
+      'marker-prefix checks skipped because no resolved marker prefixes were found',
+    );
+    return null;
+  }
+  if (result.error) {
+    report.errors.push(result.error);
+    return null;
+  }
+  report.passes.push(
+    `marker prefix is valid and consistent (${result.prefix})`,
+  );
+  return result.prefix ?? null;
+}
+/**
+ * Decide whether the marker prefixes extracted from the discover and
+ * overview instruction files are valid and consistent. Pure (no I/O), so
+ * it can be unit-tested. Empty sets impose no constraint (a file may not
+ * reference roadmap-id/blocked-by markers at all — e.g. overview-core,
+ * which defines claim markers, not roadmap markers), but an explicit
+ * all-prefixes guard still catches a mismatch hidden across different
+ * marker types (e.g. discover uses `a-roadmap-id` while overview uses
+ * `b-blocked-by`).
+ */
+export function evaluateMarkerPrefixConsistency(
+  discoverPrefixes,
+  overviewPrefixes,
+) {
+  const allPrefixes = unique([
+    ...discoverPrefixes.roadmap,
+    ...discoverPrefixes.blockedBy,
+    ...overviewPrefixes.roadmap,
+    ...overviewPrefixes.blockedBy,
+  ]);
+  if (allPrefixes.length === 0) {
+    return { skip: true };
+  }
+  const invalid = allPrefixes.filter(
+    (prefix) => !/^[a-z][a-z0-9-]{1,31}$/.test(prefix),
+  );
+  if (invalid.length > 0) {
+    return { error: `invalid marker prefixes: ${invalid.join(', ')}` };
+  }
+  // Compare only populated sets so a file that does not reference these
+  // markers at all imposes no constraint.
+  const consistent = (left, right) =>
+    left.length === 0 || right.length === 0 || sameMembers(left, right);
+  if (!consistent(discoverPrefixes.roadmap, discoverPrefixes.blockedBy)) {
+    return {
+      error:
+        'discover marker prefixes differ between roadmap-id and blocked-by',
+    };
+  }
+  if (!consistent(overviewPrefixes.roadmap, overviewPrefixes.blockedBy)) {
+    return {
+      error:
+        'overview marker prefixes differ between roadmap-id and blocked-by',
+    };
+  }
+  if (
+    !consistent(discoverPrefixes.roadmap, overviewPrefixes.roadmap) ||
+    !consistent(discoverPrefixes.blockedBy, overviewPrefixes.blockedBy)
+  ) {
+    return {
+      error:
+        'marker prefixes differ between discover and overview instructions',
+    };
+  }
+  // Catch a mismatch the empty-tolerant pairwise checks miss: two files
+  // referencing different marker types with different prefixes.
+  if (allPrefixes.length > 1) {
+    return {
+      error: `marker prefixes are inconsistent across discover/overview instructions: ${allPrefixes.join(', ')}`,
+    };
+  }
+  return { prefix: allPrefixes[0] };
+}
+// The Project commands table normally lives in idd-overview-core, but a
+// router/core split can keep it in idd-overview instead. Resolve whichever
+// candidate carries a non-empty table rather than hardcoding one file.
+const PROJECT_COMMANDS_CANDIDATE_FILES = [
+  '.github/instructions/idd-overview-core.instructions.md',
+  '.github/instructions/idd-overview.instructions.md',
+];
+export function checkProjectCommands(root, report) {
+  let commands = null;
+  let usedPath = '';
+  for (const rel of PROJECT_COMMANDS_CANDIDATE_FILES) {
+    let text;
+    try {
+      text = readFileSync(join(root, rel), 'utf8');
+    } catch {
+      continue;
+    }
+    const parsed = parseProjectCommandRows(text);
+    if (parsed.size > 0) {
+      commands = parsed;
+      usedPath = rel;
+      break;
+    }
+  }
+  if (!commands) {
+    report.errors.push(
+      `cannot find a Project commands table in any of: ${PROJECT_COMMANDS_CANDIDATE_FILES.join(', ')}`,
+    );
+    return null;
+  }
+  const requiredRows = [
+    'fix-validate',
+    'pre-push-validate',
+    'post-fix-validate',
+    'install-deps',
+  ];
+  const missingRows = requiredRows.filter((row) => !commands.has(row));
+  if (missingRows.length > 0) {
+    report.errors.push(
+      `project commands table (${usedPath}) is missing rows: ${missingRows.join(', ')}`,
+    );
+    return null;
+  }
+  const noOps = requiredRows.filter((row) => commands.get(row) === 'true');
+  if (noOps.length === requiredRows.length) {
+    report.warnings.push(
+      'all primary command rows are set to `true` (no-op substitutions)',
+    );
+  } else {
+    report.passes.push('project commands table has non-empty command values');
+  }
+  return commands;
+}
+function checkCommandResidueAndConsistency(
+  root,
+  markerPrefix,
+  projectCommands,
+  report,
+) {
+  if (!(projectCommands instanceof Map)) {
+    return;
+  }
+  const policyCommands = loadPolicyCommands(root);
+  const policyCommandMap =
+    policyCommands instanceof Map ? policyCommands : new Map();
+  const sharedKeys = unique(
+    [...policyCommandMap.keys()].filter((key) => projectCommands.has(key)),
+  ).sort();
+  for (const key of sharedKeys) {
+    const configValue = normalizeCommandValue(policyCommandMap.get(key));
+    const overviewValue = normalizeCommandValue(projectCommands.get(key));
+    if (
+      !isConcreteCommandValue(configValue) ||
+      !isConcreteCommandValue(overviewValue)
+    ) {
+      continue;
+    }
+    if (configValue !== overviewValue) {
+      report.warnings.push(
+        `command mismatch between .github/idd/config.json and overview table for "${key}": config="${configValue}" overview="${overviewValue}"`,
+      );
+    }
+  }
+  if (typeof markerPrefix !== 'string' || markerPrefix.length === 0) {
+    report.warnings.push(
+      'toolchain residue checks skipped because marker prefix could not be resolved',
+    );
+    return;
+  }
+  if (markerPrefix === 'idd-skill') {
+    return;
+  }
+  const residueMessages = new Set();
+  for (const [source, commands] of [
+    ['.github/idd/config.json', policyCommandMap],
+    ['overview project commands table', projectCommands],
+  ]) {
+    for (const [key, value] of commands.entries()) {
+      const normalized = normalizeCommandValue(value);
+      if (normalized === null) {
+        continue;
+      }
+      const token = findToolchainResidueToken(normalized);
+      if (!token) {
+        continue;
+      }
+      residueMessages.add(
+        `toolchain residue detected for marker prefix "${markerPrefix}": ${source} "${key}" contains "${token}"`,
+      );
+    }
+  }
+  for (const message of residueMessages) {
+    report.warnings.push(message);
+  }
+}
+function loadPolicyCommands(root) {
+  const configPath = join(root, '.github/idd/config.json');
+  if (!exists(configPath)) {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  const commands = parsed?.commands;
+  if (!commands || typeof commands !== 'object' || Array.isArray(commands)) {
+    return null;
+  }
+  return new Map(
+    Object.entries(commands).filter((entry) => typeof entry[1] === 'string'),
+  );
+}
+function normalizeCommandValue(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return value.trim();
+}
+function isConcreteCommandValue(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+  if (value.toLowerCase() === 'true') {
+    return false;
+  }
+  return !/\{\{\s*[A-Za-z0-9_-]+\s*\}\}/.test(value);
+}
+function findToolchainResidueToken(value) {
+  for (const token of ['dprint', 'markdownlint-cli2', 'cspell']) {
+    if (new RegExp(`\\b${escapeRegex(token)}\\b`, 'i').test(value)) {
+      return token;
+    }
+  }
+  return null;
+}
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+export function checkPolicySignals(root, report) {
+  const files = [
+    'README.md',
+    'README.ja.md',
+    'AGENTS.md',
+    'CLAUDE.md',
+    'GEMINI.md',
+    '.github/copilot-instructions.md',
+    'docs/idd-policy.md',
+    '.github/idd/config.json',
+    'idd-policy.json',
+  ];
+  const existing = files.filter((file) => exists(join(root, file)));
+  const corpus = existing
+    .map((file) => readFileSync(join(root, file), 'utf8'))
+    .join('\n');
+  const mergePolicies = [
+    'fully_autonomous_merge',
+    'human_merge',
+    'separate_merge_agent',
+  ];
+  if (!mergePolicies.some((policy) => corpus.includes(policy))) {
+    report.errors.push('merge policy signal not found in docs or entry files');
+  } else {
+    report.passes.push('merge policy signal found');
+  }
+  const reviewPolicySignals = [
+    'copilot-advisory',
+    'copilot advisory',
+    'no-advisory',
+    'human-required',
+    'external-bot',
+    'strict-reviewer-resolve',
+  ];
+  if (
+    !reviewPolicySignals.some((signal) => corpus.toLowerCase().includes(signal))
+  ) {
+    report.warnings.push(
+      'review policy signal not found in docs or entry files',
+    );
+  } else {
+    report.passes.push('review policy signal found');
+  }
+}
+function checkHelperRuntimeConfig(root, report) {
+  const candidates = ['.github/idd/config.json', 'idd-policy.json'];
+  for (const file of candidates) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      report.errors.push(`${file} is not valid JSON`);
+      continue;
+    }
+    const helperRuntime = inspectHelperRuntimeConfig(config);
+    if (helperRuntime.status === 'absent') {
+      report.passes.push(
+        `${file} leaves helperRuntime unset (instructions-only fallback)`,
+      );
+      continue;
+    }
+    if (helperRuntime.status === 'invalid') {
+      report.errors.push(`${file}: ${helperRuntime.reason}`);
+      continue;
+    }
+    report.passes.push(
+      `${file} declares helper runtime profile "${helperRuntime.profile}"`,
+    );
+  }
+}
+// The two live-config filenames idd-doctor already recognizes elsewhere in
+// this file (checkHelperRuntimeConfig's and checkTemplateVersionSignal's own
+// candidate lists): `.github/idd/config.json` is canonical, `idd-policy.json`
+// is the legacy top-level name. Both get the same schema check so an adopter
+// still on the legacy filename gets the same #1359 coverage.
+const LIVE_CONFIG_CANDIDATE_FILES = [
+  '.github/idd/config.json',
+  'idd-policy.json',
+];
+const LIVE_CONFIG_ERRORS_SHOWN = 10;
+/**
+ * Resolve the repository's configured `helperRuntime` (`profile` plus the
+ * optional pinned `packageSpec`, idd-skill#1731) for building profile-aware
+ * remediation text (see `formatCleanupBacklogRemediation` below), trying
+ * the same live-config candidates as `checkHelperRuntimeConfig` in
+ * declaration order.
+ *
+ * The **first present candidate wins outright** -- whether it declares a
+ * valid profile, leaves `helperRuntime` absent, or is malformed -- and the
+ * search never falls through to a later (legacy) candidate once a present
+ * file has been evaluated. A present canonical `.github/idd/config.json`
+ * that omits `helperRuntime` is an intentional `instructions-only`
+ * declaration, not an invitation to consult a stale `idd-policy.json` left
+ * over from before a migration to the canonical filename -- silently
+ * picking up the legacy file's profile there would build a remediation
+ * command for a runtime the repository no longer uses (idd-skill#1718
+ * review: both Copilot and the secondary advisory bot flagged this
+ * independently). Only an *absent* (nonexistent) candidate file is
+ * skipped in favor of the next one.
+ *
+ * Defaults to `{ profile: 'instructions-only', packageSpec: '' }` -- the
+ * safe, no-runnable-command fallback -- when no candidate file exists at
+ * all, the first present one is not valid JSON, or it does not declare a
+ * valid `helperRuntime.profile`; those cases are already surfaced as their
+ * own findings by `checkHelperRuntimeConfig` / `checkLiveConfigSchema`;
+ * this resolver only needs a fail-closed profile to build remediation text
+ * from, not a second diagnostic. `packageSpec` is `''` (meaning: fall back
+ * to the default package spec) whenever it isn't configured, even when
+ * `profile` itself resolved successfully.
+ *
+ * Both `resolveConfiguredHelperRuntimeProfile` and
+ * `resolveConfiguredHelperRuntimePackageSpec` below delegate to this single
+ * internal walk so the file-candidate-resolution invariant above lives in
+ * exactly one place.
+ */
+function resolveConfiguredHelperRuntime(root) {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      return { profile: 'instructions-only', packageSpec: '' };
+    }
+    const helperRuntime = inspectHelperRuntimeConfig(config);
+    return helperRuntime.status === 'ok'
+      ? {
+          profile: helperRuntime.profile,
+          packageSpec: helperRuntime.packageSpec ?? '',
+        }
+      : { profile: 'instructions-only', packageSpec: '' };
+  }
+  return { profile: 'instructions-only', packageSpec: '' };
+}
+export function resolveConfiguredHelperRuntimeProfile(root) {
+  return resolveConfiguredHelperRuntime(root).profile;
+}
+/**
+ * Resolve the repository's configured `helperRuntime.packageSpec`
+ * (idd-skill#1731), for threading a pinned ephemeral-npx/package-manager
+ * spec into remediation text instead of always falling back to the
+ * mutable default archive URL. Returns `''` (use the default) under the
+ * same fail-closed conditions as `resolveConfiguredHelperRuntimeProfile`:
+ * no candidate file, invalid JSON, an invalid `helperRuntime`, or simply no
+ * `packageSpec` configured.
+ */
+export function resolveConfiguredHelperRuntimePackageSpec(root) {
+  return resolveConfiguredHelperRuntime(root).packageSpec;
+}
+/**
+ * Decide whether a parsed live-config document is a schema finding, given
+ * the canonical policy schema and the file it was read from (for the
+ * message). Pure (no I/O) so it can be unit-tested directly. Returns `null`
+ * when `config` validates cleanly.
+ *
+ * This is the live-config counterpart to the `ciWait`/`advisoryWait`
+ * readers' own subtree-scoped validation (#1359): those readers only
+ * revert their own section on their own section's error, so a malformed
+ * config (an unknown top-level key, `additionalProperties: false`
+ * rejecting an adopter typo, a typo'd enum anywhere in the document, ...)
+ * would otherwise pass through with no diagnostic at all. This check
+ * surfaces every schema error against the whole document instead, so a
+ * malformed live config no longer passes idd-doctor silently.
+ */
+export function classifyLiveConfigSchemaFinding(
+  config,
+  schema,
+  file = '.github/idd/config.json',
+) {
+  const errors = validate(config, schema);
+  if (errors.length === 0) {
+    return null;
+  }
+  const shown = errors.slice(0, LIVE_CONFIG_ERRORS_SHOWN);
+  const remainder = errors.length - shown.length;
+  const suffix = remainder > 0 ? ` (and ${remainder} more)` : '';
+  return {
+    level: 'error',
+    message: `${file} fails schema validation against policy.schema.json: ${shown.join('; ')}${suffix}`,
+  };
+}
+/**
+ * Validate each present live-config file (`.github/idd/config.json` and the
+ * legacy `idd-policy.json`) against the canonical policy schema and report
+ * any errors as a doctor finding. Skips a candidate silently when it is
+ * absent (nothing to validate) or is not valid JSON (already reported by
+ * checkHelperRuntimeConfig above); skips the whole check when the bundled
+ * schema itself cannot be loaded (a bootstrap edge case, not a live-config
+ * problem).
+ */
+export function checkLiveConfigSchema(root, report) {
+  let schema;
+  try {
+    schema = loadJson('schemas/policy.schema.json');
+  } catch {
+    report.warnings.push(
+      'live-config schema check skipped: schemas/policy.schema.json could not be loaded',
+    );
+    return;
+  }
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const configPath = join(root, file);
+    if (!exists(configPath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const finding = classifyLiveConfigSchemaFinding(config, schema, file);
+    if (!finding) {
+      report.passes.push(`${file} validates against policy.schema.json`);
+      continue;
+    }
+    report.errors.push(finding.message);
+  }
+}
+// Adding a future anchor is a one-line addition here — no new branching
+// logic — as long as its prose lives in the same Thresholds section
+// parsed by parseThresholdsProseHours.
+const CLAIM_TIMING_ANCHORS = [
+  {
+    configKey: 'staleAge',
+    label: 'claimTiming.staleAge',
+    proseHoursKey: 'staleAgeHours',
+  },
+  {
+    configKey: 'heartbeatInterval',
+    label: 'claimTiming.heartbeatInterval',
+    proseHoursKey: 'heartbeatIntervalHours',
+  },
+];
+/**
+ * Parse an ISO 8601 duration to whole hours. Returns null when the input
+ * is not a string, does not match the ISO 8601 duration grammar, carries
+ * sub-hour precision (minutes/seconds) — the Thresholds prose only ever
+ * states whole hours, so a sub-hour config value has no prose counterpart
+ * to compare against — or resolves to zero hours (`PT0H`, ...), which
+ * matches the grammar but is operationally meaningless as a
+ * stale-age/heartbeat value. A negative duration cannot occur: the
+ * grammar has no sign, so a leading `-` fails the `^P` anchor outright.
+ *
+ * The lookaheads (`(?=\d|T\d)` after `P`, `(?=\d)` after `T`) mirror
+ * `schemas/policy.schema.json`'s `claimTiming.staleAge`/
+ * `heartbeatInterval` pattern exactly, so this rejects the same
+ * dangling-designator strings the schema does (bare `P`, bare `PT`,
+ * `P1DT` with no time components after `T`) at the match stage, instead
+ * of accepting them as a syntactically-valid zero/malformed duration
+ * that a looser grammar would silently normalize.
+ */
+export function parseIsoDurationToHours(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const match =
+    /^P(?=\d|T\d)(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
+      value,
+    );
+  if (!match) {
+    return null;
+  }
+  const [, days, hours, minutes, seconds] = match;
+  if (Number(minutes ?? 0) !== 0 || Number(seconds ?? 0) !== 0) {
+    return null;
+  }
+  const totalHours = Number(days ?? 0) * 24 + Number(hours ?? 0);
+  return totalHours > 0 ? totalHours : null;
+}
+// Matches the start of the next Markdown list item: a newline, optional
+// leading indentation (nested/indented lists), then one of the three
+// common bullet markers and at least one space. Whitespace-tolerant so
+// an indented or differently-marked list still bounds correctly instead
+// of letting the slice run past the intended bullet.
+const NEXT_BULLET_PATTERN = /\n[ \t]*[-*+]\s+/;
+/**
+ * Slice `section` down to just the bullet introduced by `bulletLabel`
+ * (e.g. `**Stale**:`), stopping before the next list item (see
+ * {@link NEXT_BULLET_PATTERN}) or at the end of `section`. Returns null
+ * when `bulletLabel` is not found. Bounding the slice to one bullet is
+ * what stops the anchor regexes in {@link parseThresholdsProseHours}
+ * from crossing into an unrelated number that happens to appear in a
+ * *different* bullet.
+ */
+function extractBulletText(section, bulletLabel) {
+  const start = section.indexOf(bulletLabel);
+  if (start === -1) {
+    return null;
+  }
+  const rest = section.slice(start);
+  const nextBulletMatch = NEXT_BULLET_PATTERN.exec(rest);
+  return nextBulletMatch ? rest.slice(0, nextBulletMatch.index) : rest;
+}
+/**
+ * Extract the stale-age and heartbeat-interval hour values the
+ * `## Thresholds` section of overview-core prose states. Returns null for
+ * the whole result when the section heading itself is not found (the
+ * section was renamed or removed); returns null for an individual field
+ * when that field's own bullet, or its anchor phrase within that bullet,
+ * is not found (the bullet was reworded past recognition or removed).
+ * Neither case is an error — the caller skips the comparison for what it
+ * cannot parse. Each anchor regex is matched only within its own
+ * bullet's text (see {@link extractBulletText}), so a number in an
+ * unrelated bullet is never misattributed to this field.
+ */
+export function parseThresholdsProseHours(overviewCoreText) {
+  const sectionStart = overviewCoreText.indexOf('## Thresholds');
+  if (sectionStart === -1) {
+    return null;
+  }
+  const nextHeading = overviewCoreText.indexOf('\n## ', sectionStart + 1);
+  const section = overviewCoreText.slice(
+    sectionStart,
+    nextHeading === -1 ? undefined : nextHeading,
+  );
+  const staleBullet = extractBulletText(section, '**Stale**:');
+  const heartbeatBullet = extractBulletText(section, '**Heartbeat**:');
+  const staleMatch = staleBullet ? /≥\s*(\d+)\s*h\b/.exec(staleBullet) : null;
+  const heartbeatMatch = heartbeatBullet
+    ? /every\s+(\d+)\s*h\b/.exec(heartbeatBullet)
+    : null;
+  return {
+    staleAgeHours: staleMatch ? Number(staleMatch[1]) : null,
+    heartbeatIntervalHours: heartbeatMatch ? Number(heartbeatMatch[1]) : null,
+  };
+}
+/**
+ * Compare `.github/idd/config.json`'s claimTiming values against the
+ * overview-core Thresholds prose. Returns a warning-level finding naming
+ * both locations and both values only when a config value and its
+ * matching prose value are both parseable AND numerically differ. Returns
+ * null (no finding) when the section/bullet cannot be parsed, when either
+ * side is unparseable, or when the values agree — this check never
+ * produces an error, per its acceptance criteria, and degrades silently
+ * on a customized adopter repo rather than false-failing it.
+ */
+export function classifyClaimTimingConsistency(claimTiming, overviewCoreText) {
+  if (!claimTiming) {
+    return null;
+  }
+  const prose = parseThresholdsProseHours(overviewCoreText);
+  if (!prose) {
+    return null;
+  }
+  const mismatches = [];
+  for (const anchor of CLAIM_TIMING_ANCHORS) {
+    const configHours = parseIsoDurationToHours(claimTiming[anchor.configKey]);
+    const proseHours = prose[anchor.proseHoursKey];
+    if (configHours === null || proseHours === null) {
+      continue;
+    }
+    if (configHours !== proseHours) {
+      mismatches.push(
+        `${anchor.label} is ${configHours} h in .github/idd/config.json but ` +
+          `${proseHours} h in the Thresholds section of ` +
+          '.github/instructions/idd-overview-core.instructions.md',
+      );
+    }
+  }
+  if (mismatches.length === 0) {
+    return null;
+  }
+  return {
+    level: 'warning',
+    message: `config↔instruction-prose policy-value drift: ${mismatches.join('; ')}.`,
+  };
+}
+export function checkClaimTimingConsistency(root, report) {
+  const read = (relativePath) => {
+    try {
+      return readFileSync(join(root, relativePath), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  const configText = read('.github/idd/config.json');
+  const overviewCoreText = read(
+    '.github/instructions/idd-overview-core.instructions.md',
+  );
+  if (configText === null || overviewCoreText === null) {
+    return;
+  }
+  let config;
+  try {
+    config = JSON.parse(configText);
+  } catch {
+    return;
+  }
+  const claimTiming = config?.claimTiming;
+  const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
+  if (finding) {
+    report.warnings.push(finding.message);
+  }
+}
+// The two packages implicated in the #1164 incident: a stale node_modules
+// install silently masked a real `pnpm run typecheck` break on fresh
+// installs, because the break only surfaced once `@types/node` was
+// actually installed at its lockfile-resolved version. Kept as a single
+// array literal so extending coverage to another package is a one-line
+// change, not a redesign.
+const DEPENDENCY_VERSION_DRIFT_PACKAGES = ['typescript', '@types/node'];
+/**
+ * Extract the resolved `version:` pinned for `packageName` under the root
+ * `.` importer's `dependencies`/`devDependencies` maps in a `pnpm-lock.yaml`
+ * text (lockfileVersion 9's nested `specifier:`/`version:` shape). Pure (no
+ * I/O) so it can be unit-tested directly. Returns `null` when the
+ * `importers:` section, the root `.` importer, or the named package's own
+ * entry cannot be found — a miss here is a staleness signal, not a
+ * required-file check, so the caller must skip silently rather than treat
+ * `null` as an error. A version resolved with a trailing peer-dependency
+ * annotation (e.g. `21.2.0(@types/node@26.1.0)`) is stripped down to the
+ * bare version so it compares cleanly against an installed package's plain
+ * `package.json` `version` field.
+ */
+export function parseLockfileImporterVersion(lockfileText, packageName) {
+  if (typeof lockfileText !== 'string' || lockfileText.length === 0) {
+    return null;
+  }
+  const normalized = lockfileText.replace(/\r\n/g, '\n');
+  const importersIndex = normalized.indexOf('\nimporters:');
+  if (importersIndex === -1) {
+    return null;
+  }
+  const rootMarker = '\n  .:\n';
+  const rootIndex = normalized.indexOf(rootMarker, importersIndex);
+  if (rootIndex === -1) {
+    return null;
+  }
+  const blockStart = rootIndex + rootMarker.length;
+  // The root importer's own block ends at the next line indented 2
+  // columns or fewer: either a sibling importer entry (workspace repos)
+  // or a top-level key such as `packages:`.
+  const boundaryMatch = /\n {0,2}\S/.exec(normalized.slice(blockStart));
+  const blockEnd = boundaryMatch
+    ? blockStart + (boundaryMatch.index ?? 0)
+    : normalized.length;
+  const block = normalized.slice(blockStart, blockEnd);
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const entryPattern = new RegExp(
+    `\\n {6}'?${escaped}'?:\\n(?:.*\\n)*? {8}version: *([^\\n]+)`,
+  );
+  const match = entryPattern.exec(block);
+  if (!match) {
+    return null;
+  }
+  const bare = match[1]
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .split('(')[0]
+    .trim();
+  return bare.length > 0 ? bare : null;
+}
+/**
+ * Compare each package's installed `node_modules` version against what
+ * `pnpm-lock.yaml` resolves for it, and produce one warning string for
+ * every entry where both sides are known and differ. Pure (no I/O) so it
+ * can be unit-tested directly. An entry with either side unknown (package
+ * not installed, or not found in the lockfile) is a staleness signal only
+ * — skipped without a warning, per this check's acceptance criteria.
+ */
+export function evaluateDependencyVersionDrift(entries) {
+  const warnings = [];
+  for (const { name, installed, resolved } of entries) {
+    if (!installed || !resolved || installed === resolved) {
+      continue;
+    }
+    warnings.push(
+      `dependency version drift: node_modules/${name} is installed at ${installed}, but pnpm-lock.yaml resolves ${resolved}. Run pnpm install to sync node_modules with the lockfile.`,
+    );
+  }
+  return warnings;
+}
+function readInstalledPackageVersion(root, name) {
+  const packageJsonPath = join(root, 'node_modules', name, 'package.json');
+  if (!exists(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+/**
+ * Warn (never fail) when the installed `node_modules/typescript` or
+ * `node_modules/@types/node` version drifts from what `pnpm-lock.yaml`
+ * resolves for this project's own root dependency. This is the local
+ * diagnostic half of the #1198 fix: it surfaces a stale local install
+ * *before* an agent chases a phantom typecheck failure caused by it — see
+ * the #1164 incident, where a stale `@types/node` install masked a real
+ * break for fresh installs. Skips silently (no warning, no error) when
+ * `pnpm-lock.yaml`, `node_modules`, or a package's matching lockfile entry
+ * is absent; this is a staleness signal, not a required-file check.
+ */
+export function checkDependencyVersionDrift(root, report) {
+  let lockfileText;
+  try {
+    lockfileText = readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8');
+  } catch {
+    return;
+  }
+  const entries = DEPENDENCY_VERSION_DRIFT_PACKAGES.map((name) => ({
+    name,
+    installed: readInstalledPackageVersion(root, name),
+    resolved: parseLockfileImporterVersion(lockfileText, name),
+  }));
+  for (const warning of evaluateDependencyVersionDrift(entries)) {
+    report.warnings.push(warning);
+  }
+}
+function checkAgentEntryFiles(root, report) {
+  for (const file of ['AGENTS.md', 'CLAUDE.md', 'GEMINI.md']) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      report.warnings.push(
+        `${file} is missing (allowed only if operator opted out)`,
+      );
+      continue;
+    }
+    const text = readFileSync(absolutePath, 'utf8');
+    if (!text.includes('docs/idd-workflow.md')) {
+      report.errors.push(
+        `${file} exists but does not reference docs/idd-workflow.md`,
+      );
+      continue;
+    }
+    report.passes.push(`${file} references docs/idd-workflow.md`);
+  }
+}
+function checkTemplateVersionSignal(root, report) {
+  const candidates = [
+    '.github/idd/config.json',
+    'idd-policy.json',
+    'docs/idd-policy.md',
+    'README.md',
+  ];
+  for (const file of candidates) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    const text = readFileSync(absolutePath, 'utf8');
+    if (!/\biddVersion\b/i.test(text) && !/template version/i.test(text)) {
+      continue;
+    }
+    report.passes.push(`template version signal found in ${file}`);
+    return;
+  }
+  report.warnings.push(
+    'template version signal not found (iddVersion/template version)',
+  );
+}
+export function readWorktreeGuardEnabled(root) {
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    );
+    return config?.worktreeGuard?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+/**
+ * Read `worktreeGuard.branchPatterns` from the repo config, falling back
+ * to the default implementation-branch globs when the key is absent,
+ * empty, or malformed. Matches the core.hooksPath hook so idd-doctor and
+ * the hook agree on which branches the guard covers.
+ */
+export function readWorktreeGuardBranchPatterns(root) {
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    );
+    const patterns = config?.worktreeGuard?.branchPatterns;
+    if (
+      Array.isArray(patterns) &&
+      patterns.length > 0 &&
+      patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
+    ) {
+      // Return trimmed patterns: a configured entry with surrounding
+      // whitespace (e.g. `"issue/* "`) otherwise passes validation but
+      // never matches a real branch, silently covering nothing. The
+      // validation above stays fail-closed — any empty/whitespace-only or
+      // non-string entry invalidates the whole list and falls back to the
+      // defaults — so every surviving entry is non-empty after trim.
+      return patterns.map((pattern) => pattern.trim());
+    }
+  } catch {
+    // fall through to defaults
+  }
+  return DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS;
+}
+/**
+ * Decide which worktree-hardening signals are missing from the consuming
+ * repository's imported files. Pure (no I/O): each argument is the file's
+ * text, or `null`/`undefined` when the file is absent (absent files are
+ * skipped, not reported, so this never double-reports a missing required
+ * file). Returns a list of human-readable missing-signal labels.
+ */
+export function findMissingWorktreeHardening({ work, core, doctor } = {}) {
+  const missing = [];
+  if (typeof work === 'string') {
+    if (!/^###\s+Anti-patterns\b/m.test(work)) {
+      missing.push('idd-work B1 Anti-patterns section');
+    }
+    if (!/^###\s+B1 self-check\b/m.test(work)) {
+      missing.push('idd-work B1 self-check section');
+    }
+  }
+  if (typeof core === 'string') {
+    if (!/cwd-vs-claim/.test(core)) {
+      missing.push('overview-core cwd-vs-claim gate');
+    } else if (
+      !/\(local commit,/.test(core) &&
+      !/before any local commit\b/.test(core)
+    ) {
+      // Scope the local-commit signal to the gate's own mutation
+      // enumeration (the opening "(local commit, ..." list and the
+      // closing "before any local commit, ..." sentence) so an unrelated
+      // "local commit" mention elsewhere in the file cannot mask a gate
+      // that still omits commit coverage.
+      missing.push('overview-core cwd-vs-claim local-commit coverage');
+    }
+  }
+  // Only meaningful when idd-doctor is vendored into the repo at all.
+  if (typeof doctor === 'string' && !/checkPrimaryWorktreeHead/.test(doctor)) {
+    missing.push('idd-doctor checkPrimaryWorktreeHead detector');
+  }
+  return missing;
+}
+function checkWorktreeHardeningPresence(root, report) {
+  const read = (relativePath) => {
+    try {
+      return readFileSync(join(root, relativePath), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  const missing = findMissingWorktreeHardening({
+    work: read('.github/instructions/idd-work.instructions.md'),
+    core: read('.github/instructions/idd-overview-core.instructions.md'),
+    doctor: read('scripts/idd-doctor.mjs'),
+  });
+  if (missing.length === 0) {
+    return;
+  }
+  report.warnings.push(
+    `stale import — missing worktree-hardening: ${missing.join('; ')}. ` +
+      'Re-sync the IDD template to adopt the B1 worktree guard; see B1 in ' +
+      '.github/instructions/idd-work.instructions.md.',
+  );
+}
+function checkPrimaryWorktreeHead(root, report, options = {}) {
+  const listResult = runCommand(
+    'git',
+    ['worktree', 'list', '--porcelain'],
+    root,
+  );
+  if (!listResult.ok) {
+    return;
+  }
+  const primaryPath = parsePrimaryWorktreePath(listResult.stdout);
+  if (!primaryPath) {
+    return;
+  }
+  const headResult = runCommand(
+    'git',
+    ['-C', primaryPath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+    root,
+  );
+  if (!headResult.ok) {
+    return;
+  }
+  const branch = headResult.stdout.trim();
+  const classification = classifyPrimaryHead(
+    branch,
+    readWorktreeGuardBranchPatterns(root),
+  );
+  const finding = classifyWorktreeHeadFinding(
+    classification,
+    branch,
+    primaryPath,
+    options.enforce === true,
+  );
+  if (!finding) {
+    return;
+  }
+  if (finding.level === 'error') {
+    report.errors.push(finding.message);
+  } else {
+    report.warnings.push(finding.message);
+  }
+}
+/**
+ * Decide whether a primary-worktree HEAD classification is a finding and,
+ * if so, at what level. Pure (no I/O) so it can be unit-tested directly.
+ *
+ * `enforce` is true when the worktree guard is enabled or `--strict` was
+ * passed; it promotes the finding from a warning to a blocking error.
+ */
+export function classifyWorktreeHeadFinding(
+  classification,
+  branch,
+  primaryPath,
+  enforce,
+) {
+  if (!classification?.isB1Violation) {
+    return null;
+  }
+  const kindLabel =
+    classification.kind === 'issue'
+      ? 'an issue branch'
+      : classification.kind === 'roadmap-audit'
+        ? 'a roadmap-audit branch'
+        : 'an implementation branch';
+  const severity = enforce
+    ? 'B1 violation: this branch must live in a sibling worktree, not the primary worktree (worktree guard enforced)'
+    : 'likely a past B1 violation';
+  return {
+    level: enforce ? 'error' : 'warning',
+    message: `primary worktree HEAD is on ${kindLabel} (${branch}) at ${primaryPath} — ${severity}. See B1 in .github/instructions/idd-work.instructions.md.`,
+  };
+}
+/**
+ * True when a git hook file body wires the B1 worktree guard, i.e. a `.`/
+ * `source` command loads the shared `_idd-worktree-guard.sh` helper. Matching
+ * the sourcing line (not a bare mention) means a hook that only names the
+ * helper in a comment — e.g. a leftover doc line after the source was removed —
+ * correctly reads as inert rather than wired. Pure (no I/O) so the
+ * wired/unwired classification can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not wiring the guard.
+ */
+export function hookWiresWorktreeGuard(content) {
+  return (
+    typeof content === 'string' &&
+    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh/m.test(content)
+  );
+}
+/**
+ * Decide whether the worktree guard is enabled-but-inert in the current
+ * environment and, if so, produce a warning finding. Pure (no I/O) so it can
+ * be unit-tested directly.
+ *
+ * The finding is intentionally a **warning**, never a blocking error: the
+ * idd-doctor CI health gate checks out a detached HEAD (which never wires the
+ * local hook) and must stay green. `headDetached` short-circuits that CI case,
+ * and a warning-level finding keeps the exit code zero even if it ever fires.
+ */
+export function classifyWorktreeGuardActivation({
+  guardEnabled,
+  headDetached,
+  hooksPath,
+  guardWired,
+}) {
+  // Only runs when the guard is opted in.
+  if (!guardEnabled) {
+    return null;
+  }
+  // CI-safe: a detached HEAD (CI checkout of a raw SHA) never wires the hook
+  // and is not a real B1 environment, so stay silent — matching how
+  // `classifyPrimaryHead('HEAD')` reports no violation.
+  if (headDetached) {
+    return null;
+  }
+  // Correctly wired → nothing to report.
+  if (guardWired) {
+    return null;
+  }
+  const shown =
+    typeof hooksPath === 'string' && hooksPath.trim().length > 0
+      ? hooksPath.trim()
+      : '(unset)';
+  return {
+    level: 'warning',
+    message:
+      `worktreeGuard.enabled is true but the commit/push guard is not active ` +
+      `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
+      `commits will NOT be blocked here. Wire it with: ` +
+      `git config core.hooksPath .githooks`,
+  };
+}
+/**
+ * Read the `pre-commit` and `pre-push` hooks at the resolved `core.hooksPath`
+ * and report whether both wire the B1 guard. A relative hooks path resolves
+ * against the repository root; an absolute one is used as-is.
+ */
+function worktreeGuardWiredAt(root, hooksPath) {
+  const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
+  const read = (name) => {
+    try {
+      return readFileSync(join(directory, name), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  return (
+    hookWiresWorktreeGuard(read('pre-commit')) &&
+    hookWiresWorktreeGuard(read('pre-push'))
+  );
+}
+/**
+ * Warn when `worktreeGuard.enabled` is true but the commit/push guard is not
+ * actually wired in this environment (`core.hooksPath` unset or pointing at a
+ * directory that does not source the guard). A fresh coding-agent / ephemeral
+ * checkout never inherits the local `core.hooksPath`, so `enabled` alone can be
+ * silently unenforced. Warning-only and inert on a detached HEAD so the
+ * idd-doctor CI health gate stays green.
+ */
+function checkWorktreeGuardActive(root, report) {
+  if (!readWorktreeGuardEnabled(root)) {
+    return;
+  }
+  // Resolve HEAD; skip on a detached HEAD (CI checks out a raw SHA) or when
+  // git is unavailable (fail-safe: no finding).
+  const headResult = runCommand(
+    'git',
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    root,
+  );
+  if (!headResult.ok) {
+    return;
+  }
+  // A detached HEAD (CI checks out a raw SHA) never wires the local hook and is
+  // not a real B1 environment — return before touching core.hooksPath so the
+  // idd-doctor CI health gate stays green. classifyWorktreeGuardActivation also
+  // guards this case so it can be unit-tested directly.
+  if (headResult.stdout.trim() === 'HEAD') {
+    return;
+  }
+  // Resolve the active hooks path. An unset core.hooksPath makes git exit
+  // non-zero, which reads as unset here.
+  const hooksResult = runCommand(
+    'git',
+    ['config', '--get', 'core.hooksPath'],
+    root,
+  );
+  const hooksPath = hooksResult.ok ? hooksResult.stdout.trim() : '';
+  const guardWired =
+    hooksPath.length > 0 && worktreeGuardWiredAt(root, hooksPath);
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached: false,
+    hooksPath: hooksPath.length > 0 ? hooksPath : null,
+    guardWired,
+  });
+  if (finding) {
+    report.warnings.push(finding.message);
+  }
+}
+export function computeWindowStartIso(now, windowDays) {
+  const ms = Number(windowDays) * 24 * 60 * 60 * 1000;
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return null;
+  }
+  const candidate = Number(now) - ms;
+  if (!Number.isFinite(candidate)) {
+    return null;
+  }
+  const date = new Date(candidate);
+  // JavaScript `Date` accepts the full IEEE 754 range, but `toISOString`
+  // throws RangeError for any `Date` outside ±100,000,000 days of the
+  // epoch (≈ year ±271,821). Detect that here so a too-large
+  // `--cleanup-backlog-window-days` value never crashes the caller.
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  try {
+    return date.toISOString();
+  } catch {
+    return null;
+  }
+}
+export function classifyBacklog(missingPrNumbers, warnThreshold) {
+  const count = Array.isArray(missingPrNumbers) ? missingPrNumbers.length : 0;
+  const thresholdNumber = Number(warnThreshold);
+  const safeThreshold =
+    Number.isFinite(thresholdNumber) && thresholdNumber >= 0
+      ? thresholdNumber
+      : 0;
+  return {
+    count,
+    warn: count > safeThreshold,
+    examples: Array.isArray(missingPrNumbers)
+      ? missingPrNumbers.slice(0, 5)
+      : [],
+  };
+}
+/**
+ * Preamble line announcing how many merged PRs the backlog scan will visit.
+ * Pure so tests can assert the exact wording without running the network scan.
+ */
+export function formatCleanupBacklogScanPreamble(total) {
+  const plural = total === 1 ? '' : 's';
+  return `post-merge cleanup backlog: scanning ${total} merged PR${plural} for F4 cleanup evidence…`;
+}
+/**
+ * Per-PR progress line for the backlog scan. Pure for the same reason as the
+ * preamble above.
+ */
+export function formatCleanupBacklogScanProgress(scanned, total, prNumber) {
+  return `  [${scanned}/${total}] merged PR #${prNumber}`;
+}
+/**
+ * Emit a backlog-scan progress line. It writes to **stderr** by default so the
+ * `--json` report on stdout stays machine-parseable — a slow network-bound scan
+ * is then distinguishable from a hang without polluting stdout. The `stream`
+ * parameter exists only so tests can capture the output and assert it never
+ * reaches stdout.
+ */
+export function emitCleanupBacklogProgress(line, stream = process.stderr) {
+  stream.write(`${line}\n`);
+}
+// `helper-runtime-manifest.mts`'s HELPER_COMMANDS id for `audit-pr-cleanup`
+// -- the helper the cleanup-backlog remediation hint below points at.
+const CLEANUP_BACKLOG_HELPER_ID = 'audit-pr-cleanup';
+const CLEANUP_BACKLOG_REMEDIATION_ARGS = '--pr <N> --apply --skip-claim-check';
+const CLEANUP_BACKLOG_DOCS_POINTER = 'docs/idd-comment-minimization.md';
+/**
+ * Build the post-merge-cleanup-backlog warning's remediation clause for one
+ * resolved `helperRuntime.profile`, resolving the `audit-pr-cleanup`
+ * invocation through `resolveHelperCommandForProfile` instead of
+ * hard-coding the `vendored-node` form (idd-skill#1718) -- a
+ * `vendored-node`-only command fails immediately under any other profile
+ * (for example `ephemeral-npx`, which has no `scripts/` directory to
+ * invoke). Pure (no I/O) so it can be unit-tested for every profile
+ * without mocking `gh` or the filesystem.
+ *
+ * The optional `packageSpec` (idd-skill#1731) is the resolved
+ * `helperRuntime.packageSpec`; an empty string (the default when unset)
+ * lets `resolveHelperCommandForProfile` fall back to the mutable default
+ * archive URL under `ephemeral-npx`, unchanged from before this pin
+ * existed.
+ *
+ * The `docs/idd-comment-minimization.md` pointer stays in every profile,
+ * including `instructions-only`, which has no runnable command at all --
+ * the pointer alone is then the whole remediation clause.
+ */
+export function formatCleanupBacklogRemediation(profile, packageSpec = '') {
+  const docsClause = `see ${CLEANUP_BACKLOG_DOCS_POINTER}`;
+  const command = resolveHelperCommandForProfile({
+    helperId: CLEANUP_BACKLOG_HELPER_ID,
+    profile,
+    packageSpec,
+  });
+  if (!command) {
+    return `Remediation: ${docsClause}.`;
+  }
+  return `Remediation: ${docsClause} or run \`${command} ${CLEANUP_BACKLOG_REMEDIATION_ARGS}\`.`;
+}
+/**
+ * Trusted authors for `<!-- idd-cleanup-evidence: ... -->` comments: the
+ * repository's configured `trustedMarkerActors` (`.github/idd/config.json`)
+ * plus `github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
+ * under via `GITHUB_TOKEN`. Any commenter outside this set can pre-post the
+ * marker prefix on a public repo, so an untrusted-author match must never
+ * count as genuine cleanup evidence -- the same trust-scoping every other
+ * IDD operational marker already applies. Fails closed to
+ * `github-actions[bot]` alone (config unreadable/malformed never widens
+ * trust).
+ */
+export function readCleanupEvidenceTrustedLogins(root) {
+  let trustedMarkerActors;
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    );
+    trustedMarkerActors = config?.trustedMarkerActors;
+  } catch {
+    trustedMarkerActors = undefined;
+  }
+  const { actors } = resolveTrustedMarkerActors({
+    config: { trustedMarkerActors },
+  });
+  return new Set([...actors, 'github-actions[bot]']);
+}
+/**
+ * Filter a `gh pr list --json number,headRefName` result down to entries
+ * whose head ref matches the IDD branch-naming convention -- the same
+ * `worktreeGuard.branchPatterns` globs (`issue/*`, `roadmap-audit/*` by
+ * default; see `readWorktreeGuardBranchPatterns`) that `classifyPrimaryHead`
+ * already matches elsewhere in this file. A routine non-IDD merge (a
+ * Dependabot dependency bump, for example) never created a branch the
+ * post-merge cleanup backlog scan is responsible for, so it is dropped here
+ * before the backlog count, evidence-fetch loop, or `Examples: ...` list
+ * ever sees it (idd-skill#1829). Pure (no I/O) so it can be unit-tested
+ * without mocking `gh`.
+ */
+export function filterIddBranchMergedPrs(
+  prs,
+  patterns = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+) {
+  const matchers = patterns.map((pattern) => branchGlobToRegExp(pattern));
+  const filtered = [];
+  for (const pr of Array.isArray(prs) ? prs : []) {
+    const number = pr?.number;
+    const headRefName = pr?.headRefName;
+    if (
+      !Number.isInteger(number) ||
+      typeof headRefName !== 'string' ||
+      !matchers.some((matcher) => matcher.test(headRefName))
+    ) {
+      continue;
+    }
+    filtered.push({ number: number });
+  }
+  return filtered;
+}
+function checkPostMergeCleanupBacklog(root, options, report) {
+  const windowDays = options.windowDays;
+  const warnThreshold = options.warnThreshold;
+  const requireGithub = options.requireGithub === true;
+  // Soft GitHub-API failures (gh missing, no token, repo view fails,
+  // pr list fails) are silent by default — same pattern as the other
+  // doctor GitHub-readiness checks — and only surface as errors when
+  // the operator passed --require-github. Per-PR evidence-fetch
+  // failures are still always reported because they materially change
+  // the backlog count.
+  const recordGhFailure = (message) => {
+    if (requireGithub) {
+      report.errors.push(`post-merge cleanup backlog check: ${message}`);
+    }
+  };
+  const repoView = runCommand(
+    'gh',
+    ['repo', 'view', '--json', 'owner,name'],
+    root,
+  );
+  if (!repoView.ok) {
+    recordGhFailure('gh repo view unavailable');
+    return;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(repoView.stdout);
+  } catch {
+    recordGhFailure('gh repo view output is not valid JSON');
+    return;
+  }
+  const owner = parsed.owner?.login;
+  const repo = parsed.name;
+  if (!owner || !repo) {
+    recordGhFailure('gh repo view did not return owner/name');
+    return;
+  }
+  const sinceIso = computeWindowStartIso(Date.now(), windowDays);
+  if (!sinceIso) {
+    report.warnings.push(
+      `post-merge cleanup backlog check skipped: --cleanup-backlog-window-days value ${windowDays} produced an out-of-range Date and cannot be used as a search window. Re-run with a smaller positive value (default: 14).`,
+    );
+    return;
+  }
+  const search = runCommand(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--repo',
+      `${owner}/${repo}`,
+      '--state',
+      'merged',
+      '--search',
+      `merged:>=${sinceIso}`,
+      '--json',
+      'number,headRefName',
+      '--limit',
+      '1000',
+    ],
+    root,
+  );
+  if (!search.ok) {
+    recordGhFailure(`merged-PR list query failed for ${owner}/${repo}`);
+    return;
+  }
+  let mergedPrs;
+  try {
+    mergedPrs = JSON.parse(search.stdout);
+  } catch {
+    recordGhFailure(
+      `merged-PR list query for ${owner}/${repo} returned invalid JSON`,
+    );
+    return;
+  }
+  if (!Array.isArray(mergedPrs) || mergedPrs.length === 0) {
+    return;
+  }
+  // Scope the scan to IDD-branch merged PRs only (idd-skill#1829) -- a
+  // routine non-IDD merge (Dependabot dependency bumps, for example) never
+  // created a branch the F4 cleanup-evidence contract applies to, so it
+  // must not count toward the backlog total or the `Examples: ...` list.
+  const iddMergedPrs = filterIddBranchMergedPrs(
+    mergedPrs,
+    readWorktreeGuardBranchPatterns(root),
+  );
+  if (iddMergedPrs.length === 0) {
+    return;
+  }
+  // Stream per-PR progress to stderr so a slow, serial, network-bound scan of a
+  // large merge burst is distinguishable from a hang. Progress must stay on
+  // stderr so the `--json` report on stdout is never polluted.
+  emitCleanupBacklogProgress(
+    formatCleanupBacklogScanPreamble(iddMergedPrs.length),
+  );
+  const trustedLogins = readCleanupEvidenceTrustedLogins(root);
+  const missing = [];
+  const evidenceFailures = [];
+  let scanned = 0;
+  for (const pr of iddMergedPrs) {
+    const number = pr.number;
+    scanned += 1;
+    emitCleanupBacklogProgress(
+      formatCleanupBacklogScanProgress(scanned, iddMergedPrs.length, number),
+    );
+    const evidence = runCommand(
+      'gh',
+      [
+        'api',
+        '--paginate',
+        `repos/${owner}/${repo}/issues/${number}/comments`,
+        '--jq',
+        '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv',
+      ],
+      root,
+    );
+    if (!evidence.ok) {
+      evidenceFailures.push(number);
+      continue;
+    }
+    // Only a trusted-author match counts as genuine cleanup evidence (see
+    // readCleanupEvidenceTrustedLogins) -- an untrusted commenter's
+    // pre-posted marker-prefixed comment must not suppress this backlog
+    // warning.
+    const hasTrustedEvidence = String(evidence.stdout)
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .some((line) => {
+        const tabIndex = line.indexOf('\t');
+        if (tabIndex === -1) {
+          return false;
+        }
+        const login = line
+          .slice(tabIndex + 1)
+          .trim()
+          .toLowerCase();
+        return trustedLogins.has(login);
+      });
+    if (!hasTrustedEvidence) {
+      missing.push(number);
+    }
+  }
+  if (evidenceFailures.length > 0) {
+    const evidenceMessage =
+      `post-merge cleanup evidence query failed for ${evidenceFailures.length} merged PR(s) ` +
+      `(examples: ${evidenceFailures
+        .slice(0, 5)
+        .map((n) => `#${n}`)
+        .join(', ')}). ` +
+      `Backlog count below may be undercounted.`;
+    if (requireGithub) {
+      report.errors.push(evidenceMessage);
+    } else {
+      report.warnings.push(evidenceMessage);
+    }
+  }
+  const verdict = classifyBacklog(missing, warnThreshold);
+  if (!verdict.warn) {
+    return;
+  }
+  const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
+  const { profile, packageSpec } = resolveConfiguredHelperRuntime(root);
+  const remediation = formatCleanupBacklogRemediation(profile, packageSpec);
+  report.warnings.push(
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. ${remediation}`,
+  );
+}
+// Default drift thresholds (idd-skill#1269): warn when the checked-out HEAD
+// (typically `main` -- see the HEAD-vs-main note below) is more than 100
+// commits OR more than 45 days past the latest reachable tag, whichever
+// fires first (OR logic -- either alone is enough to warn). "Days past the
+// tag" is measured from the tagged **commit's** date (`%cI` on the
+// dereferenced commit), not an annotated tag object's own creation
+// timestamp -- lightweight tags have no separate tagger date to read, and
+// using the commit date keeps both tag forms measured the same way.
+// Calibrated against this repository's own history rather than picked
+// arbitrarily: as of 2026-07-03, `main` was 636 commits / ~22 days past
+// `v0.3.0` under this repository's own atypically heavy dogfooding
+// velocity (~29 commits/day) -- not a representative adopter cadence, and
+// the `v0.2.0` -> `v0.3.0` gap (~10.5 hours) was too short to use as a
+// cadence sample either. 100 commits sizes the default for a *typical*
+// adopter's velocity, not idd-skill's own extreme rate -- it is expected
+// to (correctly) also fire immediately for idd-skill itself. 45 days gives
+// roughly 1.5 release cycles of slack under a monthly-ish cadence before
+// warning.
+//
+// HEAD-vs-main: the check measures drift from whatever commit is currently
+// checked out, not specifically `main` -- `.github/workflows/idd-doctor.yml`
+// runs it on every pull request against the PR's own (detached) HEAD, not
+// `main`. The warning message below says "HEAD", not "main", so it stays
+// accurate under that CI topology and any other non-main invocation.
+export const RELEASE_TAG_DRIFT_COMMIT_THRESHOLD = 100;
+export const RELEASE_TAG_DRIFT_DAY_THRESHOLD = 45;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+/**
+ * Classify how far the current HEAD has drifted from the latest release
+ * tag, given the already-computed commit and day distances. Pure and
+ * exported so tests can cover every threshold combination without shelling
+ * out to git, using the module-level `RELEASE_TAG_DRIFT_*` thresholds (no
+ * CLI override -- the issue's acceptance criteria only calls for documented
+ * defaults). `tag === null` means no tag is reachable from HEAD yet (a
+ * fresh adopter clone before its first release) -- always non-warning. The
+ * only caller, `checkReleaseTagDrift`, already returns before ever invoking
+ * this with `tag: null` (its own `git describe` failure is the earlier exit
+ * point); the branch is kept here, mirroring
+ * `classifyWorktreeGuardActivation`'s `headDetached` handling, purely so
+ * this no-tag case is directly unit-testable without shelling out to git.
+ */
+export function classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag) {
+  if (!tag) {
+    return { warn: false };
+  }
+  const commitThreshold = RELEASE_TAG_DRIFT_COMMIT_THRESHOLD;
+  const dayThreshold = RELEASE_TAG_DRIFT_DAY_THRESHOLD;
+  const commits = Number(commitsSinceTag);
+  const days = Number(daysSinceTag);
+  const safeCommits = Number.isFinite(commits) ? commits : 0;
+  const safeDays = Number.isFinite(days) ? days : 0;
+  const overCommits = safeCommits > commitThreshold;
+  const overDays = safeDays > dayThreshold;
+  if (!overCommits && !overDays) {
+    return { warn: false };
+  }
+  const parts = [];
+  if (overCommits) {
+    parts.push(`${safeCommits} commit(s) (> ${commitThreshold})`);
+  }
+  if (overDays) {
+    // Round up, not down: flooring a value just over the threshold (e.g.
+    // 45.1 with a 45-day threshold) would print "45 day(s) (> 45)", which
+    // reads as self-contradictory. Ceiling guarantees the printed integer
+    // is always strictly greater than dayThreshold whenever overDays is
+    // true (safeDays > dayThreshold implies ceil(safeDays) > dayThreshold
+    // for any integer dayThreshold).
+    parts.push(`${Math.ceil(safeDays)} day(s) (> ${dayThreshold})`);
+  }
+  return {
+    warn: true,
+    message: `release-tag drift: HEAD is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
+  };
+}
+// Warns (never fails) when the current HEAD has drifted far from the latest
+// release tag. Skips silently -- no warning, no crash -- whenever there is
+// no usable tag baseline to measure drift against: `git describe` (or the
+// follow-up `rev-list` / `log` calls) failing is treated as one single,
+// safe "no baseline" signal, covering every cause the same way -- no tags
+// at all yet (a fresh adopter clone before its first release), no tag
+// reachable from HEAD, tag history hidden by a shallow fetch (see
+// idd-skill#1286), or `git` itself being unavailable. This function never
+// tries to distinguish those causes; any of them means skip silently.
+function checkReleaseTagDrift(root, report) {
+  const describeResult = runCommand(
+    'git',
+    ['describe', '--tags', '--abbrev=0'],
+    root,
+  );
+  if (!describeResult.ok) {
+    return;
+  }
+  const tag = describeResult.stdout.trim();
+  if (!tag) {
+    return;
+  }
+  const countResult = runCommand(
+    'git',
+    ['rev-list', '--count', `${tag}..HEAD`],
+    root,
+  );
+  // `^{commit}` dereferences an annotated tag to the commit it points at, so
+  // the drift measurement uses the tagged commit's date in both tag forms.
+  const dateResult = runCommand(
+    'git',
+    ['log', '-1', '--format=%cI', `${tag}^{commit}`],
+    root,
+  );
+  if (!countResult.ok || !dateResult.ok) {
+    return;
+  }
+  const commitsSinceTag = Number(countResult.stdout.trim());
+  const tagDate = new Date(dateResult.stdout.trim());
+  if (!Number.isFinite(commitsSinceTag) || Number.isNaN(tagDate.getTime())) {
+    return;
+  }
+  const daysSinceTag = (Date.now() - tagDate.getTime()) / MS_PER_DAY;
+  const verdict = classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag);
+  if (verdict.warn && verdict.message) {
+    report.warnings.push(verdict.message);
+  }
+}
+export function findMissingWorkshopReferences(entryFiles, allowMissing) {
+  const allowSet = new Set(
+    (Array.isArray(allowMissing) ? allowMissing : []).map((path) =>
+      String(path),
+    ),
+  );
+  const missing = [];
+  for (const entry of entryFiles) {
+    if (allowSet.has(entry.path)) {
+      continue;
+    }
+    if (entry.content === null) {
+      missing.push(entry.path);
+      continue;
+    }
+    if (typeof entry.content !== 'string') {
+      continue;
+    }
+    if (!containsWorkshopReference(entry.content)) {
+      missing.push(entry.path);
+    }
+  }
+  return missing;
+}
+export function containsWorkshopReference(content) {
+  if (typeof content !== 'string' || content.length === 0) {
+    return false;
+  }
+  // Strip fenced code blocks (``` and ~~~) before scanning so demo
+  // Markdown inside code samples does not count as a real link.
+  const stripped = stripFencedCodeBlocks(content);
+  // Accept any double-quoted, single-quoted, or no-title destination
+  // form per CommonMark inline-link grammar.
+  const linkPattern =
+    /\[[^\]\n]*\]\(\s*([^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g;
+  let match;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((match = linkPattern.exec(stripped)) !== null) {
+    const target = match[1];
+    if (!target) continue;
+    if (matchesWorkshopPath(target)) {
+      return true;
+    }
+  }
+  return false;
+}
+function stripFencedCodeBlocks(content) {
+  const lines = String(content).split(/\r?\n/);
+  const out = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    out.push(line);
+  }
+  return out.join('\n');
+}
+function matchesWorkshopPath(target) {
+  const cleaned = String(target)
+    .replace(/^\.\/+/, '')
+    .replace(/^\/+/, '');
+  for (const pattern of WORKSHOP_LINK_TARGET_PATTERNS) {
+    if (pattern.test(`/${cleaned}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+// Verifies that the workshop publication is discoverable from every
+// known entry point (README.md, README.ja.md, docs/index.md).
+// Skipped silently when docs/workshop/ does not exist (adopter repos
+// that never published a workshop should not see noise). The example
+// repository's back-link is intentionally out of scope here because
+// verifying it requires fetching a remote repository's README; that
+// is a separate concern under the helper-runtime profile work.
+function checkWorkshopCrossReferences(root, options, report) {
+  const allowMissing = options.allowMissing ?? [];
+  const workshopDir = resolve(root, WORKSHOP_REL_PATH);
+  if (!existsSync(workshopDir)) {
+    return;
+  }
+  const entryFiles = WORKSHOP_ENTRY_POINTS.map((relPath) => {
+    const abs = resolve(root, relPath);
+    if (!existsSync(abs)) {
+      return { path: relPath, content: null };
+    }
+    try {
+      return { path: relPath, content: readFileSync(abs, 'utf8') };
+    } catch {
+      return { path: relPath, content: null };
+    }
+  });
+  const missing = findMissingWorkshopReferences(entryFiles, allowMissing);
+  for (const path of missing) {
+    report.warnings.push(
+      `workshop cross-reference missing in ${path}: expected a Markdown link whose target starts with ${WORKSHOP_REL_PATH}/. See acceptance criteria on issue #611 (CP-E).`,
+    );
+  }
+}
+// Returns a regex that matches a URL **pathname** of shape
+// `/<slug>/(<segments>/)*docs/workshop(/|$|[?#])`. Anchored to
+// `^/<slug>/` so the slug must occupy the first two path segments
+// and be terminated by a real path separator (prevents
+// `acme/me/repo` from matching slug `me/repo` and
+// `me/repodocs/workshop` from being read as `me/repo` +
+// `docs/workshop`). Trailing boundary prevents
+// `docs/workshops/...` and `docs/workshop-old/...` from matching
+// `docs/workshop`.
+//
+// This is the **pathname matcher only**. The URL parser that
+// pairs with it (containsExampleRepoBackLink below) handles host
+// validation, URL token cleanup, and root-relative target
+// extraction; do not use this pattern against a full URL or
+// external host token.
+export function backLinkPatternFor(repoSlug) {
+  const escSlug = String(repoSlug).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^/${escSlug}/(?:[^?#]*?/)?docs/workshop(?:/|$|[?#])`, 'i');
+}
+export function stripMarkdownNonText(content) {
+  if (typeof content !== 'string') return '';
+  let s = content;
+  // Order matters: strip code regions FIRST so a literal `<!--`
+  // inside a code span cannot trigger the HTML-comment strip
+  // across unrelated content. After code regions are gone, HTML
+  // comments are guaranteed to be real comments.
+  s = stripFencesPreservingLines(s);
+  s = stripIndentedCodeBlocksPreservingLines(s);
+  // Inline code spans (single or multi-backtick).
+  s = s.replace(/(`+)((?:(?!\1)[\s\S])+?)\1/g, '');
+  // Now strip HTML comments. Loop to a fixed point so nested
+  // payloads like `<!--<!-- x --> -->` fully collapse rather than
+  // leaving `<!--` fragments after a single pass — satisfies
+  // CodeQL's incomplete-multi-character sanitization rule.
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/<!--[\s\S]*?-->/g, '');
+  } while (s !== prev);
+  return s;
+}
+// Per CommonMark §4.5: an opening fence may have up to 3 leading
+// spaces; the opening backtick fence info string MUST NOT contain
+// backticks (the tilde fence info string may contain anything); a
+// closing fence must use the same fence character, have a length
+// at least the opening length, and may have a different indent
+// (still <= 3 spaces) and trailing whitespace only.
+function stripFencesPreservingLines(content) {
+  const lines = String(content).split(/\r?\n/);
+  const out = [];
+  let fence = null;
+  for (const line of lines) {
+    const m = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
+    if (m) {
+      const indent = m[1].length;
+      const marker = m[2];
+      const after = m[3];
+      const isCloseShape = /^\s*$/.test(after);
+      const fenceChar = marker[0];
+      const fenceLen = marker.length;
+      if (fence === null) {
+        // Backtick-fence info strings cannot contain backticks. A
+        // line like ```` ``` invalid ` info ```` is not a real
+        // fence opener, so treat it as plain content.
+        if (fenceChar === '`' && after.includes('`')) {
+          out.push(line);
+          continue;
+        }
+        fence = { char: fenceChar, length: fenceLen };
+        out.push('');
+        continue;
+      }
+      if (
+        fenceChar === fence.char &&
+        fenceLen >= fence.length &&
+        isCloseShape &&
+        indent <= 3
+      ) {
+        fence = null;
+        out.push('');
+        continue;
+      }
+    }
+    out.push(fence === null ? line : '');
+  }
+  return out.join('\n');
+}
+// CommonMark §4.4 indented code blocks: content indented at least 4
+// columns beyond the enclosing context (the top level, or an open list
+// item's content column), preceded by a blank line. The stripper below
+// tracks open list levels by content column (supporting `-`/`*`/`+` and
+// ordered `\d+[.)]` markers), so list continuation and nested list items
+// are preserved, while a deeper indent — even a list-marker-looking line
+// — is treated as a nested indented code block and blanked. See
+// stripIndentedCodeBlocksPreservingLines.
+/** Leading-indent width of a line in columns (space = 1, tab = 4). */
+function leadingIndentColumns(line) {
+  let columns = 0;
+  for (const ch of line) {
+    if (ch === ' ') {
+      columns += 1;
+    } else if (ch === '\t') {
+      columns += 4;
+    } else {
+      break;
+    }
+  }
+  return columns;
+}
+function stripIndentedCodeBlocksPreservingLines(content) {
+  const lines = String(content).split(/\r?\n/);
+  const out = [];
+  let prevBlank = true;
+  let inBlock = false;
+  // The minimum indent (in columns) of the open indented code block, set
+  // at its opener. A line indented below this leaves the block.
+  let codeBaseIndent = 4;
+  // Content-indent columns of the currently open list levels, outermost
+  // first (a stack, so ending an inner list returns to the outer level
+  // instead of losing its context). Under the innermost open list, content
+  // indented up to `top + 3` is list continuation / nested-list items,
+  // while content indented `>= top + 4` is an indented code block nested
+  // inside the item (CommonMark allows code blocks within a list item).
+  // With no list open the threshold is the top-level 4 columns, so a
+  // top-level `>=4`-column indent is still a code block even when it looks
+  // like a list marker.
+  const listContentIndents = [];
+  const innermostListIndent = () =>
+    listContentIndents.length > 0
+      ? listContentIndents[listContentIndents.length - 1]
+      : null;
+  // Drop list levels whose content column is deeper than `indent`, so a
+  // dedent re-exposes the enclosing list (or no list).
+  const popDeeperThan = (indent) => {
+    while (
+      listContentIndents.length > 0 &&
+      indent < listContentIndents[listContentIndents.length - 1]
+    ) {
+      listContentIndents.pop();
+    }
+  };
+  for (const line of lines) {
+    if (/^\s*$/.test(line)) {
+      // A blank line ends neither an open indented code block nor an open
+      // list: per CommonMark §4.4 a code block is one or more indented
+      // chunks separated by blank lines, and loose lists are blank-line
+      // separated too. Both states survive the blank; they only end at a
+      // later non-indented, non-blank line (or a dedent).
+      out.push(line);
+      prevBlank = true;
+      continue;
+    }
+    const indent = leadingIndentColumns(line);
+    // CommonMark §5.2: ordered-list markers may use either `.` or `)`
+    // after the digit. The match is the full marker prefix (leading
+    // whitespace + marker + trailing whitespace); its column width gives
+    // the list item's content column, computed tab-aware where the item
+    // is kept below.
+    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
+    if (inBlock) {
+      if (indent >= codeBaseIndent) {
+        // Continuation of the open code block (even across blank lines).
+        // A list cannot start inside it, so a list-marker-looking line
+        // here stays code and is blanked.
+        out.push('');
+        prevBlank = false;
+        continue;
+      }
+      // Indented below the code block base; it ends. Reprocess this line.
+      inBlock = false;
+    }
+    const codeThreshold = (innermostListIndent() ?? 0) + 4;
+    if (prevBlank && indent >= codeThreshold) {
+      // Indented code block opener — at the top level (no list) or nested
+      // inside the current list item. A list marker at this depth is code,
+      // not a list, so this branch precedes the list-marker handling.
+      out.push('');
+      inBlock = true;
+      codeBaseIndent = codeThreshold;
+      prevBlank = false;
+      continue;
+    }
+    if (listMarker && indent < codeThreshold) {
+      // A list item (top-level or nested, but shallower than a code block
+      // per the threshold above — a marker at code depth that was not
+      // opened as a code block is paragraph continuation, handled below,
+      // and must not open a list level). Close any deeper sibling levels,
+      // then record this item's content column as the new innermost list.
+      // The content column is the full prefix width in columns (tab = 4),
+      // consistent with leadingIndentColumns, so a tab after the marker is
+      // not miscounted as a single column.
+      out.push(line);
+      let prefixWidth = 0;
+      for (const ch of listMarker[0]) {
+        prefixWidth += ch === '\t' ? 4 : 1;
+      }
+      const contentColumn = prefixWidth;
+      popDeeperThan(indent);
+      listContentIndents.push(contentColumn);
+      prevBlank = false;
+      continue;
+    }
+    // A non-code, non-list line: close any list levels whose content
+    // column is deeper than this line's indent. A line that drops below
+    // every level closes the list entirely; a line still within an outer
+    // level keeps that level open.
+    out.push(line);
+    popDeeperThan(indent);
+    prevBlank = false;
+  }
+  return out.join('\n');
+}
+export function containsExampleRepoBackLink(readmeContent, repoSlug) {
+  if (typeof readmeContent !== 'string' || readmeContent.length === 0) {
+    return false;
+  }
+  // Strip code samples first so any literal `<!--` inside a code
+  // span does not trigger HTML-comment removal across unrelated
+  // content. The pattern is tested against the URL pathname only
+  // (no host / query / fragment) so the regex can stay anchored
+  // to `^/<slug>/` and query strings cannot smuggle the slug.
+  const pattern = backLinkPatternFor(repoSlug);
+  // Mask inline-image destinations BEFORE generic URL extraction
+  // so badge-style images like ![alt](https://github.com/...) do
+  // not count as navigational back-links.
+  const imagedStripped = stripMarkdownNonText(readmeContent).replace(
+    /!\[[^\]]*\]\(\s*<?[^()\s>]+>?(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g,
+    '',
+  );
+  // Reference-style images (`![alt][id]`, collapsed `![id][]`, shortcut
+  // `![id]`) resolve their source through a separate `[id]: <url>`
+  // reference definition, so the definition is an image source, not a
+  // navigation link. Collect every label an image references, then drop
+  // the matching reference-definition lines before the URL scans below.
+  // A real reference *link* (`[text][id]`) keeps its definition and is
+  // still counted.
+  const imageLabels = new Set();
+  const imageRefPattern = /!\[([^\]]*)\](?:\[([^\]]*)\])?/g;
+  let imageMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((imageMatch = imageRefPattern.exec(imagedStripped)) !== null) {
+    const explicit = imageMatch[2]?.trim() ?? '';
+    const shortcut = imageMatch[1]?.trim() ?? '';
+    const label = explicit.length > 0 ? explicit : shortcut;
+    if (label.length > 0) imageLabels.add(label.toLowerCase());
+  }
+  // Labels that have a reference definition. A shortcut reference
+  // (`[id]`) only resolves to a link/image when such a definition exists,
+  // so the defined-label set scopes shortcut detection below and avoids
+  // treating ordinary bracketed prose as a reference.
+  const definedLabels = new Set();
+  const refDefPattern = /^ {0,3}\[([^\]]+)\]:.*$/gm;
+  let defMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((defMatch = refDefPattern.exec(imagedStripped)) !== null) {
+    definedLabels.add(defMatch[1].trim().toLowerCase());
+  }
+  // A reference *link* (full `[text][id]`, collapsed `[id][]`, or shortcut
+  // `[id]`; the leading `!` excludes images) shares the `[id]: <url>`
+  // definition with navigation, so a label used by a link must keep its
+  // definition even when an image also references it. Collect link labels
+  // and drop only definitions for labels referenced *exclusively* by
+  // images.
+  const linkLabels = new Set();
+  const refLinkPattern = /(?<!!)\[[^\]]*\]\[([^\]]*)\]/g;
+  let linkMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((linkMatch = refLinkPattern.exec(imagedStripped)) !== null) {
+    const explicit = linkMatch[1]?.trim() ?? '';
+    // Collapsed form `[id][]` carries the label in the first bracket;
+    // recover it from the full match when the second bracket is empty.
+    const label =
+      explicit.length > 0
+        ? explicit
+        : (linkMatch[0].match(/^\[([^\]]*)\]\[\]$/)?.[1]?.trim() ?? '');
+    if (label.length > 0) linkLabels.add(label.toLowerCase());
+  }
+  // Shortcut reference links: a bare `[id]` not preceded by `]`/`!` (which
+  // would be a full-reference tail or an image) and not followed by
+  // `(`/`[`/`:` (inline link, full/collapsed reference, or definition).
+  // Only count it when `id` is actually defined.
+  const shortcutPattern = /(?<![\]!])\[([^\]]+)\](?![([:])/g;
+  let shortcutMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((shortcutMatch = shortcutPattern.exec(imagedStripped)) !== null) {
+    const label = shortcutMatch[1].trim().toLowerCase();
+    if (label.length > 0 && definedLabels.has(label)) linkLabels.add(label);
+  }
+  const dropLabels = new Set(
+    [...imageLabels].filter((label) => !linkLabels.has(label)),
+  );
+  const stripped =
+    dropLabels.size === 0
+      ? imagedStripped
+      : imagedStripped.replace(/^ {0,3}\[([^\]]+)\]:.*$/gm, (full, label) =>
+          dropLabels.has(label.trim().toLowerCase()) ? '' : full,
+        );
+  // Absolute http(s) URLs.
+  const urlPattern = /https?:\/\/[^\s<>)\]"']+/gi;
+  let match;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((match = urlPattern.exec(stripped)) !== null) {
+    const token = match[0].replace(/[.,;:!?]+$/, '');
+    let url;
+    try {
+      url = new URL(token);
+    } catch {
+      continue;
+    }
+    if (!isGithubBackLinkHost(url.hostname)) continue;
+    if (pattern.test(url.pathname)) return true;
+  }
+  // Root-relative Markdown link targets (`[text](/owner/repo/...)`)
+  // and reference-definition destinations (`[id]: /owner/repo/...`).
+  // GitHub renders these against the current repo / docs origin;
+  // the back-link pattern already requires `^/<slug>/` so a
+  // root-relative target is checked against the same shape.
+  // Allows CommonMark optional whitespace before the destination
+  // and angle-bracket-wrapped destinations (`(<...>)` / `[id]: <...>`).
+  const mdInline =
+    /\[[^\]]*\]\(\s*<?(\/[^()\s>]+)>?(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((match = mdInline.exec(stripped)) !== null) {
+    if (pattern.test(match[1].replace(/[.,;:!?]+$/, ''))) return true;
+  }
+  const mdRefDef = /^\s{0,3}\[[^\]]+\]:\s*<?(\/[^\s>]+)>?/gm;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((match = mdRefDef.exec(stripped)) !== null) {
+    if (pattern.test(match[1].replace(/[.,;:!?]+$/, ''))) return true;
+  }
+  return false;
+}
+// Runtime / skip semantics live on the check function below, not on
+// the helpers above. `checkWorkshopExampleRepoBackLink` reads the
+// example-repo coordinates from `.github/idd/config.json`
+// (`workshop.exampleRepository`, `<owner>/<repo>` shape) and skips
+// silently when the local docs/workshop/ is absent, the config
+// field is unset, or the gh fetch fails. Soft fetch failures
+// escalate to errors under `--require-github`.
+const PUBLIC_GITHUB_HOSTS = new Set([
+  'github.com',
+  'www.github.com',
+  'raw.githubusercontent.com',
+]);
+export function isGithubBackLinkHost(host) {
+  const lower = String(host ?? '').toLowerCase();
+  if (PUBLIC_GITHUB_HOSTS.has(lower)) return true;
+  // Any other host must be declared explicitly in
+  // IDD_WORKSHOP_BACKLINK_HOSTS. The `*.github.com` wildcard was
+  // removed because subdomains like `docs.github.com` and
+  // `api.github.com` do not host repository paths but would pass
+  // the wildcard check. GitHub Enterprise Server adopters whose
+  // host does not exactly match the public list must opt in
+  // explicitly.
+  const extra = (process.env.IDD_WORKSHOP_BACKLINK_HOSTS ?? '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  return extra.includes(lower);
+}
+export function decodeGithubReadmeBase64(content) {
+  if (typeof content !== 'string') return null;
+  const compact = content.replace(/\s+/g, '');
+  if (compact.length === 0) return null;
+  // `gh api --jq .content` writes the literal string `null` when
+  // the JSON path does not exist; treat that as not-a-payload so a
+  // missing README does not decode to a non-empty UTF-8 string.
+  if (compact === 'null') return null;
+  // Base64 payload length is always a multiple of 4 (with padding);
+  // a short alphanumeric string like `null` survives the
+  // character-class check above but fails the length check here.
+  if (compact.length % 4 !== 0) return null;
+  if (!BASE64_PATTERN.test(content)) return null;
+  let decoded;
+  try {
+    decoded = Buffer.from(compact, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+  if (typeof decoded !== 'string' || decoded.length === 0) return null;
+  // Re-encode and compare to guard against base64-shaped strings
+  // that happen to decode to lossy garbage. Standard GitHub README
+  // payloads round-trip cleanly.
+  if (Buffer.from(decoded, 'utf8').toString('base64') !== compact) {
+    return null;
+  }
+  return decoded;
+}
+function checkWorkshopExampleRepoBackLink(root, options, report) {
+  const requireGithub = options.requireGithub === true;
+  const workshopDir = resolve(root, WORKSHOP_REL_PATH);
+  if (!existsSync(workshopDir)) return;
+  const configPath = resolve(root, '.github/idd/config.json');
+  if (!existsSync(configPath)) return;
+  let config;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return;
+  }
+  const exampleRepo = config?.workshop?.exampleRepository;
+  if (typeof exampleRepo !== 'string' || exampleRepo.trim().length === 0) {
+    return;
+  }
+  if (!/^[^/\s]+\/[^/\s]+$/.test(exampleRepo)) {
+    const message = `invalid workshop.exampleRepository value "${exampleRepo}" — expected "<owner>/<repo>".`;
+    // Misconfiguration is not a soft GitHub failure; it is a real
+    // gating signal. Under --require-github this must escalate so
+    // CI catches the typo instead of silently passing.
+    if (requireGithub) {
+      report.errors.push(`workshop example-repo back-link check: ${message}`);
+    } else {
+      report.warnings.push(`workshop example-repo check skipped: ${message}`);
+    }
+    return;
+  }
+  const recordSoftFailure = (message) => {
+    if (requireGithub) {
+      report.errors.push(`workshop example-repo back-link check: ${message}`);
+    }
+  };
+  // Resolve this repo's slug from gh repo view so the back-link
+  // pattern matches the correct owner / name even when the
+  // configured GitHub origin differs from local assumptions.
+  const repoView = runCommand(
+    'gh',
+    ['repo', 'view', '--json', 'owner,name'],
+    root,
+  );
+  if (!repoView.ok) {
+    recordSoftFailure(`gh repo view unavailable`);
+    return;
+  }
+  let viewer;
+  try {
+    viewer = JSON.parse(repoView.stdout);
+  } catch {
+    recordSoftFailure(`gh repo view output is not valid JSON`);
+    return;
+  }
+  const owner = viewer.owner?.login;
+  const name = viewer.name;
+  if (!owner || !name) {
+    recordSoftFailure(`gh repo view did not return owner / name`);
+    return;
+  }
+  const repoSlug = `${owner}/${name}`;
+  // `repos/<owner>/<repo>/readme` returns whatever GitHub considers
+  // the canonical README (README.md, README.rst, README, case
+  // variants), so the check works for repos that do not name their
+  // README exactly `README.md`.
+  const readmeFetch = runCommand(
+    'gh',
+    ['api', `repos/${exampleRepo}/readme`, '--jq', '.content'],
+    root,
+  );
+  if (!readmeFetch.ok) {
+    recordSoftFailure(`could not fetch ${exampleRepo} README via gh api`);
+    return;
+  }
+  const stdout = String(readmeFetch.stdout);
+  const compact = stdout.replace(/\s+/g, '');
+  if (compact.length === 0) {
+    // Empty README is a real missing-back-link condition, not a
+    // soft fetch failure (the README exists but contains nothing).
+    report.warnings.push(
+      `workshop example-repo back-link missing: ${exampleRepo} README is empty; no link to ${repoSlug}/.../docs/workshop can be present.`,
+    );
+    return;
+  }
+  const decoded = decodeGithubReadmeBase64(stdout);
+  if (!decoded) {
+    recordSoftFailure(`${exampleRepo} README content was not valid base64`);
+    return;
+  }
+  if (!containsExampleRepoBackLink(decoded, repoSlug)) {
+    report.warnings.push(
+      `workshop example-repo back-link missing: ${exampleRepo} README does not contain a link whose target matches ${repoSlug}/.../docs/workshop. See acceptance criteria on issue #611 (CP-E).`,
+    );
+  }
+}
+function checkGithubReadiness(root, requireGithub, report) {
+  const repoView = runCommand(
+    'gh',
+    ['repo', 'view', '--json', 'owner,name,defaultBranchRef'],
+    root,
+  );
+  if (!repoView.ok) {
+    const message = 'github checks skipped: gh repo view unavailable';
+    if (requireGithub) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    return;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(repoView.stdout);
+  } catch {
+    const message =
+      'github checks skipped: failed to parse gh repo view output';
+    if (requireGithub) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    return;
+  }
+  const owner = parsed.owner?.login;
+  const repo = parsed.name;
+  const branch = parsed.defaultBranchRef?.name;
+  if (!owner || !repo || !branch) {
+    const message =
+      'github checks skipped: repository owner/name/default branch is incomplete';
+    if (requireGithub) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    return;
+  }
+  const protection = runCommand(
+    'gh',
+    ['api', `repos/${owner}/${repo}/branches/${branch}/protection`],
+    root,
+  );
+  if (!protection.ok) {
+    const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
+    if (requireGithub) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    return;
+  }
+  let protectionJson;
+  try {
+    protectionJson = JSON.parse(protection.stdout);
+  } catch {
+    const message = 'branch protection response is not valid JSON';
+    if (requireGithub) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    return;
+  }
+  const requiredChecks = protectionJson.required_status_checks?.contexts ?? [];
+  const strict = protectionJson.required_status_checks?.strict ?? false;
+  if (requiredChecks.length === 0) {
+    report.warnings.push(
+      `branch protection is enabled but no required status checks are configured on ${branch}`,
+    );
+  } else {
+    report.passes.push(
+      `required status checks configured on ${branch} (${requiredChecks.length}, strict=${strict})`,
+    );
+  }
+  const reviewConfig = protectionJson.required_pull_request_reviews;
+  if (!reviewConfig) {
+    report.warnings.push(
+      `required pull request reviews are not configured on ${branch}`,
+    );
+  } else {
+    report.passes.push('required pull request review policy is configured');
+  }
+}
+function runCommand(command, argv, cwd) {
+  try {
+    const stdout = execFileSync(command, argv, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout };
+  } catch (error) {
+    const candidate = error;
+    return {
+      ok: false,
+      code: candidate.status,
+      stderr: candidate.stderr?.toString?.() ?? '',
+    };
+  }
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `repo-root:`): tests/flag-name-matrix.test.mts scans this file's
+// *compiled* .mjs source text for quoted flag literals. See
+// cli-args.mts's module header for the full invariant.
+const IDD_DOCTOR_FLAG_SPEC = {
+  '--json': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h', default: false },
+  '--require-github': { type: 'boolean', default: false },
+  '--strict': { type: 'boolean', default: false },
+  '--repo-root': { type: 'string' },
+  '--cleanup-backlog-window-days': { type: 'string' },
+  '--cleanup-backlog-warn-threshold': { type: 'string' },
+  '--workshop-cross-ref-allow-missing': { type: 'string' },
+};
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, IDD_DOCTOR_FLAG_SPEC);
+  const args = {
+    root: process.cwd(),
+    json: values.json,
+    help,
+    requireGithub: values['require-github'],
+    strict: values.strict,
+  };
+  // --repo-root rejects an explicit empty string the same as an omitted
+  // flag (pre-migration guard used `!value`).
+  const repoRoot = values['repo-root'];
+  if (repoRoot !== undefined) {
+    if (!repoRoot) {
+      throw new Error('--repo-root requires a value');
+    }
+    args.root = repoRoot;
+  }
+  // --cleanup-backlog-window-days rejects an explicit empty string
+  // (pre-migration guard used `!value`); accepts any positive finite
+  // number, including decimals -- kept as Number() + Number.isFinite,
+  // NOT the canonical-integer helper, which would wrongly reject "1.5".
+  const windowDaysToken = values['cleanup-backlog-window-days'];
+  if (windowDaysToken !== undefined) {
+    if (!windowDaysToken) {
+      throw new Error('--cleanup-backlog-window-days requires a value');
+    }
+    const numeric = Number(windowDaysToken);
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      throw new Error(
+        `--cleanup-backlog-window-days must be a positive finite number (got "${windowDaysToken}")`,
+      );
+    }
+    args.cleanupBacklogWindowDays = numeric;
+  }
+  // --cleanup-backlog-warn-threshold: pre-migration guard used
+  // `=== undefined` (NOT `!value`), so an explicit empty string was
+  // accepted and Number('') === 0 passed the >= 0 check -- preserved
+  // exactly, including that quirk.
+  const warnThresholdToken = values['cleanup-backlog-warn-threshold'];
+  if (warnThresholdToken !== undefined) {
+    const numeric = Number(warnThresholdToken);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+      throw new Error(
+        `--cleanup-backlog-warn-threshold must be a non-negative finite number (got "${warnThresholdToken}")`,
+      );
+    }
+    args.cleanupBacklogWarnThreshold = numeric;
+  }
+  // --workshop-cross-ref-allow-missing: pre-migration guard used
+  // `=== undefined` (NOT `!value`), so an explicit empty string was
+  // accepted and resolved to an empty list (''.split(',') -> [''] ->
+  // filtered to []) -- preserved exactly.
+  const allowMissingToken = values['workshop-cross-ref-allow-missing'];
+  if (allowMissingToken !== undefined) {
+    args.workshopCrossRefAllowMissing = allowMissingToken
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+  return args;
+}
+function printHumanReport(report) {
+  console.log(`IDD doctor report (${report.root})`);
+  for (const pass of report.passes) {
+    console.log(`PASS  ${pass}`);
+  }
+  for (const warning of report.warnings) {
+    console.log(`WARN  ${warning}`);
+  }
+  for (const error of report.errors) {
+    console.log(`ERROR ${error}`);
+  }
+  if (report.errors.length > 0) {
+    console.log(
+      `\nresult: failed (${report.errors.length} error(s), ${report.warnings.length} warning(s))`,
+    );
+    return;
+  }
+  console.log(`\nresult: passed (${report.warnings.length} warning(s))`);
+}
+function printUsage() {
+  console.log(`usage: node scripts/idd-doctor.mjs [options]
+
+options:
+  --repo-root <path>                       repository root to inspect (default: cwd)
+  --json                                   print JSON report
+  --require-github                         treat GitHub API check failures as errors
+  --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
+  --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
+  --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
+  --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
+  --help, -h                               show this help
+
+The merged-PR backlog scan caps at gh's per-query maximum of 1000
+results; repositories with > 1000 merged PRs in the window get a
+representative sample. The check makes one gh api .../comments
+call per merged PR returned, which is intentionally simple — for
+very large or rate-limited repos consider raising the warn
+threshold or shortening the window. The scan streams per-PR
+progress to stderr so a slow network-bound run is distinguishable
+from a hang; stdout (including --json) stays free of progress. For
+a local run during a merge burst, pass --cleanup-backlog-window-days 1
+to keep it fast, mirroring what CI already does.
+`);
+}
+function listFiles(root) {
+  const gitList = runCommand(
+    'git',
+    ['ls-files', '--cached', '--others', '--exclude-standard'],
+    root,
+  );
+  if (gitList.ok) {
+    return gitList.stdout.split(/\r?\n/).filter(Boolean).sort();
+  }
+  return walk(root)
+    .map((absolutePath) => relative(root, absolutePath))
+    .sort();
+}
+function walk(directory) {
+  const entries = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === '.git') {
+      continue;
+    }
+    const absolutePath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      entries.push(...walk(absolutePath));
+      continue;
+    }
+    if (entry.isFile()) {
+      entries.push(absolutePath);
+    }
+  }
+  return entries;
+}
+function exists(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+function isTextLikeFile(file) {
+  return /\.(md|txt|yml|yaml|json|mjs|js|ts|sh)$/.test(file);
+}
+function unique(values) {
+  return [...new Set(values)];
+}
+function sameMembers(left, right) {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  if (leftSet.size !== rightSet.size) {
+    return false;
+  }
+  for (const value of leftSet) {
+    if (!rightSet.has(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+// Run as a CLI only after the whole module (including consts used by the
+// checks above) has finished evaluating. Keeping this block at the end of
+// the file avoids a temporal-dead-zone crash when runDoctor reaches a check
+// that reads a `const` declared later in the file.
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  const report = runDoctor({
+    root: resolve(args.root),
+    requireGithub: args.requireGithub,
+    cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
+    cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
+    workshopCrossRefAllowMissing: args.workshopCrossRefAllowMissing,
+    strict: args.strict,
+  });
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHumanReport(report);
+  }
+  process.exit(report.errors.length > 0 ? 1 : 0);
+}

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-merge-execute.mts
+//
+// The scripts/idd-merge-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Thin F3 merge-gate evaluator + executor. It WRAPS the read-only
+// pre-merge-readiness collector (reuses its gate logic verbatim) and
+// introduces NO new decision authority: `decisionAuthority` stays
+// `instructions`. In the default dry-run it only collects evidence and
+// reports the bound merge command; the ONLY mutation anywhere is the
+// `gh pr merge` issued under `--apply` once every F3 gate holds and the
+// head + claim re-validate immediately before the merge.
+import { ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { normalizePolicyConfig } from './policy-helpers.mjs';
+import { collectPreMergeReadiness } from './pre-merge-readiness.mjs';
+import { computePreMergeReadinessBlockers } from './protocol-helpers.mjs';
+
+/**
+ * GitHub's exact `gh pr merge` failure text for the solo-CODEOWNER
+ * self-approval deadlock (#1494): a configured pull-request-only (or wider)
+ * ruleset bypass actor does not, by itself, make the plain merge command
+ * succeed -- GitHub still rejects it and suggests `--admin`. Matched
+ * case-insensitively against the caught error's stderr/stdout/message so a
+ * harmless wording variation (capitalization) does not silently miss the
+ * one error class this fallback exists for. Any OTHER merge failure (a
+ * real conflict, a CI regression surfaced late, etc.) never matches and
+ * always falls through to the unconditional hold-and-report path.
+ */
+const BASE_BRANCH_POLICY_MERGE_FAILURE_RE =
+  /base branch policy prohibits the merge/i;
+/** `reviewerStates.codeownerSelfApproval.reason` values that mean "review
+ * requirements are unmet ONLY because of an actor-scoped ruleset bypass",
+ * as opposed to `codeowner-approval-satisfied` (real approval already
+ * happened) or `non-author-codeowner-available` (a distinct human/bot
+ * codeowner exists and could review -- never eligible for this fallback).
+ */
+const SOLO_CODEOWNER_BYPASS_REASONS = new Set([
+  'pull-request-bypass-available',
+  'ruleset-bypass-available',
+]);
+/**
+ * Evaluate every F3 gate against `report` (the pre-merge-readiness summary),
+ * returning one blocker per unmet gate (`ready` is true only when the list is
+ * empty). Delegates to the shared `computePreMergeReadinessBlockers` rollup in
+ * `protocol-helpers.mts` — the single source of the merge-gate AND that
+ * `buildPreMergeReadinessSummary` also embeds as `{ ready, blockers }` — so the
+ * conjunction is defined once and no caller re-implements it. Recomputing from
+ * the report's nested evidence (rather than trusting a possibly-absent
+ * `report.blockers` field) keeps the merge gate fail-closed; the conditions
+ * mirror the written F3 gate checklist exactly and add no stricter
+ * sub-condition.
+ */
+export function evaluateMergeGates(report) {
+  return computePreMergeReadinessBlockers(report);
+}
+function asRecord(value) {
+  return value && typeof value === 'object' ? value : {};
+}
+/**
+ * #1521: the ONLY safe trigger for the solo-CODEOWNER `--admin` merge
+ * fallback. Deliberately narrower than "the required-reviews gate is not a
+ * blocker" (`codeownerSelfApproval.status === 'clear'` alone): that status
+ * also covers `non-author-codeowner-available` (a distinct, real codeowner
+ * exists) and can be reached via the bypass-detected branch even when such
+ * a non-author codeowner's review is genuinely still outstanding --
+ * `summarizeCodeownerSelfApproval` (protocol-helpers.mts) resolves the
+ * bypass branch before it ever checks for a non-author owner. This
+ * function instead requires the additive `prAuthorIsSoleEligibleCodeowner`
+ * topology fact (no team codeowners, no email codeowners, and every
+ * eligible direct-user codeowner equals the PR author), so a genuinely
+ * outstanding review from any other owner registers as its own unmet
+ * condition and never gets folded into this fallback. See the #1521
+ * multi-CODEOWNER validation tests in tests/pre-merge-readiness.test.mts
+ * and tests/idd-merge-execute.test.mts.
+ */
+export function isEligibleForSoloCodeownerAdminFallback(reviewerStates) {
+  const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
+  return (
+    String(selfApproval.status ?? '') === 'clear' &&
+    SOLO_CODEOWNER_BYPASS_REASONS.has(String(selfApproval.reason ?? '')) &&
+    selfApproval.prAuthorIsSoleEligibleCodeowner === true
+  );
+}
+/**
+ * A generic "base branch policy prohibits the merge" error can also cover
+ * merge-queue, deployment, or other branch-policy blockers that the
+ * readiness report does not model. Require GitHub's live merge state to be
+ * settled and mergeable before an administrator retry; unknown or blocked
+ * state must never be bypassed by `--admin`.
+ */
+export function isSafeSoloCodeownerAdminMergeState(
+  mergeState,
+  branchCurrency = {},
+) {
+  const mergeable = String(mergeState.mergeable ?? '');
+  const mergeStateStatus = String(mergeState.mergeStateStatus ?? '');
+  return (
+    mergeable === 'MERGEABLE' &&
+    (mergeStateStatus === 'CLEAN' ||
+      (mergeStateStatus === 'BEHIND' &&
+        branchCurrency.requiresUpToDateHead === false))
+  );
+}
+// Prepend `-R <repoRef>` to a `gh` argument array only when a repo scope is
+// set; otherwise pass the args verbatim (current-directory repo).
+function scopedGhArgs(repoRef, args) {
+  return repoRef ? ['-R', repoRef, ...args] : args;
+}
+/**
+ * Decode and classify a remote `.github/idd/config.json` read into the
+ * `mergeGate.soloCodeownerAdminFallback` policy value. Pure aside from the
+ * injected `fetchEncodedConfig` (mirrors this repo's established
+ * injectable-fetch pattern, e.g. `resolveEligibleCodeownerUserLogins` in
+ * `pre-merge-readiness.mts`) -- default resolves the real base64 `.content`
+ * field via `gh api .../contents/.github/idd/config.json`.
+ *
+ * A confirmed `404` means the target ref has no policy file: falls back to
+ * the same distributed defaults `loadIddConfig()` uses for the local-repo
+ * path. Any other fetch failure is ambiguous or malformed and rethrows
+ * (fail-closed) rather than silently mapping onto the permissive
+ * `auto-admin-retry` default -- the #1521-adjacent fail-open corner #1708
+ * pins with direct tests (previously exercised only via a full
+ * `MergeExecuteDeps` stub, never this decode-and-classify logic itself).
+ * An empty (but successfully fetched) `.content` also throws instead of
+ * being caught as "no policy file": a policy file that exists but decodes
+ * to nothing is a malformed read, not an absent one, so it must stay
+ * fail-closed too -- `deriveGhHttpStatus` on that synthetic error returns
+ * `null` (no HTTP status text to parse), which is `!== 404`, so it rethrows
+ * exactly like any other non-404 failure.
+ */
+export function resolveRemoteSoloCodeownerAdminFallbackMode(
+  prNumber,
+  repoRef,
+  headSha,
+  fetchEncodedConfig = (scopedRepoRef, ref) =>
+    ghText(
+      scopedGhArgs(scopedRepoRef, [
+        'api',
+        `repos/${scopedRepoRef}/contents/.github/idd/config.json`,
+        '--method',
+        'GET',
+        '--field',
+        `ref=${ref}`,
+        '--jq',
+        '.content',
+      ]),
+    ),
+) {
+  let config;
+  try {
+    const encodedConfig = fetchEncodedConfig(repoRef, headSha);
+    if (!encodedConfig) {
+      throw new Error(
+        `target repository policy is empty for PR #${prNumber} at ${headSha}`,
+      );
+    }
+    config = JSON.parse(
+      Buffer.from(encodedConfig.replace(/\n/g, ''), 'base64').toString('utf8'),
+    );
+  } catch (error) {
+    if (deriveGhHttpStatus(error) !== 404) {
+      throw error;
+    }
+    config = null;
+  }
+  return normalizePolicyConfig(config).mergeGate.soloCodeownerAdminFallback;
+}
+const defaultDeps = {
+  collect: (passthrough) => collectPreMergeReadiness(passthrough),
+  fetchHeadSha: (prNumber, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'view',
+        String(prNumber),
+        '--json',
+        'headRefOid',
+        '--jq',
+        '.headRefOid',
+      ]),
+    ),
+  fetchMergeState: (prNumber, repoRef) =>
+    JSON.parse(
+      ghText(
+        scopedGhArgs(repoRef, [
+          'pr',
+          'view',
+          String(prNumber),
+          '--json',
+          'mergeable,mergeStateStatus',
+          '--jq',
+          '.',
+        ]),
+      ),
+    ),
+  mergePr: (prNumber, headSha, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'merge',
+        String(prNumber),
+        // Always a merge commit — never squash/rebase. Bind to the head.
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]),
+    ),
+  mergePrAdmin: (prNumber, headSha, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'merge',
+        String(prNumber),
+        '--merge',
+        '--match-head-commit',
+        headSha,
+        '--admin',
+      ]),
+    ),
+  resolveSoloCodeownerAdminFallbackMode: (prNumber, repoRef, headSha) =>
+    repoRef
+      ? resolveRemoteSoloCodeownerAdminFallbackMode(prNumber, repoRef, headSha)
+      : normalizePolicyConfig(loadIddConfig()).mergeGate
+          .soloCodeownerAdminFallback,
+};
+/**
+ * Build the F3 verdict and, under `--apply`, execute the merge. The
+ * dry-run path performs NO mutation. The apply path fails closed: if the
+ * gate is not ready it exits without merging; if it is ready it RE-FETCHES
+ * the head SHA and RE-VALIDATES the claim immediately before merging, and
+ * refuses to merge (clear message) on any head drift or lost claim.
+ */
+export function runMergeExecute(argv, deps = defaultDeps) {
+  const args = parseArgs(argv);
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const report = deps.collect(args.passthrough);
+  const prHeadSha = String(report.prHeadSha ?? '');
+  const blockers = evaluateMergeGates(report);
+  const ready = blockers.length === 0;
+  // Scope the printed command to the same repo the merge would run against so
+  // it matches what `--apply` executes (current-directory repo when unset).
+  const repoScope = args.repoRef ? `-R ${args.repoRef} ` : '';
+  // Suppress the copy-pasteable command when the head is invalid (the
+  // head-sha gate fired): binding --match-head-commit to a non-SHA would
+  // emit a malformed, unsafe command despite the helper failing closed.
+  const hasHeadShaBlocker = blockers.some((b) => b.gate === 'head-sha');
+  const mergeCommand = hasHeadShaBlocker
+    ? ''
+    : `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+  const verdict = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    mode: args.apply ? 'apply' : 'dry-run',
+    prNumber: args.prNumber,
+    prHeadSha,
+    ready,
+    blockers,
+    mergeCommand,
+    merged: false,
+    mergeResult: '',
+    adminFallbackUsed: false,
+  };
+  if (!args.apply) {
+    // Dry-run: read-only. Never merge.
+    return { verdict, exitCode: ready ? 0 : 1 };
+  }
+  if (!ready) {
+    // Apply but not ready: fail closed, do not merge.
+    verdict.mergeResult =
+      'not-ready: gate blockers present; no merge attempted';
+    return { verdict, exitCode: 1 };
+  }
+  // Ready under --apply: re-fetch the head and re-validate the claim
+  // immediately before merging, then fail closed on any drift.
+  const revalidation = revalidateImmediatelyBeforeMerge(
+    deps,
+    args.prNumber,
+    args.repoRef,
+    args.passthrough,
+    prHeadSha,
+  );
+  if (!revalidation.ok) {
+    if (revalidation.blockers) {
+      verdict.blockers = revalidation.blockers;
+      verdict.ready = false;
+    }
+    verdict.mergeResult = revalidation.failure;
+    return { verdict, exitCode: 1 };
+  }
+  const revalidated = revalidation.report;
+  // Always a merge commit — never squash/rebase. Bind to the validated head.
+  try {
+    const mergeOutput = deps.mergePr(args.prNumber, prHeadSha, args.repoRef);
+    verdict.merged = true;
+    verdict.mergeResult = mergeOutput || 'merge command completed';
+    return { verdict, exitCode: 0 };
+  } catch (mergeError) {
+    // #1521: the plain merge command failed. Every path below stays
+    // fail-closed by default (hold-and-report, unchanged from pre-#1521
+    // behavior); the ONLY escalation is the narrow solo-CODEOWNER `--admin`
+    // retry, gated on ALL of: the exact GitHub error text, the repository
+    // not having opted into `hold-and-report`, and
+    // `isEligibleForSoloCodeownerAdminFallback` against the FRESHLY
+    // re-validated `revalidated` report collected immediately above (not
+    // the earlier, possibly-stale `report`) — the same "immediately before
+    // merging" freshness this file already applies to the head SHA and
+    // claim checks.
+    const mergeErrorText = ghErrorText(mergeError);
+    const revalidatedReviewerStates = asRecord(revalidated.reviewerStates);
+    // Ordered cheapest-first so a merge failure unrelated to the
+    // solo-CODEOWNER deadlock (a real conflict, a late CI regression, an
+    // unrelated ruleset rejection) never pays for the I/O-bound
+    // `resolveSoloCodeownerAdminFallbackMode` config read: both the regex
+    // test and the eligibility check are pure/in-memory and short-circuit
+    // `&&` before that call ever runs.
+    const eligibleByMergeEvidence =
+      BASE_BRANCH_POLICY_MERGE_FAILURE_RE.test(mergeErrorText) &&
+      isEligibleForSoloCodeownerAdminFallback(revalidatedReviewerStates);
+    if (!eligibleByMergeEvidence) {
+      verdict.mergeResult = `merge command failed: ${mergeErrorText || 'unknown error'}`;
+      return { verdict, exitCode: 1 };
+    }
+    let fallbackMode;
+    try {
+      fallbackMode = deps.resolveSoloCodeownerAdminFallbackMode(
+        args.prNumber,
+        args.repoRef,
+        prHeadSha,
+      );
+    } catch (policyError) {
+      verdict.mergeResult = `admin-fallback aborted: target repository policy unreadable: ${ghErrorText(policyError) || 'unknown error'}; no merge`;
+      return { verdict, exitCode: 1 };
+    }
+    if (fallbackMode === 'hold-and-report') {
+      verdict.mergeResult = `merge command failed: ${mergeErrorText || 'unknown error'}`;
+      return { verdict, exitCode: 1 };
+    }
+    // #1521 (Codex review on PR #1537): re-validate a SECOND time,
+    // immediately before the --admin call, rather than trusting the
+    // `revalidated` snapshot collected above. Real time has passed since
+    // then — at minimum the failed plain-merge round trip — during which
+    // a required check could flip red, a review could be dismissed, or
+    // another blocker could appear. `--admin` bypasses the ENTIRE
+    // ruleset, not just the CODEOWNER rule, so retrying on a stale
+    // snapshot could silently merge a PR that is no longer green. Also
+    // re-confirm the solo-CODEOWNER eligibility fact itself (not only the
+    // general gate), since a non-author codeowner's review could have
+    // arrived in the interim.
+    const adminRevalidation = revalidateImmediatelyBeforeMerge(
+      deps,
+      args.prNumber,
+      args.repoRef,
+      args.passthrough,
+      prHeadSha,
+    );
+    if (!adminRevalidation.ok) {
+      if (adminRevalidation.blockers) {
+        verdict.blockers = adminRevalidation.blockers;
+        verdict.ready = false;
+      }
+      verdict.mergeResult = `admin-fallback aborted: ${adminRevalidation.failure}`;
+      return { verdict, exitCode: 1 };
+    }
+    const adminReviewerStates = asRecord(
+      adminRevalidation.report.reviewerStates,
+    );
+    if (!isEligibleForSoloCodeownerAdminFallback(adminReviewerStates)) {
+      verdict.mergeResult =
+        'admin-fallback aborted: solo-CODEOWNER eligibility no longer holds on re-validation; no merge';
+      return { verdict, exitCode: 1 };
+    }
+    let mergeState;
+    try {
+      mergeState = deps.fetchMergeState(args.prNumber, args.repoRef);
+    } catch (mergeStateError) {
+      verdict.mergeResult = `admin-fallback aborted: live merge state unreadable: ${ghErrorText(mergeStateError) || 'unknown error'}`;
+      return { verdict, exitCode: 1 };
+    }
+    if (
+      !isSafeSoloCodeownerAdminMergeState(
+        mergeState,
+        asRecord(adminRevalidation.report.branchCurrency),
+      )
+    ) {
+      verdict.mergeResult =
+        'admin-fallback aborted: live merge state is not settled and mergeable; no merge';
+      return { verdict, exitCode: 1 };
+    }
+    verdict.adminFallbackUsed = true;
+    try {
+      const adminMergeOutput = deps.mergePrAdmin(
+        args.prNumber,
+        prHeadSha,
+        args.repoRef,
+      );
+      verdict.merged = true;
+      // Keep mergeCommand in sync with the command that actually mutated
+      // the PR: an audit/log consumer reading this field alone (without
+      // also checking adminFallbackUsed) must not see the plain,
+      // non-`--admin` command after an admin-fallback merge succeeded.
+      verdict.mergeCommand = `${verdict.mergeCommand} --admin`;
+      verdict.mergeResult = `admin-fallback (#1521 solo-CODEOWNER deadlock): ${adminMergeOutput || 'merge command completed'}`;
+      return { verdict, exitCode: 0 };
+    } catch (adminMergeError) {
+      verdict.mergeResult = `admin-fallback merge also failed: ${ghErrorText(adminMergeError) || 'unknown error'}`;
+      return { verdict, exitCode: 1 };
+    }
+  }
+}
+/**
+ * Fetch the live head SHA and a fresh readiness report, then validate
+ * head-match, claim-match, and zero blockers — the fail-closed check
+ * this file applies "immediately before merging". Factored out (#1521,
+ * Codex review) so the SAME check can run a second time immediately
+ * before the `--admin` retry, not just once before the plain merge
+ * attempt: real time passes between the two (at minimum the failed
+ * plain merge's own round trip), and `--admin` bypasses the entire
+ * ruleset, so it must never act on a stale snapshot.
+ */
+function revalidateImmediatelyBeforeMerge(
+  deps,
+  prNumber,
+  repoRef,
+  passthrough,
+  prHeadSha,
+) {
+  let liveHeadSha;
+  try {
+    liveHeadSha = deps.fetchHeadSha(prNumber, repoRef);
+  } catch (error) {
+    return {
+      ok: false,
+      failure: `head re-validation failed: ${ghErrorText(error) || 'unknown error'}; no merge`,
+    };
+  }
+  if (liveHeadSha !== prHeadSha) {
+    return {
+      ok: false,
+      failure: `head drift: validated ${prHeadSha} but live head is ${liveHeadSha}; no merge`,
+    };
+  }
+  let report;
+  try {
+    report = deps.collect(passthrough);
+  } catch (error) {
+    return {
+      ok: false,
+      failure: `readiness re-validation failed: ${ghErrorText(error) || 'unknown error'}; no merge`,
+    };
+  }
+  if (String(report.prHeadSha ?? '') !== prHeadSha) {
+    return {
+      ok: false,
+      failure: `head drift on re-validation: ${String(report.prHeadSha ?? '')} != ${prHeadSha}; no merge`,
+    };
+  }
+  const claim = asRecord(report.claim);
+  if (claim.matchesExpectedClaim !== true) {
+    return {
+      ok: false,
+      failure: `claim lost on re-validation (reason="${String(claim.reason ?? 'unknown')}"); no merge`,
+    };
+  }
+  const blockers = evaluateMergeGates(report);
+  if (blockers.length > 0) {
+    return {
+      ok: false,
+      failure:
+        're-validation found new blockers immediately before merge; no merge',
+      blockers,
+    };
+  }
+  return { ok: true, report };
+}
+// Excluded from the #1446 cli-args.mts wrapper: `passthrough` below
+// collects every unrecognized flag (plus its value, when present) into an
+// array forwarded verbatim to the collector, rather than rejecting it
+// against a fixed declared spec. `util.parseArgs`'s `strict: true` rejects
+// any option not named in its static spec, and `strict: false` would
+// instead coerce every unrecognized flag to `true` -- neither matches this
+// file's "collect and forward whatever the collector itself accepts"
+// contract.
+function parseArgs(argv) {
+  const parsed = {
+    prNumber: null,
+    passthrough: [],
+    apply: false,
+    repoRef: null,
+  };
+  // Captured locally so `repoRef` is set only when BOTH are present; these
+  // are ALSO forwarded to the collector via passthrough (we do not stop
+  // forwarding them — the collector still scopes its own gh/API calls).
+  let owner = '';
+  let repo = '';
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--apply') {
+      parsed.apply = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (token === '--pr') {
+      const value = argv[index + 1];
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.passthrough.push(token, value ?? '');
+      index += 1;
+      continue;
+    }
+    if (token === '--owner' || token === '--repo') {
+      const value = argv[index + 1];
+      if (token === '--owner') {
+        owner = value ?? '';
+      } else {
+        repo = value ?? '';
+      }
+      // Keep forwarding to the collector so it still validates this repo.
+      parsed.passthrough.push(token, value ?? '');
+      index += 1;
+      continue;
+    }
+    // Every other flag (and its value, if it takes one) is forwarded
+    // verbatim to the pre-merge-readiness collector so the two CLIs accept
+    // an identical flag surface without re-declaring it here.
+    if (token.startsWith('--')) {
+      const value = argv[index + 1];
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.passthrough.push(token, value);
+        index += 1;
+      } else {
+        parsed.passthrough.push(token);
+      }
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+  // Fail closed on exactly one of `--owner` / `--repo`: the collector
+  // (`pre-merge-readiness`) fills the missing half from the
+  // current-directory repo, so a single flag would validate one repoRef
+  // while the head re-fetch and merge run against the current-directory
+  // repo — an unsafe split under `--apply`. Require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'idd-merge-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
+  // Both provided → scope to `<owner>/<repo>`. Neither → null, so the
+  // collector, the head re-fetch, and the merge all default to the
+  // current-directory repo (consistent).
+  parsed.repoRef = owner && repo ? `${owner}/${repo}` : null;
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--idd-agent-logins <login1,login2>] [--now <ISO8601>] [--apply]
+
+  Every flag except --apply is forwarded verbatim to the read-only
+  pre-merge-readiness collector, so the full collector flag surface is
+  accepted here — including --idd-agent-logins, --now, and the deprecated
+  --expected-claim-id / --expected-agent-id aliases. --owner and --repo
+  must be passed together or not at all.
+
+  Default (no --apply): dry-run. Evaluates every F3 merge gate via the
+  read-only pre-merge-readiness collector and prints { ready, blockers,
+  mergeCommand } without merging. Exit 0 when ready, 1 otherwise.
+
+  --apply: when ready, re-fetch the head SHA and re-validate the claim
+  immediately before merging, then run a merge commit bound to the
+  validated head. Fails closed (exit 1, no merge) on head drift or lost
+  claim. Never squash/rebase merges. The merge is the only mutation.
+
+  #1521 solo-CODEOWNER --admin fallback: if the plain merge command fails
+  with GitHub's "base branch policy prohibits the merge" error, and the
+  repository has not set mergeGate.soloCodeownerAdminFallback to
+  "hold-and-report" in .github/idd/config.json, this retries ONCE with
+  --admin -- but ONLY when reviewerStates.codeownerSelfApproval proves the
+  PR author is the sole eligible codeowner (status "clear", a bypass-actor
+  reason, and prAuthorIsSoleEligibleCodeowner true). A genuinely
+  outstanding review from any other codeowner never triggers this retry.
+  The retry also requires a second immediate head/claim/readiness
+  re-validation and a live MERGEABLE state; a BEHIND state is accepted only
+  when the fresh branch-currency evidence says an up-to-date head is not
+  required. Unreadable or unsafe live state aborts the retry.
+  The verdict's adminFallbackUsed field records whether this path fired.
+`);
+}
+// CLI: print the verdict as JSON and exit with the gate/merge status.
+if (import.meta.main) {
+  const { verdict, exitCode } = runMergeExecute(process.argv.slice(2));
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  process.exit(exitCode);
+}

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -1,0 +1,1295 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-roadmap-audit-execute.mts
+//
+// The scripts/idd-roadmap-audit-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Thin A1.5 roadmap-completion-audit evaluator + executor. It WRAPS the
+// read-only discover-roadmap-graph traversal (reuses its child enumeration
+// verbatim) and introduces NO new decision authority: `decisionAuthority`
+// stays `instructions`. In the default dry-run it only evaluates completion
+// and reports the canonical `IDD roadmap completion audit` evidence body; the
+// ONLY mutations anywhere (the evidence comment, the close, and the unclaim
+// marker) happen under `--apply` once the roadmap is ready AND the
+// roadmap-audit claim re-validates immediately before the close. A roadmap
+// with an open / unresolved / inaccessible / nested-roadmap descendant, a
+// closed child with an open linked PR, a traversal cycle, or no explicit child
+// work is NEVER closed.
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  buildIssueLoader,
+  buildSubIssueLoader,
+  enumerateRoadmapGraph,
+  isClaimStaleByAge,
+  parseClaimStaleAgeMs,
+} from './discover-roadmap-graph.mjs';
+import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import {
+  renderUnclaimedByMarker,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+} from './protocol-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Distributed `claim-stale-age` default (docs/policy-constants.md: 24 h). Used
+// only as the fallback when the policy declares no (or an invalid)
+// `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+// The canonical evidence comment's literal leading heading. Shared by the
+// body composer (`buildRoadmapCompletionAuditBody`) and the evidence
+// detector (`hasTrustedCompletionEvidenceComment`, #1299) so the two never
+// drift out of sync.
+const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
+// Scope caveat (A1.5): this helper gates only the MECHANICAL completion
+// preconditions. It deliberately does NOT verify the roadmap's free-form
+// success criteria or autonomy-gap items — that is agent judgment "where
+// feasible" per the instruction — so the caller must confirm those separately
+// before --apply, exactly as the merge gate trusts that review actually
+// happened.
+const MECHANICAL_GATE_NOTE =
+  'Mechanical preconditions only: every descendant is closed/complete with no open / unresolved / inaccessible / linked-PR / nested-roadmap / childless / cycle / human-gate blocker. Separately verify the roadmap’s free-form success criteria and autonomy-gap items before --apply (this helper does not, just as the merge gate trusts that review happened).';
+/** Branch field that scopes a roadmap-audit coordination claim to one roadmap. */
+function roadmapAuditBranchPattern(roadmapNumber) {
+  return new RegExp(`^roadmap-audit/${roadmapNumber}-`);
+}
+/**
+ * Evaluate roadmap completion against `report` (a discover-roadmap-graph
+ * single-root traversal). Every open / unresolved / inaccessible / nested-
+ * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
+ * childless/malformed roadmap is collected as a blocker; `ready` is true only
+ * when no blocker is collected. The rules mirror the written A1.5 completion
+ * criteria exactly — this helper adds no stricter sub-condition. One shape is
+ * interpreted as safe rather than ambiguous (#1278): a `reference` back-edge
+ * from a non-roadmap execution leaf is the provenance breadcrumb the A1.5
+ * follow-up rule itself requires, so it never blocks as a cycle (an open
+ * leaf still blocks as `open-child`). Pure and
+ * network-free so it is unit-testable apart from live GitHub.
+ */
+export function evaluateRoadmapAuditGates(report, options = {}) {
+  const blockers = [];
+  const rootNumber = report.root.number;
+  const pathTo = buildProvenanceLookup(report);
+  const openLinkedPrIssues = new Set(options.openLinkedPrIssues ?? []);
+  const reachableExecutionLeafCount = buildReachableLeafCounter(report);
+  const blockedLabels = new Set([
+    normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  ]);
+  // Root carrying a human-gate label is never auto-closed.
+  const rootNode = report.nodes.find((node) => node.number === rootNumber);
+  const rootBlockedLabel = (rootNode?.labels ?? []).find((label) =>
+    blockedLabels.has(label),
+  );
+  if (rootBlockedLabel) {
+    blockers.push({
+      kind: 'roadmap-blocked',
+      target: rootNumber,
+      provenance: [rootNumber],
+      detail: `roadmap #${rootNumber} carries "${rootBlockedLabel}"; resolve the human gate before closing`,
+    });
+  }
+  // No explicit child work → childless / malformed. Do not infer completion
+  // from the absence of candidates.
+  if (report.edges.length === 0) {
+    blockers.push({
+      kind: 'childless',
+      detail: `roadmap #${rootNumber} has no explicit child references (task-list, closing-keyword, or GitHub sub-issue); childless or malformed, not complete`,
+    });
+  }
+  // Open execution leaves (already classification === 'execution' && OPEN).
+  for (const target of [...report.executionCandidates].sort((a, b) => a - b)) {
+    const node = report.nodes.find((entry) => entry.number === target);
+    blockers.push({
+      kind: 'open-child',
+      target,
+      provenance: pathTo(target),
+      detail: `execution leaf #${target}${node ? ` "${node.title}"` : ''} is OPEN`,
+    });
+  }
+  // Nested roadmaps block the parent close when they are either (a) still
+  // OPEN — a coordination/audit node closes bottom-up before its parent — or
+  // (b) malformed: zero reachable execution-leaf descendants, so a CLOSED
+  // nested roadmap can never be taken as proof of completion (A1.5). A closed
+  // nested roadmap WITH reachable leaves is fine on its own; any open leaf
+  // beneath it is surfaced separately as its own blocker.
+  const nestedRoadmaps = report.nodes
+    .filter(
+      (node) => node.classification === 'roadmap' && node.number !== rootNumber,
+    )
+    .sort((left, right) => left.number - right.number);
+  for (const node of nestedRoadmaps) {
+    if (reachableExecutionLeafCount(node.number) === 0) {
+      blockers.push({
+        kind: 'nested-roadmap',
+        target: node.number,
+        provenance: pathTo(node.number),
+        detail: `nested roadmap #${node.number} "${node.title}" has no reachable execution-leaf descendants; childless or malformed, not proof of completion`,
+      });
+      continue;
+    }
+    if (node.state === 'OPEN') {
+      blockers.push({
+        kind: 'nested-roadmap',
+        target: node.number,
+        provenance: pathTo(node.number),
+        detail: `nested roadmap #${node.number} "${node.title}" is OPEN; close it (bottom-up) before its parent`,
+      });
+    }
+  }
+  // A CLOSED child that still has an OPEN linked / closing PR is unresolved:
+  // the child looks done but its work is in flight (A1.5). Open children are
+  // already blocked above, so only closed descendants are flagged here. The
+  // open-PR set is injected as data so the evaluator stays pure.
+  const openLinkedPrTargets = report.nodes
+    .filter(
+      (node) =>
+        node.number !== rootNumber &&
+        node.state !== 'OPEN' &&
+        openLinkedPrIssues.has(node.number),
+    )
+    .map((node) => node.number)
+    .sort((left, right) => left - right);
+  for (const target of openLinkedPrTargets) {
+    const node = report.nodes.find((entry) => entry.number === target);
+    blockers.push({
+      kind: 'open-linked-pr',
+      target,
+      provenance: pathTo(target),
+      detail: `closed child #${target}${node ? ` "${node.title}"` : ''} still has an OPEN linked/closing PR; treat as unresolved until it merges or is obsoleted`,
+    });
+  }
+  // Unresolved references (target issue not found / is a PR).
+  for (const diagnostic of report.diagnostics.unresolvedReferences) {
+    blockers.push({
+      kind: 'unresolved-reference',
+      target: diagnostic.target,
+      provenance: [...pathTo(diagnostic.source), diagnostic.target],
+      detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is unresolved: ${diagnostic.reason}`,
+    });
+  }
+  // Inaccessible references (403/410/451): cannot prove completion.
+  for (const diagnostic of report.diagnostics.inaccessibleReferences) {
+    blockers.push({
+      kind: 'inaccessible-reference',
+      target: diagnostic.target,
+      provenance: [...pathTo(diagnostic.source), diagnostic.target],
+      detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is inaccessible: ${diagnostic.reason}`,
+    });
+  }
+  // Cycles / ambiguous graph: do not guess a closure order. A `reference`
+  // back-edge whose source is a non-roadmap execution leaf is exempt (#1278):
+  // a closed leaf's `Refs #<roadmap>` breadcrumb is the provenance the A1.5
+  // follow-up rule requires, and an open leaf is already blocked above as
+  // `open-child`, so the audit still fails closed while reporting the true
+  // cause. Roadmap-source cycles, unknown-source cycles, stronger
+  // relationships (task-list / dependency / closing-keyword / sub-issue),
+  // and execution sources in any other state keep blocking.
+  const openExecutionLeaves = new Set(report.executionCandidates);
+  for (const cycle of report.diagnostics.cycles) {
+    const sourceNode = report.nodes.find(
+      (entry) => entry.number === cycle.source,
+    );
+    if (
+      cycle.relationship === 'reference' &&
+      sourceNode?.classification === 'execution' &&
+      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source))
+    ) {
+      continue;
+    }
+    blockers.push({
+      kind: 'cycle',
+      target: cycle.target,
+      provenance: cycle.path,
+      detail: `traversal cycle ${cycle.path.join(' → ')} (${cycle.relationship}); graph is ambiguous, treat as unresolved`,
+    });
+  }
+  return blockers;
+}
+/** First (sorted) root→target provenance path, or `[]` when none is recorded. */
+function buildProvenanceLookup(report) {
+  const lookup = new Map();
+  for (const entry of report.provenancePaths) {
+    if (!lookup.has(entry.target)) {
+      lookup.set(entry.target, entry.path);
+    }
+  }
+  return (target) => lookup.get(target) ?? [];
+}
+/**
+ * Count, for any node, how many distinct execution-leaf descendants are
+ * reachable from it via the enumerated graph edges (an execution-classified
+ * node present in `nodes`, open or closed). Uses only the graph/edge data the
+ * traversal already produced; a cycle-safe `visited` set bounds the walk. A
+ * count of 0 means the node has no reachable leaf descendants — childless /
+ * malformed per A1.5.
+ */
+function buildReachableLeafCounter(report) {
+  const adjacency = new Map();
+  for (const edge of report.edges) {
+    const targets = adjacency.get(edge.source) ?? [];
+    targets.push(edge.target);
+    adjacency.set(edge.source, targets);
+  }
+  const executionLeaves = new Set(
+    report.nodes
+      .filter((node) => node.classification === 'execution')
+      .map((node) => node.number),
+  );
+  return (from) => {
+    const visited = new Set([from]);
+    const stack = [from];
+    const leaves = new Set();
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (current === undefined) {
+        break;
+      }
+      for (const next of adjacency.get(current) ?? []) {
+        if (executionLeaves.has(next)) {
+          leaves.add(next);
+        }
+        if (!visited.has(next)) {
+          visited.add(next);
+          stack.push(next);
+        }
+      }
+    }
+    return leaves.size;
+  };
+}
+/**
+ * Compose the canonical `IDD roadmap completion audit` evidence comment body.
+ * Deterministic and network-free: it summarizes the audited graph (node /
+ * edge / depth counts, closed descendants split by classification, and the
+ * traversal diagnostics) and asserts no open / unresolved / inaccessible /
+ * nested-roadmap descendant remains. Only called when the roadmap is ready,
+ * so every descendant is closed or otherwise complete.
+ */
+export function buildRoadmapCompletionAuditBody(report) {
+  const rootNumber = report.root.number;
+  const descendants = report.nodes.filter((node) => node.number !== rootNumber);
+  const executionCount = descendants.filter(
+    (node) => node.classification === 'execution',
+  ).length;
+  const nestedRoadmapCount = descendants.filter(
+    (node) => node.classification === 'roadmap',
+  ).length;
+  const closedExecution = descendants
+    .filter((node) => node.classification === 'execution')
+    .map((node) => `#${node.number}`)
+    .join(', ');
+  const closedNested = descendants
+    .filter((node) => node.classification === 'roadmap')
+    .map((node) => `#${node.number}`)
+    .join(', ');
+  return [
+    COMPLETION_AUDIT_HEADING,
+    '',
+    `Roadmap #${rootNumber} "${report.root.title}" audited as complete: every referenced child and descendant issue is closed or otherwise complete.`,
+    '',
+    'Evidence:',
+    `- Graph: ${report.summary.nodeCount} nodes, ${report.summary.edgeCount} edges, max depth ${report.summary.maxDepth}.`,
+    `- Closed descendants: ${descendants.length} (${executionCount} execution leaves, ${nestedRoadmapCount} nested roadmaps).`,
+    `- Closed execution leaves: ${closedExecution || 'none'}.`,
+    `- Closed nested roadmaps: ${closedNested || 'none'}.`,
+    '- Open / unresolved / inaccessible / nested-roadmap / open-linked-PR descendants: none.',
+    `- Diagnostics: ${report.summary.cycleCount} cycles, ${report.summary.unresolvedReferenceCount} unresolved references, ${report.summary.inaccessibleReferenceCount} inaccessible references, ${report.summary.duplicateReferenceCount} duplicate references.`,
+    '',
+    'Closing the roadmap as completed.',
+    '',
+    '_IDD roadmap-audit automation. Do not edit._',
+  ].join('\n');
+}
+/**
+ * Reconcile a chronological CONNECTED / DISCONNECTED linked-PR event stream
+ * into the PR numbers that are CURRENTLY connected (the last event for the PR
+ * is a connect, with no later disconnect) AND in the `OPEN` state. Mirrors
+ * resume-claim-routing's `fetchOpenLinkedPrReferences` reconciliation so an
+ * open PR merely linked (no closing keyword) still blocks a roadmap close,
+ * while a CONNECTED-then-DISCONNECTED PR or a connected MERGED PR does not.
+ * Pure so it is unit-testable without `gh`.
+ */
+export function reconcileConnectedOpenPrs(events) {
+  const connected = new Map();
+  const states = new Map();
+  for (const event of events) {
+    if (!Number.isInteger(event.prNumber)) {
+      continue;
+    }
+    if (event.type === 'connected') {
+      connected.set(event.prNumber, true);
+      states.set(event.prNumber, String(event.state ?? ''));
+    } else if (event.type === 'disconnected') {
+      connected.set(event.prNumber, false);
+    }
+  }
+  const open = [];
+  for (const [prNumber, isConnected] of connected) {
+    if (isConnected && states.get(prNumber) === 'OPEN') {
+      open.push(prNumber);
+    }
+  }
+  return open.sort((left, right) => left - right);
+}
+/**
+ * Re-validate the roadmap-audit claim from the live claim-marker stream. The
+ * shared `summarizeClaimValidation` resolver decides claim ownership exactly
+ * as the merge gate does (trusted-author gated, claim-id / agent-id match).
+ * This helper additionally enforces the two roadmap-side ownership rules of
+ * A1.5:
+ *
+ *  1. the active claim's `branch` must be the `roadmap-audit/<roadmapNumber>-…`
+ *     coordination branch for THIS roadmap — a normal execution claim such as
+ *     `issue/123-fix` on the roadmap issue does NOT authorize closure; and
+ *  2. the claim must not be STALE relative to `nowIso`, using the configured
+ *     `claimTiming.staleAge` (`staleAgeMs`, default 24 h) via the shared
+ *     `isClaimStaleByAge` — a stale claim is takeover-eligible and so cannot
+ *     prove ongoing ownership.
+ *
+ * Pure and network-free: the comment stream, trusted-author predicate, and
+ * stale age are injected so every fail-closed path is unit-testable.
+ */
+export function evaluateRoadmapClaim(comments, options) {
+  const summary = summarizeClaimValidation(comments, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    expectedClaimId: options.expectedClaimId,
+    expectedAgentId: options.expectedAgentId,
+  });
+  if (!summary.matchesExpectedClaim) {
+    return {
+      owned: false,
+      reason: summary.reason,
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  // Roadmap-side ownership requires the roadmap-audit coordination branch for
+  // exactly this roadmap; a normal execution claim on the roadmap issue does
+  // not authorize the close.
+  if (
+    !roadmapAuditBranchPattern(options.roadmapNumber).test(
+      summary.activeClaim.branch,
+    )
+  ) {
+    return {
+      owned: false,
+      reason: 'claim-branch-mismatch',
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  // Staleness uses the configured stale age (default 24 h); the math is reused
+  // verbatim from the shared `isClaimStaleByAge` rather than re-derived here.
+  const stale = isClaimStaleByAge(
+    summary.activeClaim.createdAt,
+    options.nowIso,
+    options.staleAgeMs ?? DEFAULT_CLAIM_STALE_AGE_MS,
+  );
+  if (stale) {
+    return {
+      owned: false,
+      reason: 'claim-stale',
+      stale: true,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  return {
+    owned: true,
+    reason: 'match',
+    stale: false,
+    activeClaim: summary.activeClaim,
+  };
+}
+/**
+ * Fallback explanation for a {@link RoadmapClaimVerdict.reason} /
+ * {@link ClaimValidationSummary} `reason` code this map does not (yet)
+ * recognize. Keeps {@link explainRoadmapClaimReason} total instead of
+ * throwing or returning an empty string for a future/unlisted code.
+ */
+const UNKNOWN_CLAIM_REASON_EXPLANATION =
+  'unrecognized claim-verification reason code';
+/**
+ * Human-readable explanation for every `reason` code {@link evaluateRoadmapClaim}
+ * (and the `summarizeClaimValidation` it wraps) can produce (#1396). The codes
+ * themselves stay stable, machine-readable strings — several are asserted by
+ * exact equality in tests — so this map is additive: it never replaces
+ * `RoadmapClaimVerdict.reason`, it only makes the CLI's human-facing `result`
+ * messages self-describing, so a policy rejection (e.g. a normal execution
+ * claim rejected for lacking the roadmap-audit coordination branch) is never
+ * misread as an unexplained fetch failure.
+ */
+const CLAIM_REASON_EXPLANATIONS = {
+  match:
+    'the claim is owned: claim-id, agent-id, branch, and staleness all match',
+  'missing-active-claim':
+    'no active claim is present on the roadmap issue (no trusted claimed-by comment, or it was released/superseded)',
+  'claim-id-mismatch':
+    "the active claim's claim-id does not match the claim-id this run expected to own",
+  'agent-id-mismatch':
+    "the active claim's agent-id does not match the agent-id this run expected to own",
+  'claim-branch-mismatch':
+    'the audit only accepts roadmap-audit/<n>-* coordination claims; a normal execution claim (e.g. issue/<n>-...) on the roadmap issue does not authorize closure',
+  'claim-stale':
+    'the active claim is older than the configured stale age and is takeover-eligible, so it cannot prove ongoing ownership',
+};
+/**
+ * Resolve the human-readable explanation for a claim-verification `reason`
+ * code. Total: an unrecognized code (never emitted by the current
+ * `evaluateRoadmapClaim` / `summarizeClaimValidation` vocabulary, but a safe
+ * default for any future addition) reports
+ * {@link UNKNOWN_CLAIM_REASON_EXPLANATION} instead of throwing or silently
+ * omitting an explanation.
+ */
+export function explainRoadmapClaimReason(reason) {
+  return CLAIM_REASON_EXPLANATIONS[reason] ?? UNKNOWN_CLAIM_REASON_EXPLANATION;
+}
+/**
+ * Trailing caveat appended to a claim-not-owned `result` message when the
+ * production viewer-login lookup failed (#1396). Empty string when the
+ * lookup succeeded (or was never attempted, e.g. injected test deps), so the
+ * common-case message is unaffected. Kept as its own function so all three
+ * not-owned call sites in {@link runRoadmapAuditExecute} render the exact
+ * same caveat text.
+ */
+function viewerLoginUnavailableCaveat(viewerLoginUnavailable) {
+  return viewerLoginUnavailable
+    ? ' NOTE: the viewer-login lookup failed for this run, so trusted-author resolution may be incomplete — this not-owned result could stem from that instead of a genuine claim conflict.'
+    : '';
+}
+/**
+ * Detect the helper's own canonical `IDD roadmap completion audit` evidence
+ * comment (the exact heading `buildRoadmapCompletionAuditBody` emits) among
+ * `comments`, posted by an author for which `isTrustedAuthor` is true. Used
+ * only to recognize the idempotent "already complete" retry case (#1299)
+ * when the `--apply` early claim re-validation finds no owned claim but the
+ * live roadmap is already CLOSED — never to gate the primary close itself,
+ * which always requires a freshly re-validated claim. Pure and network-free
+ * so it is unit-testable apart from live GitHub.
+ */
+export function hasTrustedCompletionEvidenceComment(comments, isTrustedAuthor) {
+  return (comments ?? []).some(
+    (comment) =>
+      String(comment.body ?? '').startsWith(COMPLETION_AUDIT_HEADING) &&
+      isTrustedAuthor(String(comment.author?.login ?? '')),
+  );
+}
+/**
+ * Run `check` and treat any thrown error as "no evidence" (`false`) rather
+ * than letting it propagate. The #1299 already-complete recognition is only
+ * ever meant to convert one already-provable claim-loss shape into a nicer
+ * idempotent success — it must never leave the helper worse off than the
+ * pre-existing fail-closed `claim not owned …; no mutation` exit it sits in
+ * front of. Production wires this around the live `gh` comment fetch, whose
+ * `ghText` throws on any non-zero exit (transient network blip, rate limit,
+ * auth hiccup): without this wrapper such a failure would crash the whole
+ * helper instead of falling through to that already-correct fail-closed
+ * message (flagged by Copilot review on PR #1303). Pure given a
+ * non-throwing `check`, so the catch behavior itself is unit-testable
+ * without live `gh`.
+ */
+export function safeHasTrustedCompletionEvidence(check) {
+  try {
+    return check();
+  } catch {
+    return false;
+  }
+}
+/**
+ * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
+ * path performs NO mutation. The apply path fails closed: if the roadmap is
+ * not ready it exits without mutating; if it is ready it RE-VALIDATES the
+ * roadmap-audit claim and RE-EVALUATES the roadmap graph immediately before
+ * mutating, then refuses to mutate (clear message) on any lost / stale / non-
+ * owned claim or any newly-discovered blocker. Only after both re-validations
+ * pass does it post the evidence comment, close the roadmap, and release the
+ * claim — in that order.
+ *
+ * One claim-loss shape at the EARLY re-validation is recognized as a distinct
+ * idempotent no-op instead of a bare failure (#1299): a retry after a prior
+ * `--apply` already fully completed (e.g. its stdout was lost) finds no owned
+ * claim because that prior run already released it. When the live roadmap is
+ * already CLOSED and carries this helper's own canonical evidence comment
+ * from a trusted marker actor, report `already-complete` (exit 0) rather than
+ * the generic claim-not-owned error. Every other claim-loss shape — roadmap
+ * still open, closed without trusted evidence — keeps the unchanged
+ * fail-closed behavior.
+ */
+export async function runRoadmapAuditExecute(argv, deps) {
+  const args = parseArgs(argv);
+  if (!args.roadmapNumber) {
+    throw new Error('missing required --roadmap <number> argument');
+  }
+  const roadmapNumber = args.roadmapNumber;
+  const resolvedDeps = deps ?? createProductionDeps(args);
+  const report = await resolvedDeps.collect(roadmapNumber);
+  const blockers = evaluateRoadmapAuditGates(report, {
+    openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
+      closedDescendantNumbers(report),
+    ),
+    blockedByHumanLabelName: resolvedDeps.blockedByHumanLabelName,
+    needsDecisionLabelName: resolvedDeps.needsDecisionLabelName,
+  });
+  const ready = blockers.length === 0;
+  const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
+  const verdict = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    mode: args.apply ? 'apply' : 'dry-run',
+    roadmapNumber,
+    ready,
+    blockers,
+    evidenceBody,
+    closed: false,
+    claimReleased: false,
+    result: '',
+    // Present only when the lookup genuinely failed (#1396): keeps the
+    // common healthy-path JSON byte-identical to before this field existed.
+    ...(resolvedDeps.viewerLoginUnavailable
+      ? { viewerLoginUnavailable: true }
+      : {}),
+  };
+  if (!args.apply) {
+    // Dry-run: read-only. Never mutate. Surface the scope caveat so a caller
+    // does not mistake a mechanical "ready" for a full success-criteria audit.
+    verdict.result = MECHANICAL_GATE_NOTE;
+    return { verdict, exitCode: ready ? 0 : 1 };
+  }
+  if (!ready) {
+    // Apply but not ready: fail closed, do not mutate.
+    verdict.result =
+      'not-ready: completion blockers present; no comment, close, or claim release attempted';
+    return { verdict, exitCode: 1 };
+  }
+  if (!args.claimId) {
+    // Apply requires the caller to assert which claim it owns; fail closed.
+    verdict.result =
+      'not-applied: --claim-id is required under --apply to re-validate roadmap-audit ownership';
+    return { verdict, exitCode: 1 };
+  }
+  // The roadmap-audit claim is scoped to the EXACT roadmap being mutated; a
+  // divergent --claim-issue would validate ownership elsewhere while closing
+  // this roadmap. Reject it (fail closed) and always validate on the roadmap.
+  if (args.claimIssue !== null && args.claimIssue !== roadmapNumber) {
+    verdict.result = `claim-issue #${args.claimIssue} must equal the roadmap #${roadmapNumber}; roadmap-audit ownership is scoped to the exact roadmap`;
+    return { verdict, exitCode: 1 };
+  }
+  // Validate + normalize the apply-time clock ONCE, before any mutation: an
+  // unparseable "now" would mis-evaluate claim staleness, and an offset /
+  // sub-second form would reach the unclaim renderer (which accepts only `…Z`
+  // second-precision) and throw AFTER the comment + close had already landed.
+  // The single normalized value is reused for every staleness check AND the
+  // release marker.
+  const rawNow = resolvedDeps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
+    verdict.result = `invalid "now" value "${rawNow}"; expected a parseable ISO timestamp (no mutation)`;
+    return { verdict, exitCode: 1 };
+  }
+  // Early claim re-validation (defense in depth): bail before the graph
+  // re-fetch if ownership is already gone.
+  const earlyClaim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!earlyClaim.owned) {
+    // #1299: a lost/missing claim here is indistinguishable from a race or
+    // hijack UNLESS the live roadmap independently proves the audit already
+    // completed — already CLOSED, carrying this helper's own canonical
+    // evidence comment from a trusted marker actor (`report` is the graph
+    // already fetched at the top of this invocation, so this reuses that
+    // read rather than a fresh one). Recognize that one positively-provable
+    // state as an idempotent no-op success instead of the fail-closed
+    // claim-not-owned error; every other claim-loss shape (roadmap still
+    // open, closed without trusted evidence) is unchanged.
+    if (
+      report.root.state === 'CLOSED' &&
+      resolvedDeps.hasTrustedCompletionEvidence(roadmapNumber)
+    ) {
+      verdict.closed = true;
+      verdict.result = `already-complete: roadmap #${roadmapNumber} is already closed with a trusted IDD roadmap completion audit evidence comment (claim reason="${earlyClaim.reason}"); idempotent no-op, no mutation performed`;
+      return { verdict, exitCode: 0 };
+    }
+    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}": ${explainRoadmapClaimReason(earlyClaim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
+    return { verdict, exitCode: 1 };
+  }
+  // Re-fetch the roadmap + child state and confirm the audit input still
+  // holds; a roadmap that gained an open / unresolved / nested-roadmap /
+  // open-linked-PR descendant between the first read and now must NEVER be
+  // closed.
+  const revalidated = await resolvedDeps.collect(roadmapNumber);
+  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated, {
+    openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
+      closedDescendantNumbers(revalidated),
+    ),
+    blockedByHumanLabelName: resolvedDeps.blockedByHumanLabelName,
+    needsDecisionLabelName: resolvedDeps.needsDecisionLabelName,
+  });
+  if (revalidatedBlockers.length > 0) {
+    verdict.blockers = revalidatedBlockers;
+    verdict.ready = false;
+    verdict.evidenceBody = '';
+    verdict.result =
+      're-validation found new completion blockers immediately before close; no mutation';
+    return { verdict, exitCode: 1 };
+  }
+  // The graph re-fetch can span many API calls during which another session
+  // can take over, so re-validate ownership immediately before posting.
+  const claim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!claim.owned) {
+    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}": ${explainRoadmapClaimReason(claim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
+    return { verdict, exitCode: 1 };
+  }
+  // Post the evidence comment (non-destructive), THEN re-validate ownership one
+  // final time immediately before the CLOSE: a takeover landing in the
+  // comment→close gap must not let us close under a claim we no longer own. An
+  // already-posted evidence comment before an aborted close is harmless — the
+  // successor session simply re-audits — but a wrongful close is destructive.
+  const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
+  verdict.evidenceBody = finalEvidenceBody;
+  resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
+  const preCloseClaim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!preCloseClaim.owned) {
+    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}": ${explainRoadmapClaimReason(preCloseClaim.reason)}); evidence comment posted but roadmap NOT closed${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
+    return { verdict, exitCode: 1 };
+  }
+  // Ownership held through the comment: close, then release using the last
+  // verdict's activeClaim and the normalized second-precision "now".
+  resolvedDeps.closeRoadmap(roadmapNumber);
+  resolvedDeps.releaseClaim(roadmapNumber, {
+    agentId: preCloseClaim.activeClaim.agentId,
+    claimId: preCloseClaim.activeClaim.claimId,
+    timestamp: nowIso,
+  });
+  verdict.closed = true;
+  verdict.claimReleased = true;
+  verdict.result =
+    'roadmap closed as completed; evidence comment posted and roadmap-audit claim released';
+  return { verdict, exitCode: 0 };
+}
+/** Closed (non-root) descendant issue numbers — the open-linked-PR candidates. */
+function closedDescendantNumbers(report) {
+  return report.nodes
+    .filter(
+      (node) => node.number !== report.root.number && node.state !== 'OPEN',
+    )
+    .map((node) => node.number);
+}
+/** Truncate any sub-second fraction so an ISO stamp is `YYYY-MM-DDTHH:mm:ssZ`. */
+function toSecondPrecisionIso(iso) {
+  return String(iso).replace(/\.\d+Z$/, 'Z');
+}
+/**
+ * Validate and normalize the apply-time "now" to UTC second-precision ISO
+ * (`YYYY-MM-DDTHH:mm:ssZ`), or `null` when unparseable. The caller fails closed
+ * on `null` BEFORE any mutation: an unparseable value would mis-evaluate claim
+ * staleness (NaN comparisons read as not-stale), and an offset / sub-second
+ * form (e.g. `…+09:00`) would otherwise reach `renderUnclaimedByMarker` — which
+ * accepts only `…Z` second-precision — and throw AFTER the comment + close had
+ * already landed. Normalizing through `toISOString()` also converts any zone
+ * offset to UTC, so the single normalized value is safe for both the staleness
+ * checks and the release marker.
+ */
+function normalizeApplyNow(raw) {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return toSecondPrecisionIso(parsed.toISOString());
+}
+// ---------------------------------------------------------------------------
+// Production dependency wiring (live gh + roadmap-graph traversal).
+// ---------------------------------------------------------------------------
+/**
+ * Fetch the authenticated actor's own GitHub login via `gh api user`, or
+ * `null` on any failure (e.g. an under-scoped or expired token). Uses the
+ * throwing {@link ghText} (not `safeGhText`) wrapped in a local try/catch so
+ * a genuine failure is distinguishable from a merely-empty response — the
+ * distinction {@link resolveViewerLogin} needs to report
+ * `viewerLoginUnavailable` instead of silently treating a failed lookup the
+ * same as an anonymous one (#1396).
+ */
+function fetchViewerLogin() {
+  try {
+    return ghText(['api', 'user', '--jq', '.login'], GH_TEXT_LOOP_OPTIONS);
+  } catch {
+    return null;
+  }
+}
+/**
+ * Resolve the viewer login used to always-trust the current claimant (see
+ * {@link buildTrustedAuthorPredicate}), distinguishing a genuinely failed
+ * lookup from an empty one instead of collapsing both to `''` (#1396). A
+ * previously silent failure here excluded the real claimant from the
+ * trusted-author set with no signal that the LOOKUP, not the claim itself,
+ * was the problem, so a `not owned` verdict could be misread as a genuine
+ * claim conflict.
+ *
+ * `fetchLogin` defaults to the real {@link fetchViewerLogin} network call but
+ * is injectable so both outcomes (success and failure) are unit-testable
+ * without shelling out to `gh`. A successful-but-blank response (`''` or
+ * whitespace-only) is also reported as unavailable: an authenticated `gh api
+ * user` call should never legitimately return an empty login, so a blank
+ * result signals a degraded response rather than a real anonymous viewer.
+ */
+export function resolveViewerLogin(fetchLogin = fetchViewerLogin) {
+  const raw = fetchLogin();
+  const normalized = String(raw ?? '')
+    .trim()
+    .toLowerCase();
+  if (raw === null || normalized === '') {
+    return { viewerLogin: '', viewerLoginUnavailable: true };
+  }
+  return { viewerLogin: normalized, viewerLoginUnavailable: false };
+}
+function createProductionDeps(args) {
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const rawConfig = loadPolicy(args.policy);
+  const markerPrefix = normalizeMarkerPrefix(rawConfig.markerPrefix);
+  const { viewerLogin, viewerLoginUnavailable } = resolveViewerLogin();
+  const isTrustedAuthor = buildTrustedAuthorPredicate({
+    owner,
+    viewerLogin,
+    rawConfig: rawConfig,
+  });
+  // Honor the configured `claimTiming.staleAge` (docs/policy-constants.md);
+  // reuse discover-roadmap-graph's ISO-duration parser, falling back to the
+  // distributed 24 h default on an absent/invalid value.
+  const staleAgeMs =
+    parseClaimStaleAgeMs(rawConfig?.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
+  const labelsPolicy = normalizePolicyConfig(rawConfig).labels;
+  const loadIssue = buildIssueLoader(owner, repo);
+  const loadSubIssues = buildSubIssueLoader(owner, repo);
+  return {
+    collect: (roadmapNumber) =>
+      enumerateRoadmapGraph(roadmapNumber, {
+        markerPrefix,
+        roadmapLabelName: labelsPolicy.roadmapLabelName,
+        owner,
+        repo,
+        loadIssue,
+        loadSubIssues,
+      }),
+    resolveOpenLinkedPrIssues: (issueNumbers) =>
+      resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    viewerLoginUnavailable,
+    revalidateClaim: ({
+      issueNumber,
+      roadmapNumber,
+      expectedClaimId,
+      expectedAgentId,
+      nowIso,
+    }) =>
+      evaluateRoadmapClaim(loadIssueComments(owner, repo, issueNumber), {
+        roadmapNumber,
+        expectedClaimId,
+        expectedAgentId,
+        isTrustedAuthor,
+        nowIso,
+        staleAgeMs,
+      }),
+    hasTrustedCompletionEvidence: (roadmapNumber) =>
+      safeHasTrustedCompletionEvidence(() =>
+        hasTrustedCompletionEvidenceComment(
+          loadIssueComments(owner, repo, roadmapNumber),
+          isTrustedAuthor,
+        ),
+      ),
+    postEvidenceComment: (issueNumber, body) =>
+      postIssueComment(owner, repo, issueNumber, body),
+    closeRoadmap: (issueNumber) =>
+      ghText(
+        [
+          'issue',
+          'close',
+          String(issueNumber),
+          '--repo',
+          `${owner}/${repo}`,
+          '--reason',
+          'completed',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      ),
+    releaseClaim: (issueNumber, fields) =>
+      postIssueComment(
+        owner,
+        repo,
+        issueNumber,
+        renderUnclaimedByMarker(fields),
+      ),
+    // Honor a caller-supplied --now (deterministic staleness + release
+    // timestamps for tests / replays); fall back to the wall clock.
+    now: () => args.now || new Date().toISOString(),
+  };
+}
+/**
+ * Trusted marker-author predicate for claim re-validation. Mirrors the
+ * external-check-waiver write-gate set: the repo owner and the authenticated
+ * viewer (the agent posting the claim) are always trusted, plus the configured
+ * `trustedMarkerActors` and the `IDD_TRUSTED_MARKER_ACTORS` env override
+ * (resolved through the shared `resolveTrustedMarkerActors`).
+ */
+function buildTrustedAuthorPredicate({ owner, viewerLogin, rawConfig }) {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const trusted = new Set(
+    [owner, viewerLogin, ...actors]
+      .filter(Boolean)
+      .map((login) => login.trim().toLowerCase()),
+  );
+  return (login) =>
+    trusted.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+/** Load every issue comment (paginated) as the claim-marker event stream. */
+function loadIssueComments(owner, repo, issueNumber) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const raw = ghText(
+      [
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+        '--jq',
+        '.',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+    const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+    if (!Array.isArray(pageItems) || pageItems.length === 0) {
+      break;
+    }
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments.map((entry) => {
+    const comment = entry ?? {};
+    return {
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      author: {
+        login: String(comment.author?.login ?? comment.user?.login ?? ''),
+      },
+    };
+  });
+}
+/**
+ * Resolve which of `issueNumbers` still have an OPEN linked PR — covering A1.5's
+ * "open linked OR closing PR". Two GraphQL signals per issue, either of which
+ * blocks (issue-level short-circuit, `||`):
+ *
+ *  1. `closedByPullRequestsReferences` — PRs that reference-CLOSE the issue via
+ *     a closing keyword — kept only when at least one is still `OPEN` (MERGED /
+ *     CLOSED are obsolete; the field returns merged PRs even with
+ *     `includeClosedPrs:false`, so the `OPEN`-state filter is what matters); and
+ *  2. CONNECTED / DISCONNECTED timeline events — a PR manually linked via
+ *     GitHub's Development relationship with NO closing keyword — reconciled
+ *     (`CONNECTED_EVENT` with no later `DISCONNECTED_EVENT` for the same PR) and
+ *     kept only when that PR is still `OPEN`. Mirrors resume-claim-routing's
+ *     `fetchOpenLinkedPrReferences` shape.
+ *
+ * Both queries paginate fully (the connected stream MUST be read whole so a
+ * later DISCONNECTED is never missed). Fails closed: a per-issue lookup error,
+ * OR an ABSENT lookup connection (`issue: null` / connection `null`|`undefined`
+ * — a deleted / transferred / inaccessible issue, or partial GraphQL data),
+ * treats the issue as blocked. An absent connection is distinct from a
+ * genuinely present-but-empty `nodes: []` (legitimately no PR on that signal),
+ * which does NOT block on that signal. The GraphQL runner is injectable so the
+ * absence distinction is unit-testable without `gh`.
+ */
+export function resolveOpenLinkedPrIssues(
+  owner,
+  repo,
+  issueNumbers,
+  runGraphql = ghGraphql,
+) {
+  const blocked = [];
+  for (const issueNumber of issueNumbers) {
+    try {
+      if (
+        hasOpenClosingPr(owner, repo, issueNumber, runGraphql) ||
+        hasOpenConnectedPr(owner, repo, issueNumber, runGraphql)
+      ) {
+        blocked.push(issueNumber);
+      }
+    } catch {
+      // Fail closed: an undeterminable / absent PR state blocks the close.
+      blocked.push(issueNumber);
+    }
+  }
+  return blocked;
+}
+/**
+ * Narrow a parsed GraphQL response to the named connection on its issue node,
+ * THROWING (→ fail closed) when the issue is `null`/absent or the connection
+ * itself is `null`/`undefined`. A present connection (even with empty `nodes`)
+ * is returned as-is so a legitimately PR-free issue is not treated as blocked.
+ */
+function requireIssueConnection(parsed, pick, label) {
+  const issue = parsed?.data?.repository?.issue;
+  if (issue === null || issue === undefined) {
+    throw new Error(`${label}: issue is null/absent (fail closed)`);
+  }
+  const connection = pick(issue);
+  if (connection === null || connection === undefined) {
+    throw new Error(`${label}: connection is null/absent (fail closed)`);
+  }
+  return connection;
+}
+/**
+ * True when the issue has an OPEN PR that reference-closes it. Pages through
+ * `closedByPullRequestsReferences` and short-circuits on the first OPEN PR
+ * (one is enough to block); truncating the list could miss an OPEN blocker on
+ * a later page, wrongly green-lighting a close. Throws (→ blocked) on an absent
+ * connection.
+ */
+function hasOpenClosingPr(owner, repo, issueNumber, runGraphql) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50,after:$after,includeClosedPrs:false){
+        nodes { state }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  let after = null;
+  for (;;) {
+    const parsed = runGraphql(query, owner, repo, issueNumber, after);
+    const connection = requireIssueConnection(
+      parsed,
+      (issue) => issue.closedByPullRequestsReferences,
+      'closedByPullRequestsReferences',
+    );
+    const nodes = connection.nodes ?? [];
+    if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+      return true;
+    }
+    if (!connection.pageInfo?.hasNextPage) {
+      return false;
+    }
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) {
+      // hasNextPage with no endCursor: an incomplete / unexpected connection
+      // read. Throw so the per-issue catch fails closed (blocks the child)
+      // rather than treating a partial page as "no open PR".
+      throw new Error(
+        'incomplete closing-PR pagination: hasNextPage with no endCursor',
+      );
+    }
+  }
+}
+/**
+ * True when the issue has a currently-CONNECTED, OPEN linked PR (Development
+ * relationship without a closing keyword). Pages the CONNECTED/DISCONNECTED
+ * timeline in full — the whole stream is needed so a later DISCONNECTED is not
+ * missed — then reconciles it via the pure {@link reconcileConnectedOpenPrs}.
+ * Throws (→ blocked) on an absent connection.
+ */
+function hasOpenConnectedPr(owner, repo, issueNumber, runGraphql) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      timelineItems(first:50,after:$after,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+        nodes {
+          __typename
+          ... on ConnectedEvent { subject { __typename ... on PullRequest { number state } } }
+          ... on DisconnectedEvent { subject { __typename ... on PullRequest { number } } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const events = [];
+  let after = null;
+  for (;;) {
+    const parsed = runGraphql(query, owner, repo, issueNumber, after);
+    const connection = requireIssueConnection(
+      parsed,
+      (issue) => issue.timelineItems,
+      'timelineItems',
+    );
+    events.push(...parseConnectedPrEvents(connection.nodes ?? []));
+    if (!connection.pageInfo?.hasNextPage) {
+      break;
+    }
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) {
+      // hasNextPage with no endCursor: reconciling a truncated timeline could
+      // miss a later CONNECTED open PR. Throw so the per-issue catch fails
+      // closed (blocks the child) instead of trusting the partial stream.
+      throw new Error(
+        'incomplete connected-PR timeline pagination: hasNextPage with no endCursor',
+      );
+    }
+  }
+  return reconcileConnectedOpenPrs(events).length > 0;
+}
+/**
+ * Run one `gh api graphql` page, passing `after` only when set.
+ *
+ * Stdin-safe (#1396): called from a per-issue pagination loop
+ * (`resolveOpenLinkedPrIssues` → `hasOpenClosingPr` / `hasOpenConnectedPr`),
+ * the exact tight-loop hazard `GH_TEXT_LOOP_OPTIONS` exists for — this call
+ * site was missed by the initial pass over the file's other `ghText` calls.
+ */
+function ghGraphql(query, owner, repo, issueNumber, after) {
+  const apiArgs = [
+    'api',
+    'graphql',
+    '-f',
+    `query=${query}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+  if (after) {
+    apiArgs.push('-f', `after=${after}`);
+  }
+  return JSON.parse(ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+}
+/** Coerce raw CONNECTED/DISCONNECTED timeline nodes into reconcile events. */
+function parseConnectedPrEvents(nodes) {
+  const events = [];
+  for (const node of nodes) {
+    const record = node;
+    const subject = record?.subject;
+    if (subject?.__typename !== 'PullRequest') {
+      continue;
+    }
+    const prNumber =
+      typeof subject.number === 'number' ? subject.number : Number.NaN;
+    if (!Number.isInteger(prNumber)) {
+      continue;
+    }
+    if (record?.__typename === 'ConnectedEvent') {
+      events.push({
+        type: 'connected',
+        prNumber,
+        state: String(subject.state ?? ''),
+      });
+    } else if (record?.__typename === 'DisconnectedEvent') {
+      events.push({ type: 'disconnected', prNumber });
+    }
+  }
+  return events;
+}
+/**
+ * POST a comment body as a JSON document (`{"body": …}`) via `gh api --input
+ * -`. The JSON path is mandatory because HTML-comment-first bodies (the
+ * unclaim marker) are silently dropped by `gh issue comment` / `gh api -f
+ * body=`; the same path is reused for the evidence comment for consistency.
+ */
+function postIssueComment(owner, repo, issueNumber, body) {
+  ghText(
+    [
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }) },
+  );
+}
+// Read-and-parse failure semantics (explicit path throws; default path
+// silently falls back only on ENOENT) are converged in idd-config.mts's
+// loadPolicyConfig (#1721). The `?? {}` preserves this helper's existing
+// contract of always returning a plain object: callers below dereference
+// fields off the returned value via a non-optional-chained `rawConfig as
+// {...}` cast, so a bare `null` on the "no config" default-path case would
+// throw downstream.
+function loadPolicy(policyPath) {
+  return loadPolicyConfig(policyPath).config ?? {};
+}
+function normalizeMarkerPrefix(markerPrefix) {
+  const normalized = String(markerPrefix ?? '').trim();
+  return normalized || DEFAULT_MARKER_PREFIX;
+}
+/**
+ * Resolve one configured `labels.*` name (#1273), falling back to the given
+ * `policy-helpers.mts` `POLICY_DEFAULTS.labels` default for an absent or
+ * invalid value.
+ */
+function normalizeConfiguredLabelName(labelName, fallback) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : fallback;
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `roadmap:`): tests/flag-name-matrix.test.mts scans this file's
+// *compiled* .mjs source text for quoted flag literals such as the
+// --roadmap spec key below. See cli-args.mts's module header for the full
+// invariant.
+const ROADMAP_AUDIT_EXECUTE_FLAG_SPEC = {
+  '--roadmap': { type: 'string' },
+  '--apply': { type: 'boolean', default: false },
+  '--claim-issue': { type: 'string' },
+  '--claim-id': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--now': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, ROADMAP_AUDIT_EXECUTE_FLAG_SPEC);
+  const roadmapNumber = parsePositiveIntegerOrNull(values.roadmap, '--roadmap');
+  const claimIssue = parsePositiveIntegerOrNull(
+    values['claim-issue'],
+    '--claim-issue',
+  );
+  const owner = (values.owner ?? '').trim();
+  const repo = (values.repo ?? '').trim();
+  // Fail closed on exactly one of --owner / --repo: a single flag would
+  // validate one repo while the traversal / mutation runs against the
+  // current-directory repo. Require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'idd-roadmap-audit-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
+  return {
+    roadmapNumber,
+    apply: values.apply,
+    claimIssue,
+    claimId: (values['claim-id'] ?? '').trim(),
+    agentId: (values['agent-id'] ?? '').trim(),
+    owner,
+    repo,
+    policy: (values.policy ?? '').trim(),
+    now: (values.now ?? '').trim(),
+    help,
+  };
+}
+function parsePositiveIntegerOrNull(token, flag) {
+  if (token === undefined) {
+    return null;
+  }
+  const raw = token.trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${token}`);
+  }
+  return Number(raw);
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/idd-roadmap-audit-execute.mjs --roadmap <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+  node scripts/idd-roadmap-audit-execute.mjs --roadmap <number> --claim-id <claim-id> [--claim-issue <number>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>] [--apply]
+
+  Default (no --apply): dry-run. Evaluates A1.5 roadmap completion via the
+  read-only discover-roadmap-graph traversal and prints { ready, blockers,
+  evidenceBody } without mutating. Exit 0 when ready, 1 otherwise. evidenceBody
+  is the canonical "IDD roadmap completion audit" comment body (empty when the
+  roadmap is not ready).
+
+  --apply: when ready, re-validate the roadmap-audit claim and re-evaluate the
+  roadmap graph immediately before mutating, then post the evidence comment,
+  close the roadmap as completed, and release the claim. Fails closed (exit 1,
+  no mutation) on any lost / stale / non-owned claim or any blocker. The claim
+  is re-validated against the roadmap issue; --claim-issue, when provided, must
+  equal --roadmap. The active claim must be a roadmap-audit-scoped claim
+  (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
+  --apply) and, when given, --agent-id. --owner and --repo must be passed
+  together or not at all.
+
+  CLAIM REJECTION REASONS: a not-owned result's "reason" code is one of:
+    match                 the claim is owned (not a rejection)
+    missing-active-claim  no active claim is present on the roadmap issue
+    claim-id-mismatch     the active claim's claim-id is not the expected one
+    agent-id-mismatch     the active claim's agent-id is not the expected one
+    claim-branch-mismatch the active claim's branch is not a roadmap-audit
+                           coordination claim (roadmap-audit/<roadmap>-<slug>)
+                           for THIS roadmap -- a normal execution claim on the
+                           roadmap issue does not authorize closure
+    claim-stale           the active claim is older than the configured stale
+                           age and is takeover-eligible, so it cannot prove
+                           ongoing ownership
+  Each not-owned "result" message embeds both the code and this explanation,
+  so a policy rejection (e.g. claim-branch-mismatch) is never misread as an
+  unexplained fetch failure.
+
+  VIEWER-LOGIN LOOKUP: the trusted-author check needs this run's own GitHub
+  login (via "gh api user"). A genuinely FAILED lookup (network/auth error, or
+  an unexpected blank response) is reported as { viewerLoginUnavailable: true }
+  on the verdict, and any not-owned "result" message gets a trailing NOTE, so a
+  failed lookup is never silently indistinguishable from a real not-owned
+  claim. Absent (never explicitly false) whenever the lookup succeeded.
+
+  SCOPE: this helper gates only the MECHANICAL completion preconditions (all
+  descendants closed/complete; no open / unresolved / inaccessible / linked-PR
+  / nested-roadmap / childless / cycle / human-gate blocker). It does NOT verify
+  the roadmap's free-form success criteria or autonomy-gap items — the caller
+  must confirm those separately before --apply, exactly as the merge gate
+  trusts that review actually happened.
+`);
+}
+if (import.meta.main) {
+  if (process.argv.slice(2).some((arg) => arg === '--help' || arg === '-h')) {
+    printHelp();
+    process.exit(0);
+  }
+  runRoadmapAuditExecute(process.argv.slice(2))
+    .then(({ verdict, exitCode }) => {
+      process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+      process.exit(exitCode);
+    })
+    .catch((error) => {
+      process.stderr.write(`Error: ${error.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -1,0 +1,642 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/live-status-digest.mts
+//
+// The scripts/live-status-digest.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  collaboratorPermission,
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghApiJson,
+  ghText,
+} from './gh-exec.mjs';
+import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
+import {
+  applyDigestUpsert,
+  normalizeTrustedMarkerLogins,
+  parsePaginatedGhNdjson,
+  planLiveStatusDigestUpsert,
+  resolvePrFirstCommitAt,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+} from './protocol-helpers.mjs';
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant.
+const LIVE_STATUS_DIGEST_FLAG_SPEC = {
+  '--help': { type: 'boolean', short: 'h', default: false },
+  '--issue': { type: 'string' },
+  '--pr': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--dry-run': { type: 'boolean', default: false },
+  '--apply': { type: 'boolean', default: false },
+  '--phase': { type: 'string' },
+  '--claim': { type: 'string' },
+  '--branch': { type: 'string' },
+  '--last-checked': { type: 'string' },
+  '--open-blockers': { type: 'string' },
+  '--next-action': { type: 'string' },
+  '--authoritative-by': { type: 'string' },
+  '--claim-issue': { type: 'string' },
+  '--claim-id': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--skip-claim-check': { type: 'boolean', default: false },
+  '--include-body': { type: 'boolean', default: false },
+  '--format': { type: 'string', default: 'json' },
+};
+const TRUSTED_MARKER_PERMISSIONS = new Set(['admin', 'maintain', 'write']);
+const trustedMarkerAuthorCache = new Map();
+const collaboratorPermissionCache = new Map();
+let cachedConfiguredTrustedMarkerAuthors = null;
+let cachedCurrentViewerLogin = null;
+if (import.meta.main) {
+  main();
+}
+// The CLI body. Guarded behind `import.meta.main` so importing this
+// module (for unit tests) does not parse process.argv, fail, or
+// process.exit.
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (args.issue && args.pr) {
+    fail('choose only one of --issue or --pr');
+  }
+  if (!args.issue && !args.pr) {
+    fail('missing required --issue <number> or --pr <number>');
+  }
+  if (args.apply && args.dryRun) {
+    fail('choose only one of --dry-run or --apply');
+  }
+  if (!args.apply) {
+    args.dryRun = true;
+  }
+  if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+    fail(
+      '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+    );
+  }
+  if (
+    args.apply &&
+    !args.skipClaimCheck &&
+    (!args.claimIssue || !args.claimId)
+  ) {
+    fail(
+      '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
+    );
+  }
+  const repository = args.repo ?? detectRepository();
+  const [owner, repo] = parseRepository(repository);
+  const targetType = args.issue ? 'issue' : 'pr';
+  const targetNumber = parsePositiveInteger(
+    args.issue ?? args.pr,
+    `--${targetType}`,
+  );
+  // `expectedLinkedPrs` is a pure, local computation, so building it
+  // eagerly is free. `prFirstCommitAt` is not: resolving it makes a
+  // paginated `gh api pulls/{pr}/commits` call. `claimContext` is only
+  // consumed inside the `assertClaim` callback below, which
+  // `applyDigestUpsert` invokes only for a real `--apply` claim check (never
+  // for a dry-run, a duplicate-plan exit, or `--apply --skip-claim-check`),
+  // so resolve `prFirstCommitAt` lazily at that same call site instead of
+  // paying for it on every invocation regardless of whether anything ends
+  // up consuming it.
+  const claimContext =
+    targetType === 'pr'
+      ? {
+          expectedLinkedPrs: buildExpectedLinkedPrReferences(
+            owner,
+            repo,
+            targetNumber,
+          ),
+        }
+      : {};
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+  const fields = {
+    phase: args.phase,
+    claim: args.claim,
+    branch: args.branch,
+    lastChecked: args.lastChecked ?? currentIsoTimestamp(),
+    openBlockers: args.openBlockers,
+    nextAction: args.nextAction,
+    authoritativeBy: args.authoritativeBy,
+  };
+  const comments = fetchIssueComments(owner, repo, targetNumber);
+  let planned;
+  try {
+    planned = planLiveStatusDigestUpsert(comments, fields);
+  } catch (error) {
+    fail(error.message);
+  }
+  const report = {
+    repository: `${owner}/${repo}`,
+    target: {
+      type: targetType,
+      number: targetNumber,
+    },
+    mode: args.apply ? 'apply' : 'dry-run',
+    action: planned.action,
+    canApply: planned.canApply,
+    commentId: planned.commentId ?? null,
+    url: planned.url ?? null,
+    duplicates: planned.duplicates ?? [],
+    repairPath: planned.repairPath ?? null,
+    applied: false,
+    body: args.includeBody ? planned.body : undefined,
+  };
+  if (planned.action === 'duplicate') {
+    writeReport(report, args.format);
+    process.exit(1);
+  }
+  if (args.apply) {
+    // The ordering invariant — re-fetch and re-plan, then revalidate the
+    // active claim immediately before the create/update mutation, with no
+    // write if the claim check throws — lives in applyDigestUpsert. The live
+    // `gh` I/O is injected here so that invariant stays unit-testable.
+    let outcome;
+    try {
+      outcome = applyDigestUpsert({
+        skipClaimCheck: Boolean(args.skipClaimCheck),
+        refetchAndPlan: () =>
+          planLiveStatusDigestUpsert(
+            fetchIssueComments(owner, repo, targetNumber),
+            fields,
+          ),
+        assertClaim: () =>
+          assertActiveClaim(
+            owner,
+            repo,
+            args.claimIssue,
+            args.agentId,
+            args.claimId,
+            {
+              ...claimContext,
+              prFirstCommitAt:
+                targetType === 'pr'
+                  ? resolvePrFirstCommitAtForPr(owner, repo, targetNumber)
+                  : null,
+            },
+          ),
+        createComment: (body) =>
+          createIssueComment(owner, repo, targetNumber, body),
+        updateComment: (commentId, body) =>
+          updateIssueComment(owner, repo, commentId, body),
+      });
+    } catch (error) {
+      fail(error.message);
+    }
+    planned = outcome.planned;
+    updateReportFromPlan(report, planned, args.includeBody);
+    if (outcome.outcome === 'duplicate') {
+      writeReport(report, args.format);
+      process.exit(1);
+    }
+    if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
+      report.applied = true;
+      report.commentId = outcome.commentId ?? report.commentId;
+      report.url = outcome.url ?? report.url;
+    }
+  }
+  writeReport(report, args.format);
+}
+function updateReportFromPlan(report, planned, includeBody = false) {
+  report.action = planned.action;
+  report.canApply = planned.canApply;
+  report.commentId = planned.commentId ?? null;
+  report.url = planned.url ?? null;
+  report.duplicates = planned.duplicates ?? [];
+  report.repairPath = planned.repairPath ?? null;
+  if (includeBody) {
+    report.body = planned.body;
+  }
+}
+function fetchIssueComments(owner, repo, number) {
+  // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+  // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+  // via apt, so keep the NDJSON-compatible form here.
+  const result = parsePaginatedGhNdjson(
+    ghText(
+      [
+        'api',
+        '--paginate',
+        '--jq',
+        '.[]',
+        `repos/${owner}/${repo}/issues/${number}/comments`,
+      ],
+      { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS },
+    ),
+  );
+  return result.map((comment) => ({
+    id: comment.id,
+    url: comment.url,
+    html_url: comment.html_url,
+    body: comment.body ?? '',
+    created_at: comment.created_at ?? '',
+    updated_at: comment.updated_at ?? comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+}
+function createIssueComment(owner, repo, number, body) {
+  return ghJson([
+    'api',
+    `repos/${owner}/${repo}/issues/${number}/comments`,
+    '-X',
+    'POST',
+    '-f',
+    `body=${body}`,
+  ]);
+}
+function updateIssueComment(owner, repo, commentId, body) {
+  return ghJson([
+    'api',
+    `repos/${owner}/${repo}/issues/comments/${commentId}`,
+    '-X',
+    'PATCH',
+    '-f',
+    `body=${body}`,
+  ]);
+}
+function assertActiveClaim(
+  owner,
+  repo,
+  issueNumber,
+  agentId,
+  claimId,
+  options = {},
+) {
+  const active = readActiveClaim(owner, repo, issueNumber, options);
+  if (
+    !active ||
+    active.claimId !== claimId ||
+    (agentId && active.agentId !== agentId)
+  ) {
+    const activeLabel = active ? `${active.agentId} ${active.claimId}` : 'none';
+    throw new Error(
+      `claim check failed for #${issueNumber}: active claim is ${activeLabel}`,
+    );
+  }
+}
+function readActiveClaim(owner, repo, issueNumber, options = {}) {
+  const comments = fetchIssueComments(owner, repo, issueNumber).map(
+    (comment) => {
+      return {
+        body: comment.body,
+        createdAt: comment.created_at,
+        author: { login: comment.author?.login ?? '' },
+      };
+    },
+  );
+  // Read the authority policy once per call; the
+  // isAuthorizedForcedHandoff callback may fire multiple times during
+  // claim parsing and re-reading .github/idd/config.json on each call
+  // would be a needless I/O hot path.
+  const forcedHandoffAuthorityPolicyValue = readForcedHandoffAuthorityPolicy();
+  const summary = summarizeClaimValidation(comments, {
+    trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
+    forcedHandoffEnabled: readForcedHandoffMode() === 'human-gated',
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicyValue,
+        collaboratorPermissionCache,
+      ),
+  });
+  return summary.activeClaimPresent ? summary.activeClaim : null;
+}
+function resolveTrustedMarkerLogins(owner, repo, comments) {
+  return normalizeTrustedMarkerLogins(
+    comments
+      .map((comment) => comment.author?.login ?? '')
+      .filter(Boolean)
+      .filter((login) => isTrustedMarkerAuthor(owner, repo, login)),
+  );
+}
+function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
+  const normalized = String(prNumber ?? '').trim();
+  if (!normalized) {
+    return [];
+  }
+  return [
+    normalized,
+    `#${normalized}`,
+    `https://github.com/${owner}/${repo}/pull/${normalized}`,
+  ];
+}
+// The PR's first-commit time backs the Part B forced-handoff rule (#1058): a
+// legitimate issue-only handoff that predates the PR is honored even against
+// a PR-backed claim -- see `buildForcedHandoffEnableGate` in
+// protocol-helpers.mts. Resolve it only when forced handoffs are enabled, and
+// fail closed to `null` (reject) on any lookup/parse error so a transient
+// commits-API failure never widens what the gate accepts. Mirrors
+// `pre-merge-readiness.mts` / `advisory-convergence.mts`'s identical
+// resolution, sharing `resolvePrFirstCommitAt`'s date computation with both.
+function resolvePrFirstCommitAtForPr(owner, repo, prNumber) {
+  if (readForcedHandoffMode() !== 'human-gated') {
+    return null;
+  }
+  try {
+    const prCommits = ghApiJson(
+      `repos/${owner}/${repo}/pulls/${prNumber}/commits`,
+      {
+        paginate: true,
+      },
+    );
+    return resolvePrFirstCommitAt(prCommits);
+  } catch {
+    return null;
+  }
+}
+export function isTrustedMarkerAuthor(owner, repo, login) {
+  if (!login) {
+    return false;
+  }
+  const normalized = login.toLowerCase();
+  if (normalized === currentViewerLogin()) {
+    return true;
+  }
+  if (configuredTrustedMarkerAuthors().has(normalized)) {
+    return true;
+  }
+  if (!trustCollaboratorMarkers()) {
+    return false;
+  }
+  const cacheKey = `${owner}/${repo}:${normalized}`;
+  if (trustedMarkerAuthorCache.has(cacheKey)) {
+    return trustedMarkerAuthorCache.get(cacheKey) ?? false;
+  }
+  const trusted = TRUSTED_MARKER_PERMISSIONS.has(
+    collaboratorPermission(owner, repo, normalized, collaboratorPermissionCache)
+      .permission,
+  );
+  trustedMarkerAuthorCache.set(cacheKey, trusted);
+  return trusted;
+}
+function currentViewerLogin() {
+  if (cachedCurrentViewerLogin !== null) {
+    return cachedCurrentViewerLogin;
+  }
+  try {
+    cachedCurrentViewerLogin = ghText(['api', 'user', '--jq', '.login'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toLowerCase();
+  } catch {
+    cachedCurrentViewerLogin = '';
+  }
+  return cachedCurrentViewerLogin;
+}
+export function configuredTrustedMarkerAuthors() {
+  if (cachedConfiguredTrustedMarkerAuthors) {
+    return cachedConfiguredTrustedMarkerAuthors;
+  }
+  // Read config.json the same way trustCollaboratorMarkers() does, then defer
+  // to the shared flag-less env -> config ladder (env still wins over config),
+  // so trusted-marker authors are no longer env-only in this script.
+  let config = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    // No readable or parseable config; fall back to env-only resolution.
+  }
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  cachedConfiguredTrustedMarkerAuthors = new Set(actors);
+  return cachedConfiguredTrustedMarkerAuthors;
+}
+export function trustCollaboratorMarkers() {
+  try {
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
+  } catch {
+    // Fall through to env-var fallback.
+  }
+  return /^(1|true|yes)$/i.test(
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? '',
+  );
+}
+/**
+ * Test-only seam: clear the module-level trusted-marker caches so each unit
+ * test starts from a known state, and optionally seed the cached current-viewer
+ * login so `isTrustedMarkerAuthor` is deterministic without shelling out to
+ * `gh`. Not part of the CLI contract.
+ */
+export function __resetTrustedMarkerCachesForTest(seed = {}) {
+  trustedMarkerAuthorCache.clear();
+  collaboratorPermissionCache.clear();
+  cachedConfiguredTrustedMarkerAuthors = null;
+  cachedCurrentViewerLogin = seed.currentViewerLogin ?? null;
+}
+function detectRepository() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+  return ghText([
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner',
+  ]);
+}
+function parseRepository(value) {
+  const parts = value.split('/');
+  if (
+    parts.length !== 2 ||
+    parts.some((part) => part.length === 0 || /\s/.test(part))
+  ) {
+    fail(`invalid repository ${value}; expected owner/name`);
+  }
+  return parts;
+}
+function ghJson(commandArgs) {
+  try {
+    return JSON.parse(ghText(commandArgs));
+  } catch (error) {
+    const stdout = String(error.stdout ?? '').trim();
+    const stderr = String(error.stderr ?? '').trim();
+    const response = parseJsonOrNull(stdout);
+    if (response?.message || response?.errors) {
+      fail(`gh ${commandArgs.join(' ')} failed: ${JSON.stringify(response)}`);
+    }
+    if (response) {
+      return response;
+    }
+    fail(`gh ${commandArgs.join(' ')} failed: ${stderr || error.message}`);
+  }
+}
+function parseJsonOrNull(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+function writeReport(report, format) {
+  if (format === 'json') {
+    console.log(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  console.log(`mode\taction\tcanApply\tapplied\tcommentId\turl`);
+  console.log(
+    [
+      report.mode,
+      report.action,
+      report.canApply,
+      report.applied,
+      report.commentId ?? '',
+      report.url ?? '',
+    ].join('\t'),
+  );
+  if (report.duplicates.length > 0) {
+    console.log('duplicates:');
+    console.log('id\tcreatedAt\tupdatedAt\turl');
+    for (const duplicate of report.duplicates) {
+      console.log(
+        [
+          duplicate.id ?? '',
+          duplicate.createdAt ?? '',
+          duplicate.updatedAt ?? '',
+          duplicate.url ?? '',
+        ].join('\t'),
+      );
+    }
+  }
+  if (report.repairPath) {
+    console.log(`repairPath:\t${report.repairPath}`);
+  }
+}
+function parseArgs(argv) {
+  // No test in this file asserts the pre-migration message text or the
+  // no-colon "unknown argument X" / "X requires a value" spelling (see
+  // #1451's PR description), so a parse failure adopts the wrapper's
+  // uniform message. The exit-code-2 contract IS preserved: catch the
+  // wrapper's thrown Error here and route it through this file's own
+  // fail() exactly as every other malformed-input path already does.
+  let parsed;
+  try {
+    parsed = parseCliArgs(argv, LIVE_STATUS_DIGEST_FLAG_SPEC);
+  } catch (error) {
+    fail(error.message);
+  }
+  const { values, help } = parsed;
+  // The pre-migration readValue() used `!value` (not `=== undefined`), so
+  // an explicit empty-string value was rejected the same as an omitted
+  // flag for EVERY flag in this file. parseCliArgs accepts an empty
+  // string (matching bare node:util parseArgs), so this check restores
+  // that exact uniform pre-migration behavior. The message matches
+  // parseCliArgs' own "missing value for argument: <flag>" phrasing
+  // (Copilot review finding on PR #1467) so an empty-string value and an
+  // omitted/flag-shaped value report the same failure style.
+  const requireNonEmpty = (token, flag) => {
+    if (token === '') {
+      fail(`missing value for argument: ${flag}`);
+    }
+    return token;
+  };
+  const format = requireNonEmpty(values.format, '--format');
+  if (!['json', 'table'].includes(format)) {
+    fail('--format must be json or table');
+  }
+  const parsedArgs = {
+    format,
+    help,
+    issue: requireNonEmpty(values.issue, '--issue'),
+    pr: requireNonEmpty(values.pr, '--pr'),
+    repo: requireNonEmpty(values.repo, '--repo'),
+    dryRun: values['dry-run'],
+    apply: values.apply,
+    phase: requireNonEmpty(values.phase, '--phase'),
+    claim: requireNonEmpty(values.claim, '--claim'),
+    branch: requireNonEmpty(values.branch, '--branch'),
+    lastChecked: requireNonEmpty(values['last-checked'], '--last-checked'),
+    openBlockers: requireNonEmpty(values['open-blockers'], '--open-blockers'),
+    nextAction: requireNonEmpty(values['next-action'], '--next-action'),
+    authoritativeBy: requireNonEmpty(
+      values['authoritative-by'],
+      '--authoritative-by',
+    ),
+    claimIssue: requireNonEmpty(values['claim-issue'], '--claim-issue'),
+    claimId: requireNonEmpty(values['claim-id'], '--claim-id'),
+    agentId: requireNonEmpty(values['agent-id'], '--agent-id'),
+    skipClaimCheck: values['skip-claim-check'],
+    includeBody: values['include-body'],
+  };
+  for (const flag of [
+    ['phase', '--phase'],
+    ['claim', '--claim'],
+    ['branch', '--branch'],
+    ['openBlockers', '--open-blockers'],
+    ['nextAction', '--next-action'],
+    ['authoritativeBy', '--authoritative-by'],
+  ]) {
+    if (!parsedArgs[flag[0]]) {
+      if (!parsedArgs.help) {
+        fail(`${flag[1]} is required`);
+      }
+    }
+  }
+  return parsedArgs;
+}
+function parsePositiveInteger(value, flag) {
+  if (!value || !/^[1-9]\d*$/.test(value)) {
+    fail(`${flag} must be a positive integer`);
+  }
+  return Number.parseInt(value, 10);
+}
+function currentIsoTimestamp() {
+  return new Date().toISOString().replace('.000Z', 'Z');
+}
+function printUsage() {
+  console.log(`usage: node scripts/live-status-digest.mjs (--issue <number> | --pr <number>) [options]
+
+Options:
+  --dry-run                         compute the create/update/noop action (default)
+  --apply                           create or update the single current digest
+  --phase <text>                    digest Phase field
+  --claim <text>                    digest Claim field
+  --branch <text>                   digest Branch field
+  --last-checked <timestamp>        digest Last checked field (default: current UTC)
+  --open-blockers <text>            digest Open blockers field
+  --next-action <text>              digest Next action field
+  --authoritative-by <text>         digest Authoritative by field
+  --claim-issue <number>            issue whose active claim protects apply mode
+  --claim-id <id>                   active claim id required for apply mode
+  --agent-id <id>                   optionally require this claim agent id
+  --skip-claim-check                explicit maintainer override for apply mode
+  --repo <owner/name>               repository override
+  --format <json|table>             output format (default: json)
+  --include-body                    include the rendered body in JSON reports
+  --help                            show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS         comma-separated trusted bot/app logins
+  IDD_TRUST_COLLABORATOR_MARKERS    set true to trust Write/Maintain/Admin collaborators
+`);
+}
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1,0 +1,1297 @@
+// idd-generated-from: src/scripts/markdown-code.mts
+//
+// The scripts/markdown-code.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+/**
+ * Strip Markdown code regions (fenced blocks and inline code spans) from a body
+ * before scanning it for machine-readable markers or dependency references. A
+ * genuine marker is raw text GitHub renders as intended (an HTML comment it
+ * hides, or a `Blocked by #N` line it links), never inside a code span or
+ * fence, so an example an issue merely *quotes* in code (e.g. an issue about
+ * the marker or dependency syntax) must not be read as real. HTML comments are
+ * deliberately NOT stripped here — only code regions are, since some markers
+ * are themselves HTML comments. Masked regions keep their line count and
+ * surrounding text so a real marker elsewhere in the body still matches.
+ */
+/**
+ * Blank fenced code block lines (``` or ~~~), tracking the fence char +
+ * length so a longer opening fence is not closed by a shorter inner fence
+ * (CommonMark §4.5). Preserves line count so line-number math on the
+ * returned text stays valid. Shared by {@link stripMarkdownCodeRegions} and
+ * the inline-code-span wrap scan in `code-span-wrap.mts`.
+ */
+export function blankFencedCodeBlocks(text) {
+  const lines = text.split(/\r?\n/);
+  const out = [];
+  let fence = null;
+  const listTracker = createListContentIndentTrackerState();
+  for (const line of lines) {
+    const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
+    const listContinuationLine =
+      fence === null || fence.listContentIndent === null
+        ? containerLine.content
+        : stripContainerPrefixes(line, fence.containerDepth);
+    if (
+      fence !== null &&
+      ((fence.containerDepth > 0 &&
+        containerLine.containerDepth < fence.containerDepth) ||
+        (fence.listContentIndent !== null &&
+          !continuesListContainer(
+            listContinuationLine,
+            fence.listContentIndent,
+          )))
+    ) {
+      fence = null;
+    }
+    const fenceWasOpen = fence !== null;
+    if (!fenceWasOpen) {
+      resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    }
+    const openerListContentIndent = fence
+      ? fence.listContentIndent
+      : listTracker.contentIndent;
+    const parsed = parseFencedLine(
+      line,
+      openerListContentIndent,
+      fence !== null,
+    );
+    if (!fenceWasOpen) {
+      adoptListContentIndentForLine(listTracker, containerLine);
+    }
+    if (parsed) {
+      const fenceChar = parsed.marker[0];
+      if (fence === null) {
+        // CommonMark §4.5: a backtick-fence opener's info string may not
+        // contain a backtick (that would be ambiguous with a close or inline
+        // code), so such a line is not a fence opener and stays content.
+        if (isValidFenceOpener(parsed)) {
+          fence = {
+            char: fenceChar,
+            length: parsed.marker.length,
+            containerDepth: parsed.containerDepth,
+            listContentIndent:
+              openerListContentIndent ?? parsed.listContentIndent,
+          };
+          out.push('');
+          continue;
+        }
+      } else if (
+        fenceChar === fence.char &&
+        parsed.marker.length >= fence.length &&
+        parsed.containerDepth === fence.containerDepth &&
+        /^\s*$/.test(parsed.info)
+      ) {
+        fence = null;
+        out.push('');
+        continue;
+      }
+    }
+    out.push(fence === null ? line : '');
+  }
+  return out.join('\n');
+}
+/**
+ * Inline code span pattern (`...`, ``...``): the inner match allows a
+ * single newline (CommonMark renders it as a space) but stops at a blank
+ * line, which ends the paragraph: a code span cannot cross it. Allowing a
+ * blank line would let a stray unclosed backtick mask a real dependency
+ * line in a later paragraph — a fail-open miss. Shared by
+ * {@link stripMarkdownCodeRegions} and the inline-code-span wrap scan in
+ * `code-span-wrap.mts`, so both stay in sync on what counts as a span.
+ */
+export const INLINE_CODE_SPAN_PATTERN =
+  /(`+)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)\1/g;
+export function stripMarkdownCodeRegions(text) {
+  // Inline code spans: mask the inner content so a quoted marker no longer
+  // matches, keeping the backticks and surrounding text.
+  return blankFencedCodeBlocks(text).replace(
+    INLINE_CODE_SPAN_PATTERN,
+    (_match, ticks, inner) =>
+      `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
+  );
+}
+function isEscapedBacktick(text, index) {
+  let backslashCount = 0;
+  for (
+    let cursor = index - 1;
+    cursor >= 0 && text[cursor] === '\\';
+    cursor -= 1
+  ) {
+    backslashCount += 1;
+  }
+  return backslashCount % 2 === 1;
+}
+function hasBlankLine(text, start, end) {
+  return /\r?\n[ \t]*\r?\n/u.test(text.slice(start, end));
+}
+const MARKDOWN_BLOCK_CONTENT_PATTERN =
+  /^ {0,3}(?:#{1,6}(?:[ \t]|$)|(?:[-+*])[ \t]+|1[.)][ \t]+|(?:-{1,}|={1,}|_{3,}|\*{3,})[ \t]*$)/u;
+const MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN =
+  /^ {0,3}(?:#{1,6}(?:[ \t]|$)|(?:-{1,}|={1,}|_{3,}|\*{3,})[ \t]*$)/u;
+const MARKDOWN_HTML_BLOCK_START_PATTERN =
+  /^ {0,3}(?:<!--|<\?|<![A-Z]|<!\[CDATA\[|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|ol|p|pre|script|section|style|summary|table|tbody|td|textarea|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|\/?>|$))/iu;
+const MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN =
+  /^ {0,3}<\/?[A-Za-z][A-Za-z0-9-]*(?:[ \t]+[^<>]*?)?[ \t]*\/?>/u;
+// CommonMark §4.1: a thematic break is 3+ matching -, _, or * characters,
+// each optionally followed by spaces/tabs -- interior spacing is allowed
+// (e.g. `_ _ _`), unlike the tightly-packed run already covered above.
+const MARKDOWN_THEMATIC_BREAK_PATTERN =
+  /^ {0,3}([-_*])(?:[ \t]*\1){2,}[ \t]*$/u;
+const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
+  /^ {0,3}<(script|pre|style|textarea)\b/iu;
+const HTML_RAW_TEXT_TAG_CLOSE_PATTERNS = {
+  script: /<\/script\b/iu,
+  pre: /<\/pre\b/iu,
+  style: /<\/style\b/iu,
+  textarea: /<\/textarea\b/iu,
+};
+/**
+ * The raw-text tag that `content` opens (one of {@link HtmlRawTextTag}'s
+ * four members), lower-cased for use as a
+ * {@link HTML_RAW_TEXT_TAG_CLOSE_PATTERNS} key, or `null` when `content`
+ * does not open a raw-text element.
+ */
+function rawTextOpenTag(content) {
+  const match = HTML_RAW_TEXT_TAG_OPEN_PATTERN.exec(content);
+  return match === null ? null : match[1].toLowerCase();
+}
+/**
+ * True when `content` (a line with any blockquote container prefix already
+ * stripped -- a caller-held list-item marker, if present, may still be in
+ * place) starts a new Markdown block -- either the fixed-form patterns
+ * above, or a thematic break whose repeated marker characters are separated
+ * by spaces or tabs. `MARKDOWN_BLOCK_CONTENT_PATTERN`'s own list-item
+ * alternative already matches a leading `-`/`+`/`*`/`1.`/`1)` marker
+ * directly, correctly treating it as a block start on its own -- a list
+ * item is a genuine new block per CommonMark -- so no separate stripping is
+ * needed here regardless of whether the caller already stripped one.
+ */
+function isMarkdownBlockStart(content) {
+  return (
+    MARKDOWN_BLOCK_CONTENT_PATTERN.test(content) ||
+    MARKDOWN_THEMATIC_BREAK_PATTERN.test(content)
+  );
+}
+/** True when `content` opens with an HTML closing-tag slash (`</tag>`). */
+function isHtmlClosingSyntax(content) {
+  return /^ {0,3}<\//u.test(content);
+}
+/**
+ * The literal token that closes the CommonMark special HTML block form
+ * (comment, processing instruction, declaration, CDATA) `content` opens, or
+ * `null` when `content` does not open one of these four forms. Used both to
+ * check a same-line self-close ({@link isSelfClosedSpecialHtmlBlock}) and,
+ * by {@link isWithinOpenHtmlBlock}'s forward state tracking, to know which
+ * token to watch for on a later line once the form is confirmed still open.
+ */
+function specialHtmlBlockCloseToken(content) {
+  if (/^ {0,3}<!--/u.test(content)) {
+    return '-->';
+  }
+  if (/^ {0,3}<\?/u.test(content)) {
+    return '?>';
+  }
+  if (/^ {0,3}<!\[CDATA\[/iu.test(content)) {
+    return ']]>';
+  }
+  if (/^ {0,3}<![A-Z]/iu.test(content)) {
+    return '>';
+  }
+  return null;
+}
+/**
+ * True when `content` opens one of CommonMark's four special HTML block
+ * forms (comment, processing instruction, declaration, CDATA) and also
+ * carries that form's own closing token later on the same line -- e.g.
+ * `<!-- comment -->`. Unlike a raw-text or generic HTML block, these forms
+ * can be fully self-contained on one line; when they are, that line proves
+ * nothing about enclosing a later line and must not be read as leaving an
+ * open block behind it.
+ */
+function isSelfClosedSpecialHtmlBlock(content) {
+  const closeToken = specialHtmlBlockCloseToken(content);
+  return closeToken !== null && content.includes(closeToken);
+}
+function lineBounds(text, lineStart) {
+  const newlineIndex = text.indexOf('\n', lineStart);
+  const end =
+    newlineIndex === -1
+      ? text.length
+      : newlineIndex > lineStart && text[newlineIndex - 1] === '\r'
+        ? newlineIndex - 1
+        : newlineIndex;
+  return {
+    end,
+    next: newlineIndex === -1 ? text.length : newlineIndex + 1,
+  };
+}
+/**
+ * Find the start offset of the line immediately before `lineStart`, or
+ * `null` when `lineStart` is already the first line of `text`.
+ */
+function findPreviousLineStart(text, lineStart) {
+  if (lineStart <= 0) {
+    return null;
+  }
+  const terminatorIndex = lineStart - 1;
+  if (terminatorIndex === 0) {
+    return 0;
+  }
+  const priorNewline = text.lastIndexOf('\n', terminatorIndex - 1);
+  return priorNewline === -1 ? 0 : priorNewline + 1;
+}
+/**
+ * True when the line at `openingLineStart` is still inside a raw, special,
+ * or generic HTML block opened on an earlier line at the same container
+ * depth (for example, an unclosed `<script>` directly above a quoted
+ * paragraph) -- so it must not be mistaken for an ordinary paragraph line.
+ *
+ * Two passes, per the CommonMark distinction the shared
+ * {@link HtmlBlockScanState} type documents:
+ *
+ * 1. **Bounded backward collection.** Walk backward from
+ *    `openingLineStart` through consecutive same-depth lines (list-marker-
+ *    stripped, the same way the opening line's own marker already is,
+ *    which is what makes this scan reachable from a bare, blockquote-free
+ *    list item too, per #1894's follow-up fix, not only from inside a
+ *    blockquote). A container-depth change stops collection unconditionally
+ *    -- a block-type hypothesis from a different depth never reaches
+ *    `openingLineStart`.
+ * 2. **Forward, single-pass state tracking** over the collected lines (now
+ *    in document order, oldest first): thread exactly one
+ *    {@link HtmlBlockScanState} through them. Only a `none` state ever
+ *    considers opening a new hypothesis (via {@link specialHtmlBlockCloseToken}
+ *    and {@link isSelfClosedSpecialHtmlBlock} for the special forms, the
+ *    existing `!isHtmlClosingSyntax` guard preserved for the generic
+ *    branch so a lone closing tag like `</div>` still doesn't count as an
+ *    opener); once a state other than `none` is active, only that family's
+ *    own close condition can end it -- nothing else changes it. Returning
+ *    the final state's non-`none`-ness is what resolves the ambiguity a
+ *    single backward short-circuit scan could not: a literal `</script>`
+ *    encountered while `special` is active is never misread as a raw-text
+ *    close, and a blank line encountered while `special` or `raw-text` is
+ *    active never ends it (only `generic` closes on a blank line).
+ *
+ * `findMarkdownBlockBoundary` now calls this scan whenever an active list
+ * zone is involved, not only inside a blockquote -- including when the
+ * opening line itself looks like a fresh list-item opener: the scan still
+ * runs there (it does not know or care whether its own starting
+ * line has a marker; only the *lines it walks backward
+ * through* have their own markers stripped before testing). Since #1896's
+ * fix, a `true` result forces the enclosing code span to never form at all
+ * (an unconditional block boundary), rather than merely gating the
+ * `isLazyListContinuation` / `isLazyQuoteContinuation` laziness exception
+ * for later lines -- *unless* the opening line is a genuine fresh sibling
+ * list-item opener (its own marker, and not itself still within an
+ * earlier, outer list item's content zone; see the guard in
+ * `findMarkdownBlockBoundary` below), in which case only the laziness-gate
+ * consumption still applies, so a legitimate same-line span opened by that
+ * fresh sibling right after an unclosed tag in the previous item is not
+ * destroyed.
+ *
+ * **Deliberate side effect.** A stray raw-text-close-shaped line (e.g. a
+ * bare `</script>`) encountered while the state is still `none` -- no raw-
+ * text block open at all -- is now inert rather than ending the scan. This
+ * only changes the observable result when a genuine opener (raw-text,
+ * special, or generic) is reachable further back past the stray closer: the
+ * old scan returned "not enclosed" as soon as it saw the closer, regardless
+ * of state, so it never reached that opener; the new scan correctly
+ * continues past it and finds the still-open block. With no such opener
+ * reachable, both scans agree (nothing was ever open to end). Verified
+ * empirically both ways; covered by the last two cases in
+ * `tests/markdown-code.test.mts`'s #1895 section.
+ *
+ * `earliestLineStart` (PR #1902 review finding): an optional lower bound on
+ * how far back this scan may walk. The scan otherwise has no concept of a
+ * list-item boundary -- it walks backward purely by same-`containerDepth`
+ * lines -- so, unbounded, it can reach *past* a genuine sibling list-item
+ * opener into an earlier, unrelated item's own open HTML block (a fresh
+ * sibling's own line does not reset `containerDepth`, only its list-content
+ * indent does, which this function does not track). `findMarkdownBlockBoundary`
+ * passes the nearest enclosing list zone's own opener line (or the opening
+ * line itself, when no such zone reaches it) whenever an active list zone
+ * is involved; omitted (unbounded) for the pure-blockquote case, where no
+ * sibling-item boundary concept applies and unbounded reachability across
+ * shape-only lines is the CommonMark-correct behavior already relied on by
+ * `tests/markdown-code.test.mts`'s pre-#1896 blockquote coverage.
+ */
+function isWithinOpenHtmlBlock(
+  text,
+  openingLineStart,
+  containerDepth,
+  earliestLineStart,
+) {
+  const sameDepthLines = [];
+  let lineStart = findPreviousLineStart(text, openingLineStart);
+  while (lineStart !== null) {
+    if (earliestLineStart !== undefined && lineStart < earliestLineStart) {
+      break;
+    }
+    const line = lineBounds(text, lineStart);
+    const parsed = parseContainerLine(text.slice(lineStart, line.end));
+    if (parsed.containerDepth !== containerDepth) {
+      break;
+    }
+    // Blankness is judged on the container-stripped line as a whole (a
+    // marker-only line like `- ` is not itself a blank line), before a list
+    // marker (e.g. `- <script>`) is stripped for the HTML-pattern tests
+    // below -- stripping first would read that marker-only line's now-empty
+    // remainder as blank, wrongly closing an open `generic` state.
+    sameDepthLines.push({
+      content: parseListItemMatch(parsed.content)?.content ?? parsed.content,
+      isBlank: parsed.content.trim() === '',
+    });
+    lineStart = findPreviousLineStart(text, lineStart);
+  }
+  sameDepthLines.reverse();
+  let state = { type: 'none' };
+  for (const { content, isBlank } of sameDepthLines) {
+    if (state.type === 'raw-text') {
+      if (HTML_RAW_TEXT_TAG_CLOSE_PATTERNS[state.tag].test(content)) {
+        state = { type: 'none' };
+      }
+      continue;
+    }
+    if (state.type === 'special') {
+      if (content.includes(state.closeToken)) {
+        state = { type: 'none' };
+      }
+      continue;
+    }
+    if (state.type === 'generic') {
+      if (isBlank) {
+        state = { type: 'none' };
+      }
+      continue;
+    }
+    if (isBlank) {
+      continue;
+    }
+    const openTag = rawTextOpenTag(content);
+    if (openTag !== null) {
+      if (!HTML_RAW_TEXT_TAG_CLOSE_PATTERNS[openTag].test(content)) {
+        state = { type: 'raw-text', tag: openTag };
+      }
+      continue;
+    }
+    const closeToken = specialHtmlBlockCloseToken(content);
+    if (closeToken !== null) {
+      if (!isSelfClosedSpecialHtmlBlock(content)) {
+        state = { type: 'special', closeToken };
+      }
+      continue;
+    }
+    if (
+      !isHtmlClosingSyntax(content) &&
+      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(content) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(content))
+    ) {
+      state = { type: 'generic' };
+    }
+  }
+  return state.type !== 'none';
+}
+/**
+ * True when `marker` is one of the "genuine", paragraph-interrupting list
+ * markers {@link isMarkdownBlockStart}'s own list branch recognizes (`-`,
+ * `+`, `*`, `1.`, `1)`) -- unlike {@link parseListItemContainer}, which
+ * accepts any ordered-list digit. CommonMark allows a non-"1" ordered
+ * marker (e.g. `2.`) to appear mid-paragraph without interrupting it, so
+ * such a marker must never anchor list-content-indent tracking.
+ */
+function isInterruptingListMarker(marker) {
+  return (
+    marker === '-' ||
+    marker === '+' ||
+    marker === '*' ||
+    /^1[.)]$/u.test(marker)
+  );
+}
+/**
+ * The list-item content indent for `content` when it opens with a genuine,
+ * paragraph-interrupting list marker (see {@link isInterruptingListMarker}),
+ * else `null`.
+ */
+function interruptingListContentIndent(content) {
+  const listItem = parseListItemMatch(content);
+  return listItem !== null && isInterruptingListMarker(listItem.marker)
+    ? parseListItemContainer(content)
+    : null;
+}
+/**
+ * The narrowest possible list-item content indent: a one-character marker
+ * (`-`, `+`, `*`) plus its one required separating space. Every genuine
+ * list-item opener requires at least this much indentation on any
+ * continuation line, regardless of the marker actually in play (a wider
+ * marker, e.g. `10. `, only requires more) -- see {@link parseListItemContainer}.
+ */
+const MINIMUM_LIST_CONTENT_INDENT = 2;
+function createListContentIndentTrackerState() {
+  return { contentIndent: null, containerDepth: null, blankLines: 0 };
+}
+/**
+ * First half of advancing `state` for the current line, in place -- every
+ * reason `state.contentIndent` can drop out from *under* the current line
+ * (container-depth mismatch, an indentation drop below the active indent, or
+ * a second consecutive blank line). Mirrors the reset half of
+ * {@link findIndentedCodeRanges}'s own `activeListContentIndent` bookkeeping.
+ * Call this **before** reading `state.contentIndent` as the current line's
+ * `openerListContentIndent` -- {@link findIndentedCodeRanges} applies this
+ * same reset (its inline equivalent) ahead of its own opener-detection
+ * `parseFencedLine` call, so a line whose own indentation no longer
+ * qualifies (e.g. a top-level fence following an unrelated list, separated
+ * only by one blank line) must not inherit a stale indent left over from
+ * that earlier list -- doing so was a real, verified regression (a
+ * top-level fence's own content misread as still inside that list, closing
+ * the fence one line early). {@link adoptListContentIndentForLine} is the
+ * second half, called after.
+ */
+function resetListContentIndentTrackerForLine(state, parsed, isBlank) {
+  if (
+    state.contentIndent !== null &&
+    parsed.containerDepth !== state.containerDepth
+  ) {
+    state.contentIndent = null;
+    state.containerDepth = null;
+    state.blankLines = 0;
+    return;
+  }
+  if (
+    !isBlank &&
+    parsed.listContentIndent === null &&
+    state.contentIndent !== null &&
+    indentationColumns(parsed.content) < state.contentIndent
+  ) {
+    state.contentIndent = null;
+    state.containerDepth = null;
+    state.blankLines = 0;
+    return;
+  }
+  if (state.contentIndent !== null) {
+    if (isBlank) {
+      state.blankLines += 1;
+      if (state.blankLines >= 2) {
+        state.contentIndent = null;
+        state.containerDepth = null;
+      }
+    } else {
+      state.blankLines = 0;
+    }
+  }
+}
+/**
+ * Second half of advancing `state` for the current line, in place -- adopts
+ * a freshly seen list item's content indent. Gated on
+ * {@link isInterruptingListMarker} via {@link interruptingListContentIndent}
+ * -- the same paragraph-interruption-blind predicate
+ * {@link findEnclosingListContentZone} (the backward scan this tracker
+ * replaces at these two call sites) applies via its own
+ * `interruptingListContentIndent` call, restoring parity with it rather than
+ * {@link findIndentedCodeRanges}'s own richer, context-sensitive
+ * `isNonInterruptingListItem` refinement (which additionally excludes an
+ * empty-content or non-`1.`-numbered marker immediately continuing a
+ * paragraph -- context {@link blankFencedCodeBlocks}/
+ * {@link findFencedCodeRanges} do not track: `previousLineBlank` /
+ * `previousLineBlockBoundary` / `previousContainerDepth`). An earlier
+ * version adopted any `parsed.listContentIndent`, unfiltered -- confirmed
+ * wrong: `2.    fenced item marker` immediately after an ordinary paragraph
+ * line (no blank line between) does not start a list per CommonMark (a
+ * non-`1.` ordered marker never interrupts a paragraph), so content after a
+ * fence-shaped line at its indent must stay masked as ordinary paragraph
+ * text, not read as list-driven fenced code -- the unfiltered version
+ * wrongly did the latter, silently hiding real content
+ * (fail-open, worse than a missed fence, which merely leaves content
+ * unmasked). Call this **after** reading `state.contentIndent` as the
+ * current line's `openerListContentIndent` (see
+ * {@link resetListContentIndentTrackerForLine} for why the ordering
+ * matters) and only while not already inside an open fence -- an open
+ * fence's own `fence.listContentIndent` applies directly instead, mirroring
+ * {@link findIndentedCodeRanges}'s `rangeStart === null` gate on its
+ * equivalent update.
+ */
+function adoptListContentIndentForLine(state, parsed) {
+  const contentIndent = interruptingListContentIndent(parsed.content);
+  if (contentIndent !== null) {
+    state.contentIndent = contentIndent;
+    state.containerDepth = parsed.containerDepth;
+    state.blankLines = 0;
+  }
+}
+/**
+ * Determine the active list-item content zone enclosing `openingLineStart`,
+ * if any -- the list-continuation counterpart, for
+ * {@link findMarkdownBlockBoundary}'s opening line, of
+ * {@link isWithinOpenHtmlBlock}'s own backward scan for open HTML blocks.
+ * Returns `null` when `openingLineStart` is not inside an active list
+ * item's content zone at `containerDepth`.
+ *
+ * Phase 1 scans backward for the nearest same-depth list-item opener,
+ * bounded only by a container-depth mismatch or a non-blank line whose
+ * indentation falls below {@link MINIMUM_LIST_CONTENT_INDENT} (which can
+ * never continue *any* list's content zone, regardless of marker width) --
+ * deliberately not by whether an intermediate line merely *looks like* a
+ * fresh block start (heading/HTML/fence): such a line can still
+ * legitimately sit inside an already-open list item's content zone (the
+ * forward tracker in {@link findIndentedCodeRanges} only ends list state on
+ * an indentation drop or two consecutive blank lines, never on a line's
+ * shape), so aborting on shape alone produced false negatives -- Copilot
+ * review finding on #1894's PR. Phase 2 below is what actually verifies
+ * continuation, with the discovered opener's real indent, not Phase 1.
+ *
+ * Phase 2 verifies every line from that opener through `openingLineStart`
+ * itself continues the list per {@link continuesListContainer}, with the
+ * same two-consecutive-blank-line cutoff {@link findIndentedCodeRanges}
+ * applies (CommonMark ends a list after two blank lines in a row) -- the
+ * opening line must satisfy this too, not only the lines between it and
+ * the opener, or a call whose opening line has nothing to do with an
+ * earlier, unrelated list (separated only by a single blank line) would
+ * wrongly inherit that list's indent.
+ */
+function findEnclosingListContentZone(text, openingLineStart, containerDepth) {
+  let openerLineStart = null;
+  let openerContentIndent = null;
+  let lineStart = findPreviousLineStart(text, openingLineStart);
+  while (lineStart !== null) {
+    const line = lineBounds(text, lineStart);
+    const raw = text.slice(lineStart, line.end);
+    const parsed = parseContainerLine(raw);
+    if (parsed.containerDepth !== containerDepth) {
+      return null;
+    }
+    if (parsed.content.trim() === '') {
+      lineStart = findPreviousLineStart(text, lineStart);
+      continue;
+    }
+    const contentIndent = interruptingListContentIndent(parsed.content);
+    if (contentIndent !== null) {
+      openerLineStart = lineStart;
+      openerContentIndent = contentIndent;
+      break;
+    }
+    if (indentationColumns(parsed.content) < MINIMUM_LIST_CONTENT_INDENT) {
+      return null;
+    }
+    lineStart = findPreviousLineStart(text, lineStart);
+  }
+  if (openerLineStart === null || openerContentIndent === null) {
+    return null;
+  }
+  let blankRun = 0;
+  let cursor = lineBounds(text, openerLineStart).next;
+  while (cursor <= openingLineStart) {
+    const line = lineBounds(text, cursor);
+    const continuation = stripContainerPrefixes(
+      text.slice(cursor, line.end),
+      containerDepth,
+    );
+    if (continuation.trim() === '') {
+      blankRun += 1;
+      if (blankRun >= 2) {
+        return null;
+      }
+    } else {
+      blankRun = 0;
+      if (!continuesListContainer(continuation, openerContentIndent)) {
+        return null;
+      }
+    }
+    if (line.next === cursor) {
+      break;
+    }
+    cursor = line.next;
+  }
+  return { contentIndent: openerContentIndent, openerLineStart };
+}
+function findMarkdownBlockBoundary(text, start, end) {
+  const openingLineStart = text.lastIndexOf('\n', start - 1) + 1;
+  const openingLine = lineBounds(text, openingLineStart);
+  const openingRawLine = text.slice(openingLineStart, openingLine.end);
+  const openingParsed = parseContainerLine(openingRawLine);
+  const openingListItem = parseListItemMatch(openingParsed.content);
+  const openingParagraphContent =
+    openingListItem?.content ?? openingParsed.content;
+  const openingFence = parseFencedLine(openingRawLine);
+  const openingContainerDepth = openingParsed.containerDepth;
+  // List-content-indent tracking (#1894): when the opening line is itself a
+  // genuine list-item opener, its own indent applies directly; otherwise a
+  // bounded backward/forward scan checks whether it continues an earlier
+  // list item's content zone. A later line that no longer continues that
+  // zone is a genuine block boundary, mirroring the listContentIndent /
+  // continuesListContainer pairing findIndentedCodeRanges and
+  // blankFencedCodeBlocks already use -- unless it is itself a lazy
+  // continuation of the opening paragraph (below), the list counterpart of
+  // isLazyQuoteContinuation. Computed before openingIsParagraph, which
+  // needs it to decide whether the (more expensive) backward HTML-block
+  // scan below is worth running at all.
+  const openingOwnListIndent = interruptingListContentIndent(
+    openingParsed.content,
+  );
+  const openingEnclosingListZone =
+    openingOwnListIndent === null
+      ? findEnclosingListContentZone(
+          text,
+          openingLineStart,
+          openingContainerDepth,
+        )
+      : null;
+  const openingListContentIndent =
+    openingOwnListIndent ?? openingEnclosingListZone?.contentIndent ?? null;
+  // PR #1902 review finding: isWithinOpenHtmlBlock's backward scan has no
+  // concept of a list-item boundary -- it walks backward purely by
+  // same-containerDepth lines -- so, unbounded, it can reach past a
+  // genuine sibling list-item opener into an earlier, unrelated item's own
+  // open HTML block. Resolve the same "ignoring this line's own apparent
+  // marker" zone lookup #1894's own boundary check already uses, reusing
+  // the one just computed above when possible, to bound the scan at that
+  // zone's own opener line (or at the opening line itself, when no such
+  // zone reaches it -- a genuinely unreachable fresh sibling). Only
+  // computed when there is an active list zone at all (`openingListContentIndent
+  // !== null`); the pure-blockquote case (no list zone) stays unbounded,
+  // matching the pre-#1896 CommonMark-correct reachability across
+  // shape-only lines that has no sibling-item concept to bound against.
+  const openingHtmlScanBoundZone =
+    openingListContentIndent === null
+      ? null
+      : openingOwnListIndent === null
+        ? openingEnclosingListZone
+        : findEnclosingListContentZone(
+            text,
+            openingLineStart,
+            openingContainerDepth,
+          );
+  const openingHtmlScanBound =
+    openingListContentIndent === null
+      ? undefined
+      : (openingHtmlScanBoundZone?.openerLineStart ?? openingLineStart);
+  // Its backward scan only needs to run when it could actually change the
+  // outcome below: not just the laziness exception (quote laziness
+  // requires openingContainerDepth > 0, list laziness requires an active
+  // list zone) but, since #1896, also the unconditional early-return
+  // boundary a few lines down -- both share the same precondition, so one
+  // guard covers both consumers. Skip the scan entirely otherwise (Copilot
+  // review finding on #1894's PR: calling it unconditionally cost
+  // avoidable backward-scan work on every inline-code opening backtick, the
+  // common case being neither a blockquote nor an active list zone).
+  const openingIsWithinHtmlBlock =
+    (openingContainerDepth > 0 || openingListContentIndent !== null) &&
+    isWithinOpenHtmlBlock(
+      text,
+      openingLineStart,
+      openingContainerDepth,
+      openingHtmlScanBound,
+    );
+  // The opening line's own content merely *matching* a list-item marker
+  // pattern (`openingListItem !== null`) does not by itself prove it is a
+  // genuine, structurally fresh sibling block. If it is still within reach
+  // of an EARLIER, OUTER list item's content zone -- the same
+  // `openingHtmlScanBoundZone` lookup already resolved above -- it is raw
+  // or nested content still inside whatever that outer zone encloses (e.g.
+  // a `<script>` body line that happens to start with `- `), not a block
+  // boundary (PR #1902 review finding).
+  const openingListOpenerStillWithinOuterZone =
+    openingListItem !== null &&
+    openingIsWithinHtmlBlock &&
+    openingHtmlScanBoundZone !== null;
+  // #1896: a still-open raw or custom HTML block enclosing the opening line
+  // must prevent a code span from ever forming at all -- not merely gate a
+  // later line's laziness exception (below), since CommonMark never runs
+  // inline parsing inside such a block, at any container depth. Excluded
+  // only when the opening line is a genuine fresh sibling list-item opener
+  // (`openingListItem !== null` and, per the check above, not still within
+  // an outer enclosing zone): a list marker starts a structurally new
+  // block only when it is not itself raw/nested content the outer zone
+  // already encloses -- otherwise treating isWithinOpenHtmlBlock's true
+  // result as unconditional here would destroy a legitimate same-line span
+  // genuinely opened by a fresh sibling list item right after an unclosed
+  // tag in the previous one.
+  if (
+    openingIsWithinHtmlBlock &&
+    (openingListItem === null || openingListOpenerStillWithinOuterZone)
+  ) {
+    return openingLineStart;
+  }
+  // #1894/#1896: openingIsParagraph now gates list-content-indent laziness
+  // below too, not only isLazyQuoteContinuation (blockquote-only). CommonMark
+  // laziness (omitting a container's own required indentation/markers on a
+  // continuation line) only ever applies to an in-progress *paragraph*; a
+  // still-open HTML block is a different block type with its own closing
+  // rule, so it must not inherit laziness -- openingIsWithinHtmlBlock is
+  // exactly the signal that tells the two apart. This is the residual case
+  // where the early return above did not fire (the opening line is a
+  // genuine fresh sibling list-item opener), so a still-open HTML block
+  // from an earlier sibling can still suppress a *later* line's laziness
+  // exception without destroying the opening line's own same-line span.
+  const openingIsParagraph =
+    !isMarkdownBlockStart(openingParagraphContent) &&
+    !MARKDOWN_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
+    !MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
+    (openingFence === null || !isValidFenceOpener(openingFence)) &&
+    !openingIsWithinHtmlBlock;
+  let lineStart = openingLine.next;
+  while (lineStart < end) {
+    const line = lineBounds(text, lineStart);
+    const rawLine = text.slice(lineStart, line.end);
+    const parsed = parseContainerLine(rawLine);
+    // #1898 (partial): a fence marker indented to match a wide-padded list
+    // item's content start (e.g. `-    ` giving indent 5) must still be
+    // recognized as a fence opener here -- parseFencedLine's own regex only
+    // permits 0-3 leading columns, so the active list-content indent has to
+    // be stripped first, mirroring how blankFencedCodeBlocks/
+    // findFencedCodeRanges thread listContentIndent for an already-open
+    // fence's continuation/closing line. Only applies while this line still
+    // shares the opening line's container depth -- the same precondition
+    // failsListContinuation below already relies on for whether
+    // openingListContentIndent still describes this line's zone.
+    const activeListContentIndent =
+      openingListContentIndent !== null &&
+      parsed.containerDepth === openingContainerDepth
+        ? openingListContentIndent
+        : null;
+    const fencedLine = parseFencedLine(rawLine, activeListContentIndent);
+    const isBlockStart =
+      isMarkdownBlockStart(parsed.content) ||
+      MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
+      MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
+      (fencedLine !== null && isValidFenceOpener(fencedLine));
+    // A de-indented line that would otherwise end the list item's content
+    // zone still lazily continues an in-progress ordinary paragraph --
+    // CommonMark laziness -- unless the opening line is itself inside a
+    // still-open HTML block (openingIsParagraph false), which has no such
+    // exception.
+    const isLazyListContinuation = openingIsParagraph && !isBlockStart;
+    const failsListContinuation =
+      openingListContentIndent !== null &&
+      parsed.containerDepth === openingContainerDepth &&
+      !isLazyListContinuation &&
+      !continuesListContainer(
+        stripContainerPrefixes(rawLine, openingContainerDepth),
+        openingListContentIndent,
+      );
+    if (parsed.containerDepth !== openingContainerDepth) {
+      // A quote marker may continue an inline span while it stays a proper
+      // prefix of the opening container -- CommonMark laziness permits
+      // omitting any number of trailing `>` markers, not only all of them.
+      // A quote that goes deeper, or a line that starts a new block, is a
+      // real break.
+      const isLazyQuoteContinuation =
+        openingContainerDepth > 0 &&
+        parsed.containerDepth < openingContainerDepth &&
+        openingIsParagraph &&
+        !isBlockStart;
+      if (
+        !isLazyQuoteContinuation &&
+        (parsed.containerDepth > 0 || openingContainerDepth > 0)
+      ) {
+        return lineStart;
+      }
+    }
+    if (isBlockStart || failsListContinuation) {
+      return lineStart;
+    }
+    if (line.next === lineStart) {
+      break;
+    }
+    lineStart = line.next;
+  }
+  return null;
+}
+function countBackticks(text, start, end) {
+  let cursor = start;
+  while (cursor < end && text[cursor] === '`') {
+    cursor += 1;
+  }
+  return cursor - start;
+}
+const LIST_ITEM_PATTERN = /^([ \t]{0,3})([-+*]|\d{1,9}[.)])([ \t]+)(.*)$/u;
+function indentationColumns(text, initialColumns = 0) {
+  let columns = initialColumns;
+  for (const character of text) {
+    if (character === ' ') {
+      columns += 1;
+    } else if (character === '\t') {
+      columns += 4 - (columns % 4);
+    } else {
+      break;
+    }
+  }
+  return columns;
+}
+function parseListItemMatch(content) {
+  const match = content.match(LIST_ITEM_PATTERN);
+  if (!match || indentationColumns(match[1]) >= 4) {
+    return null;
+  }
+  return {
+    markerIndent: match[1],
+    marker: match[2],
+    spacing: match[3],
+    content: match[4],
+  };
+}
+function parseListItemContainer(content) {
+  const listItem = parseListItemMatch(content);
+  if (!listItem) {
+    return null;
+  }
+  const markerEndColumns =
+    indentationColumns(listItem.markerIndent) + listItem.marker.length;
+  const spacingColumns =
+    indentationColumns(listItem.spacing, markerEndColumns) - markerEndColumns;
+  // CommonMark treats five or more spaces after a list marker as one
+  // separating space plus literal content indentation. Keeping the full
+  // padding here would make a valid four-column continuation look like
+  // ordinary prose instead of nested code.
+  const contentPadding = spacingColumns > 4 ? 1 : spacingColumns;
+  return markerEndColumns + contentPadding;
+}
+function parseContainerLine(line) {
+  let cursor = 0;
+  let containerDepth = 0;
+  while (cursor < line.length) {
+    const markerStart = cursor;
+    let leadingSpaces = 0;
+    while (leadingSpaces < 3 && line[cursor] === ' ') {
+      cursor += 1;
+      leadingSpaces += 1;
+    }
+    if (line[cursor] !== '>') {
+      cursor = markerStart;
+      break;
+    }
+    cursor += 1;
+    containerDepth += 1;
+    if (line[cursor] === ' ') {
+      cursor += 1;
+    }
+  }
+  const content = containerDepth > 0 ? line.slice(cursor) : line;
+  return {
+    content,
+    containerDepth,
+    listContentIndent: parseListItemContainer(content),
+  };
+}
+function stripContainerPrefixes(line, depth) {
+  let cursor = 0;
+  for (let level = 0; level < depth; level += 1) {
+    const markerStart = cursor;
+    let leadingSpaces = 0;
+    while (leadingSpaces < 3 && line[cursor] === ' ') {
+      cursor += 1;
+      leadingSpaces += 1;
+    }
+    if (line[cursor] !== '>') {
+      return line.slice(markerStart);
+    }
+    cursor += 1;
+    if (line[cursor] === ' ') {
+      cursor += 1;
+    }
+  }
+  return line.slice(cursor);
+}
+function stripListItemMarker(content) {
+  const listItem = parseListItemMatch(content);
+  if (!listItem) {
+    return content;
+  }
+  const markerEndColumns =
+    indentationColumns(listItem.markerIndent) + listItem.marker.length;
+  const spacingColumns =
+    indentationColumns(listItem.spacing, markerEndColumns) - markerEndColumns;
+  const literalSpacing =
+    spacingColumns > 4
+      ? stripLeadingIndentColumns(
+          listItem.spacing,
+          markerEndColumns + 1,
+          markerEndColumns,
+        )
+      : '';
+  return literalSpacing + listItem.content;
+}
+function continuesListContainer(content, contentIndent) {
+  return content.trim() === '' || indentationColumns(content) >= contentIndent;
+}
+function stripLeadingIndentColumns(text, targetColumns, initialColumns = 0) {
+  if (targetColumns <= initialColumns) {
+    return text;
+  }
+  let columns = initialColumns;
+  let cursor = 0;
+  while (cursor < text.length && columns < targetColumns) {
+    const character = text[cursor];
+    if (character === ' ') {
+      columns += 1;
+    } else if (character === '\t') {
+      const nextTabStop = columns + 4 - (columns % 4);
+      if (nextTabStop > targetColumns) {
+        return ' '.repeat(nextTabStop - targetColumns) + text.slice(cursor + 1);
+      }
+      columns = nextTabStop;
+    } else {
+      return text;
+    }
+    cursor += 1;
+  }
+  return columns >= targetColumns ? text.slice(cursor) : text;
+}
+function parseFencedLine(
+  line,
+  activeListContentIndent = null,
+  fenceIsOpen = false,
+) {
+  const {
+    content: containerContent,
+    containerDepth,
+    listContentIndent,
+  } = parseContainerLine(line);
+  // A fenced block may begin directly after a list marker (`- ~~~` or
+  // `1. ~~~`). The list marker is a container prefix, not part of the fence;
+  // continuation lines commonly carry only the list indentation (`  ~~~`).
+  const relativeContent =
+    activeListContentIndent === null
+      ? containerContent
+      : stripLeadingIndentColumns(containerContent, activeListContentIndent);
+  // Once a fence is open, its contents are opaque. A line such as
+  // `    - ~~~` must not be reparsed as a nested list item and mistaken for
+  // the closing fence; strip a list marker only while recognizing an opener.
+  const content = !fenceIsOpen
+    ? stripListItemMarker(relativeContent)
+    : relativeContent;
+  const fenceMatch = content.match(/^ {0,3}(`{3,}|~{3,})(.*)$/u);
+  if (!fenceMatch) {
+    return null;
+  }
+  return {
+    marker: fenceMatch[1],
+    info: fenceMatch[2],
+    containerDepth,
+    listContentIndent,
+  };
+}
+function isValidFenceOpener(fence) {
+  return fence.marker[0] !== '`' || !fence.info.includes('`');
+}
+function findFencedCodeRanges(text) {
+  const ranges = [];
+  let fence = null;
+  const listTracker = createListContentIndentTrackerState();
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    const newlineIndex = text.indexOf('\n', lineStart);
+    const lineEnd =
+      newlineIndex === -1
+        ? text.length
+        : newlineIndex > lineStart && text[newlineIndex - 1] === '\r'
+          ? newlineIndex - 1
+          : newlineIndex;
+    const lineAfter = newlineIndex === -1 ? text.length : newlineIndex + 1;
+    const line = text.slice(lineStart, lineEnd);
+    const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
+    if (fence !== null) {
+      const listContinuationLine =
+        fence.listContentIndent === null
+          ? containerLine.content
+          : stripContainerPrefixes(line, fence.containerDepth);
+      if (
+        (fence.containerDepth > 0 &&
+          containerLine.containerDepth < fence.containerDepth) ||
+        (fence.listContentIndent !== null &&
+          !continuesListContainer(
+            listContinuationLine,
+            fence.listContentIndent,
+          ))
+      ) {
+        ranges.push({ start: fence.start, end: lineStart });
+        fence = null;
+      }
+    }
+    const fenceWasOpen = fence !== null;
+    if (!fenceWasOpen) {
+      resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    }
+    const openerListContentIndent = fence
+      ? fence.listContentIndent
+      : listTracker.contentIndent;
+    const match = parseFencedLine(
+      line,
+      openerListContentIndent,
+      fence !== null,
+    );
+    if (!fenceWasOpen) {
+      adoptListContentIndentForLine(listTracker, containerLine);
+    }
+    if (match) {
+      const marker = match.marker;
+      const info = match.info;
+      const fenceChar = marker[0];
+      if (fence === null) {
+        if (isValidFenceOpener(match)) {
+          fence = {
+            char: fenceChar,
+            length: marker.length,
+            start: lineStart,
+            containerDepth: match.containerDepth,
+            listContentIndent:
+              openerListContentIndent ?? match.listContentIndent,
+          };
+        }
+      } else if (
+        fenceChar === fence.char &&
+        marker.length >= fence.length &&
+        match.containerDepth === fence.containerDepth &&
+        /^\s*$/u.test(info)
+      ) {
+        ranges.push({ start: fence.start, end: lineAfter });
+        fence = null;
+      }
+    }
+    if (newlineIndex === -1) {
+      break;
+    }
+    lineStart = lineAfter;
+  }
+  if (fence !== null) {
+    ranges.push({ start: fence.start, end: text.length });
+  }
+  return ranges;
+}
+function findIndentedCodeRanges(text, fencedRanges) {
+  const ranges = [];
+  let rangeStart = null;
+  let rangeEnd = 0;
+  let previousLineBlank = true;
+  let previousLineBlockBoundary = true;
+  let previousContainerDepth = 0;
+  let activeListContentIndent = null;
+  let activeListContainerDepth = null;
+  let activeListBlankLines = 0;
+  let lineStart = 0;
+  let fencedRangeIndex = 0;
+  while (lineStart <= text.length) {
+    const line = lineBounds(text, lineStart);
+    const rawLine = text.slice(lineStart, line.end);
+    while (
+      fencedRangeIndex < fencedRanges.length &&
+      lineStart >= (fencedRanges[fencedRangeIndex]?.end ?? text.length)
+    ) {
+      fencedRangeIndex += 1;
+    }
+    const fencedRange = fencedRanges[fencedRangeIndex];
+    const isOpaqueFenceContent =
+      fencedRange !== undefined &&
+      lineStart > fencedRange.start &&
+      lineStart < fencedRange.end;
+    if (isOpaqueFenceContent) {
+      if (line.next === lineStart) {
+        break;
+      }
+      lineStart = line.next;
+      continue;
+    }
+    const parsed = parseContainerLine(rawLine);
+    const listItem = parseListItemMatch(parsed.content);
+    const isBlank = parsed.content.trim() === '';
+    if (
+      activeListContentIndent !== null &&
+      parsed.containerDepth !== activeListContainerDepth
+    ) {
+      activeListContentIndent = null;
+      activeListContainerDepth = null;
+      activeListBlankLines = 0;
+    }
+    if (
+      !isBlank &&
+      listItem === null &&
+      activeListContentIndent !== null &&
+      indentationColumns(parsed.content) < activeListContentIndent
+    ) {
+      activeListContentIndent = null;
+      activeListContainerDepth = null;
+      activeListBlankLines = 0;
+    }
+    const isNonInterruptingListItem =
+      listItem !== null &&
+      !previousLineBlank &&
+      !previousLineBlockBoundary &&
+      parsed.containerDepth === previousContainerDepth &&
+      activeListContentIndent === null &&
+      (listItem.content.trim() === '' ||
+        (/^\d{1,9}[.)]$/u.test(listItem.marker) &&
+          !/^1[.)]$/u.test(listItem.marker)));
+    const listContentIndent = isNonInterruptingListItem
+      ? null
+      : parsed.listContentIndent;
+    const isIndented =
+      indentationColumns(parsed.content) >=
+      (activeListContentIndent === null ? 4 : activeListContentIndent + 4);
+    if (rangeStart === null && activeListContentIndent !== null) {
+      if (isBlank) {
+        activeListBlankLines += 1;
+        if (activeListBlankLines >= 2) {
+          activeListContentIndent = null;
+          activeListContainerDepth = null;
+        }
+      } else {
+        activeListBlankLines = 0;
+      }
+    }
+    const canStartCode =
+      rangeStart !== null ||
+      previousLineBlank ||
+      previousLineBlockBoundary ||
+      parsed.containerDepth !== previousContainerDepth;
+    if (isIndented && canStartCode) {
+      rangeStart ??= lineStart;
+      rangeEnd = line.next;
+    } else if (isBlank && rangeStart !== null) {
+      // A blank line may occur inside an indented code block. Keeping it in
+      // the range is harmless for masking and lets the next indented line
+      // remain part of the same Markdown example.
+      rangeEnd = line.next;
+    } else if (rangeStart !== null) {
+      ranges.push({ start: rangeStart, end: rangeEnd });
+      rangeStart = null;
+      rangeEnd = 0;
+    }
+    previousLineBlank = isBlank;
+    previousLineBlockBoundary =
+      MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(parsed.content) ||
+      (() => {
+        const fencedLine = parseFencedLine(rawLine, activeListContentIndent);
+        return fencedLine !== null && isValidFenceOpener(fencedLine);
+      })();
+    previousContainerDepth = parsed.containerDepth;
+    if (rangeStart === null && listContentIndent !== null) {
+      activeListContentIndent = listContentIndent;
+      activeListContainerDepth = parsed.containerDepth;
+      activeListBlankLines = 0;
+    }
+    if (line.next === lineStart) {
+      break;
+    }
+    lineStart = line.next;
+  }
+  if (rangeStart !== null) {
+    ranges.push({ start: rangeStart, end: rangeEnd });
+  }
+  return ranges;
+}
+function mergeMarkdownCodeRanges(ranges) {
+  const merged = [];
+  for (const range of ranges.sort((left, right) => left.start - right.start)) {
+    const previous = merged.at(-1);
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+function findInlineCodeRanges(text, start, end) {
+  const ranges = [];
+  let cursor = start;
+  while (cursor < end) {
+    if (text[cursor] !== '`' || isEscapedBacktick(text, cursor)) {
+      cursor += 1;
+      continue;
+    }
+    const openingLength = countBackticks(text, cursor, end);
+    const contentStart = cursor + openingLength;
+    let candidate = contentStart;
+    let closed = false;
+    const blockBoundary = findMarkdownBlockBoundary(text, contentStart, end);
+    const candidateEnd = blockBoundary ?? end;
+    while (candidate < candidateEnd) {
+      if (text[candidate] !== '`') {
+        candidate += 1;
+        continue;
+      }
+      const closingLength = countBackticks(text, candidate, end);
+      if (
+        closingLength === openingLength &&
+        !hasBlankLine(text, contentStart, candidate)
+      ) {
+        ranges.push({
+          start: cursor,
+          end: candidate + closingLength,
+        });
+        cursor = candidate + closingLength;
+        closed = true;
+        break;
+      }
+      candidate += closingLength;
+    }
+    if (!closed) {
+      cursor = contentStart;
+    }
+  }
+  return ranges;
+}
+export function findMarkdownCodeRanges(text) {
+  const fencedRanges = findFencedCodeRanges(text);
+  const structuralRanges = mergeMarkdownCodeRanges([
+    ...fencedRanges,
+    ...findIndentedCodeRanges(text, fencedRanges),
+  ]);
+  const ranges = [...structuralRanges];
+  let cursor = 0;
+  for (const structuralRange of structuralRanges) {
+    ranges.push(...findInlineCodeRanges(text, cursor, structuralRange.start));
+    cursor = structuralRange.end;
+  }
+  ranges.push(...findInlineCodeRanges(text, cursor, text.length));
+  return mergeMarkdownCodeRanges(ranges);
+}
+/** Return the valid code region containing a source position, if any. */
+export function getMarkdownCodeRange(
+  text,
+  position,
+  ranges = findMarkdownCodeRanges(text),
+) {
+  if (!Number.isInteger(position) || position < 0 || position >= text.length) {
+    return null;
+  }
+  let low = 0;
+  let high = ranges.length - 1;
+  while (low <= high) {
+    const middle = low + Math.floor((high - low) / 2);
+    const range = ranges[middle];
+    if (range === undefined) {
+      break;
+    }
+    if (position < range.start) {
+      high = middle - 1;
+    } else if (position >= range.end) {
+      low = middle + 1;
+    } else {
+      return range;
+    }
+  }
+  return null;
+}
+/**
+ * Mask Markdown code regions without changing UTF-16 character positions.
+ * Unlike {@link stripMarkdownCodeRegions}, this is intended for regex matches
+ * whose offsets must be mapped back to the original text. It also follows
+ * CommonMark's equal-length backtick delimiters and escaped-backtick rules so
+ * malformed Markdown cannot hide an ordinary-prose policy directive.
+ */
+export function maskMarkdownCodeRegionsPreservingPositions(
+  text,
+  ranges = findMarkdownCodeRanges(text),
+) {
+  const masked = text.split('');
+  for (const range of ranges) {
+    for (let index = range.start; index < range.end; index += 1) {
+      if (masked[index] !== '\n' && masked[index] !== '\r') {
+        masked[index] = ' ';
+      }
+    }
+  }
+  return masked.join('');
+}

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1,0 +1,1030 @@
+// idd-generated-from: src/scripts/marker-helpers.mts
+//
+// The scripts/marker-helpers.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Operational-marker rendering and parsing (wave 1 of the protocol-helpers
+// split; see #1209): the render*/parse* functions for the claim, watermark,
+// baseline, advisory-wait, forced-handoff, and external-check-waiver
+// HTML-comment markers, plus the marker-field validation helpers they
+// share. The protocol-helpers module re-exports every name below (a plain
+// `export * from` re-export), so existing call sites are unaffected.
+//
+// Layering: this module MUST NOT import from protocol-helpers — that would
+// form an import cycle, since protocol-helpers imports from here. Gate-level
+// aggregation that folds many markers together with trust/policy context
+// (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
+// resolveLatestReviewWatermark, deriveIddAgentLogins, and friends) stays in
+// protocol-helpers on purpose: those depend on the broader trusted-actor
+// resolution machinery there (normalizeTrustedMarkerLogins and friends), and
+// moving them here would force exactly that forbidden back-import. Only the
+// single-marker parse/render primitives move in this wave.
+const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
+const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
+const OPERATIONAL_MARKER_ENTRIES = [
+  {
+    label: '<!-- claimed-by:',
+    pattern:
+      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*claimed-by:/i,
+    malformedPrefixPattern:
+      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->/i,
+  },
+  {
+    label: '<!-- unclaimed-by:',
+    pattern:
+      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*unclaimed-by:/i,
+    malformedPrefixPattern:
+      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
+  },
+  {
+    label: '<!-- activation-nonce:',
+    pattern:
+      /^<!--\s*activation-nonce:\s+\S+\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*activation-nonce:/i,
+    malformedPrefixPattern:
+      /^<!--\s*activation-nonce:\s+\S+\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
+  },
+  {
+    label: '<!-- review-watermark:',
+    pattern:
+      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*review-watermark:/i,
+    malformedPrefixPattern:
+      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/i,
+  },
+  {
+    label: '<!-- review-baseline:',
+    pattern:
+      /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*review-baseline:/i,
+    malformedPrefixPattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/i,
+  },
+  {
+    label: 'advisory-wait:',
+    pattern:
+      /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720): `pattern` above has no `/i`, so
+    // `startPattern` must not gain one either -- widening this one would
+    // loosen a marker family the issue explicitly requires to stay
+    // case-sensitive on both paths.
+    startPattern: /^advisory-wait:/,
+  },
+  {
+    // #1572: the trailing ` claim:{claimId} attempt:{n}` suffix is OPTIONAL
+    // here on purpose. The shipped AW3-R recovery flow
+    // (idd-advisory-wait.instructions.md) already posts and consumes the
+    // legacy 3-field form via post-idd-marker's `--type advisory-recovery`
+    // and protocol-helpers.mts's `advisoryWaitMarkerMatchesHead` (which
+    // matches on a prefix, so any well-formed suffix here stays compatible
+    // with it unmodified). Making the suffix required would silently break
+    // that live flow; making it optional keeps the legacy form recognized
+    // (`operationalMarkerPrefix*`) while still letting a future bound
+    // marker match here too. Only the bound form parses via
+    // `parseAdvisoryRecoveryComment` -- the legacy form is recognized
+    // (filtered as a trusted operational comment) but is NOT usable
+    // recovery-cycle evidence (excluded from counting/anchoring).
+    label: 'advisory-wait-recovery:',
+    pattern:
+      /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z(?:\s+claim:\S+\s+attempt:[1-9]\d*)?\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:
+    // above; also structurally distinct from it (the literal `:` sits right
+    // after `-recovery`, so this never matches an `advisory-wait:` body).
+    startPattern: /^advisory-wait-recovery:/,
+  },
+  {
+    label: '<!-- advisory-wait:',
+    pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
+    // Case-sensitive on purpose (#1720): not one of the issue's four named
+    // plain-text markers, but `pattern` above has no `/i` either, so this
+    // must not gain case-insensitivity -- only the same internal-whitespace
+    // tolerance after `<!--` that `pattern` already allows.
+    startPattern: /^<!--\s*advisory-wait:/,
+  },
+  {
+    // #1511: bounded same-HEAD advisory reroll request marker. PLAIN-TEXT,
+    // same shape as advisory-wait: (no visible note), so it is excluded from
+    // activity/currency/watermark computations exactly like advisory-wait /
+    // advisory-wait-recovery already are -- otherwise the agent's own
+    // reroll-request comment would pollute review-currency logic the same
+    // way a stray bot ack would (see the ack-only-convergence rationale).
+    // Deliberately a DISTINCT prefix from advisory-wait: so it never counts
+    // toward REQUEST_CAP / REQUEST_MARKER_COUNT (separateness is a named
+    // acceptance criterion of #1511).
+    label: 'advisory-reroll:',
+    pattern:
+      /^advisory-reroll:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
+    startPattern: /^advisory-reroll:/,
+  },
+  {
+    // #1572: brand-new terminal marker type, no legacy form to preserve, so
+    // the `claim:{claimId} attempt:{n}` binding suffix is unconditionally
+    // required (unlike advisory-wait-recovery: above). PLAIN-TEXT, same
+    // family shape as advisory-wait: / advisory-wait-recovery: (no visible
+    // note). This issue defines the render/parse contract only; deciding
+    // when to post it is out of scope (owned by the sibling execution/
+    // routing tracks).
+    label: 'copilot-unavailable:',
+    pattern:
+      /^copilot-unavailable:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+claim:\S+\s+attempt:[1-9]\d*\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
+    startPattern: /^copilot-unavailable:/,
+  },
+  {
+    label: '<!-- forced-handoff:',
+    pattern: /^\s*<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*forced-handoff:/i,
+  },
+  {
+    label: '<!-- idd-external-check-waiver:',
+    pattern:
+      /^<!--\s*idd-external-check-waiver:\s+\S+\s+\S+\s+[0-9a-f]{40}\s+check:\S+\s+reason:\S+\s+expires:\S+\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*idd-external-check-waiver:/i,
+  },
+];
+/**
+ * Frozen, exported view of {@link OPERATIONAL_MARKER_ENTRIES}. This array is
+ * exported (and re-exported transitively via `protocol-helpers.mts`'s
+ * `export * from './marker-helpers.mts'`) so tests can iterate every entry
+ * for the case-flag-parity / label-correspondence invariants (#1720). The
+ * `readonly OperationalMarker[]` type is compile-time only and does not
+ * stop a JS consumer -- or a TS call site that casts around the type --
+ * from mutating the array or an entry at runtime, which would silently
+ * change marker recognition for every `operationalMarkerPrefix*` call
+ * process-wide (this module's own three call sites included). `Object.freeze`
+ * on both the array and each entry makes that mutation a no-op (throwing in
+ * strict mode) instead of a silent, shared-state corruption.
+ */
+export const OPERATIONAL_MARKERS = Object.freeze(
+  OPERATIONAL_MARKER_ENTRIES.map((marker) => Object.freeze(marker)),
+);
+export const IDD_AGENT_DERIVED_MARKERS = new Set([
+  '<!-- claimed-by:',
+  '<!-- unclaimed-by:',
+  '<!-- activation-nonce:',
+  '<!-- review-watermark:',
+  '<!-- review-baseline:',
+  'advisory-wait:',
+  'advisory-wait-recovery:',
+  '<!-- advisory-wait:',
+  'advisory-reroll:',
+  'copilot-unavailable:',
+]);
+const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
+const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
+export function parseClaimComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[4])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    supersedes: match[3],
+    branch: match[5],
+    createdAt,
+  };
+}
+export function parseActivationNonceComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*activation-nonce:\\s+(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[4])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    nonce: match[3],
+    createdAt,
+  };
+}
+/**
+ * Resolve the winning activation nonce among `events` for `claimId`: the
+ * lexicographically earliest nonce (`.sort()`) among every trusted
+ * `activation-nonce` marker parsed from `events` whose `claimId` matches.
+ * This is a pure function of the observed nonce *set* (not post order or
+ * timestamp), so two sessions that both activated the same claim-id compute
+ * the identical winner once each has re-read the same trusted comment
+ * stream (#1522). `events` must already be trust-filtered by the caller --
+ * this function does no author checks of its own. Returns `null` when no
+ * matching `activation-nonce` marker exists -- callers must treat that as
+ * "no comparison possible," not a mismatch (#1522 AC3).
+ */
+export function findActivationNonceWinner(events, claimId) {
+  const nonces = events
+    .map((event) =>
+      parseActivationNonceComment(event.body ?? '', event.createdAt ?? ''),
+    )
+    .filter((marker) => Boolean(marker) && marker?.claimId === claimId)
+    .map((marker) => marker.nonce)
+    .sort();
+  return nonces.length > 0 ? nonces[0] : null;
+}
+export function parseReleaseComment(body) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[3])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+  };
+}
+export function parseForcedHandoffComment(body, createdAt) {
+  const trimmed = body.trimStart().trimEnd();
+  const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
+  if (!markerMatch) {
+    return null;
+  }
+  const markerEnd = trimmed.indexOf('-->');
+  if (markerEnd < 0) {
+    return null;
+  }
+  const visibleNote = trimmed.slice(markerEnd + 3);
+  const visibleText = visibleNote
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<!--[\s\S]*$/g, ' ')
+    .trim();
+  if (!visibleText) {
+    return null;
+  }
+  const payloadText = trimmed.slice(markerMatch[0].length, markerEnd).trim();
+  let payload;
+  try {
+    payload = JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
+  return normalizeForcedHandoffPayload(payload, { createdAt });
+}
+export function normalizeForcedHandoffPayload(payload, options = {}) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload;
+  if (
+    hasConflictingPayloadAliases(record, 'oldAgentId', 'old-agent-id') ||
+    hasConflictingPayloadAliases(record, 'oldClaimId', 'old-claim-id') ||
+    hasConflictingPayloadAliases(record, 'newAgentId', 'new-agent-id') ||
+    hasConflictingPayloadAliases(record, 'newClaimId', 'new-claim-id') ||
+    hasConflictingPayloadAliases(record, 'forcedBy', 'forced-by') ||
+    hasConflictingPayloadAliases(record, 'linkedPr', 'linked-pr') ||
+    hasConflictingPayloadAliases(record, 'contextScope', 'context-scope')
+  ) {
+    return null;
+  }
+  const oldAgentId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'oldAgentId', 'old-agent-id'),
+  );
+  const oldClaimId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'oldClaimId', 'old-claim-id'),
+  );
+  const newAgentId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'newAgentId', 'new-agent-id'),
+  );
+  const newClaimId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'newClaimId', 'new-claim-id'),
+  );
+  const branch = normalizeBranchToken(pickPayloadValue(record, 'branch'));
+  const forcedBy = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'forcedBy', 'forced-by'),
+  );
+  const reason = normalizeForcedHandoffReason(
+    pickPayloadValue(record, 'reason'),
+  );
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(
+    pickPayloadValue(record, 'timestamp'),
+  );
+  const contextScope = normalizeContextScope(
+    pickPayloadValue(record, 'contextScope', 'context-scope'),
+  );
+  const linkedPr = normalizeLinkedPr(
+    pickPayloadValue(record, 'linkedPr', 'linked-pr'),
+  );
+  const createdAt = normalizeSecondPrecisionIsoTimestamp(options.createdAt);
+  if (
+    !oldAgentId ||
+    !oldClaimId ||
+    !newAgentId ||
+    !newClaimId ||
+    !branch ||
+    !forcedBy ||
+    !reason ||
+    !timestamp ||
+    !contextScope
+  ) {
+    return null;
+  }
+  if (oldClaimId === newClaimId) {
+    return null;
+  }
+  if (contextScope === 'issue-plus-pr' && !linkedPr) {
+    return null;
+  }
+  if (contextScope === 'issue-only' && linkedPr) {
+    return null;
+  }
+  return {
+    oldAgentId,
+    oldClaimId,
+    newAgentId,
+    newClaimId,
+    branch,
+    ...(linkedPr ? { linkedPr } : {}),
+    forcedBy,
+    reason,
+    timestamp,
+    contextScope,
+    ...(createdAt ? { createdAt } : {}),
+  };
+}
+export function renderForcedHandoffConsentNote(payload) {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error('invalid forced handoff payload');
+  }
+  if (normalized.contextScope === 'issue-plus-pr') {
+    const linkedPr = normalized.linkedPr ?? '';
+    const prReference = /^\d+$/.test(linkedPr) ? `#${linkedPr}` : linkedPr;
+    return [
+      `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+      'owning session or agent is unavailable. This transfers ownership away',
+      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR ${prReference}.`,
+      'If the prior session resumes, it must stop immediately and must not',
+      'push, comment, resolve review state, or merge until a maintainer',
+      'reassigns ownership.',
+    ].join('\n');
+  }
+  return [
+    `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+    'owning session or agent is unavailable. This transfers ownership away',
+    `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\`.`,
+    'If the prior session resumes, it must stop immediately and must not',
+    'push, comment, resolve review state, or merge until a maintainer',
+    'reassigns ownership.',
+  ].join('\n');
+}
+export function renderForcedHandoffComment(payload) {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error('invalid forced handoff payload');
+  }
+  const markerPayload = {
+    'old-agent-id': normalized.oldAgentId,
+    'old-claim-id': normalized.oldClaimId,
+    'new-agent-id': normalized.newAgentId,
+    'new-claim-id': normalized.newClaimId,
+    branch: normalized.branch,
+    ...(normalized.linkedPr ? { 'linked-pr': normalized.linkedPr } : {}),
+    'forced-by': normalized.forcedBy,
+    reason: normalized.reason,
+    timestamp: normalized.timestamp,
+    'context-scope': normalized.contextScope,
+  };
+  return `<!-- forced-handoff: ${JSON.stringify(markerPayload)} -->\n\n${renderForcedHandoffConsentNote(normalized)}`;
+}
+function normalizeExternalCheckWaiverField(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    /[\r\n]/.test(trimmed) ||
+    trimmed.includes('<!--') ||
+    trimmed.includes('-->')
+  ) {
+    return '';
+  }
+  return trimmed;
+}
+function encodeExternalCheckWaiverField(value) {
+  return encodeURIComponent(value);
+}
+function decodeExternalCheckWaiverField(value) {
+  try {
+    return decodeURIComponent(String(value ?? '').trim());
+  } catch {
+    return '';
+  }
+}
+function renderExternalCheckWaiverNote(normalized) {
+  const actor = normalizeNonWhitespaceToken(normalized.actor) || 'idd-operator';
+  return [
+    `_${actor}: external check waiver for IDD F phase on \`${normalized.checkSelector}\``,
+    `until \`${normalized.expiresAt}\` (reason: ${normalized.reason})._`,
+  ].join(' ');
+}
+export function renderExternalCheckWaiverComment(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const checkSelector = normalizeExternalCheckWaiverField(
+    payload?.checkSelector ?? payload?.check,
+  );
+  const reason = normalizeExternalCheckWaiverField(payload?.reason);
+  const expiresAt = normalizeIsoTimestamp(
+    payload?.expiresAt ?? payload?.expires,
+  );
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !checkSelector ||
+    !reason ||
+    !expiresAt
+  ) {
+    throw new Error('invalid external check waiver payload');
+  }
+  const encodedCheck = encodeExternalCheckWaiverField(checkSelector);
+  const encodedReason = encodeExternalCheckWaiverField(reason);
+  return [
+    `<!-- idd-external-check-waiver: ${agentId} ${claimId} ${headSha} check:${encodedCheck} reason:${encodedReason} expires:${expiresAt} -->`,
+    '',
+    renderExternalCheckWaiverNote({
+      actor: payload?.actor,
+      checkSelector,
+      reason,
+      expiresAt,
+    }),
+  ].join('\n');
+}
+// --- Per-cycle marker body renderers (#900) ---
+//
+// Pure, network-free renderers for the three operational markers an agent
+// posts every cycle. Each returns the exact ready-to-post body (HTML marker
+// token + visible "Do not edit" note); the agent still posts it via the
+// documented HTTP path, so the read-only-by-default / instructions-only
+// fallback is unaffected. The written formats in idd-overview-core (claim)
+// and idd-review-snapshot (watermark/baseline) remain canonical.
+function normalizeMarkerCount(value) {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
+  }
+  const trimmed = String(value ?? '').trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  // The watermark parser reads the count back with Number.parseInt; reject
+  // magnitudes beyond the safe-integer range, which would not round-trip to
+  // the same value (and as a JS number would stringify to exponential form
+  // that the parser's `\d+` count pattern rejects outright).
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? trimmed : null;
+}
+// `none` or a valid ISO timestamp (matching the watermark parser's
+// none-or-ISO contract); null signals an invalid value the caller rejects.
+function normalizeMarkerIsoOrNone(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (token === '' || token === 'none') {
+    return 'none';
+  }
+  return normalizeIsoTimestamp(token) || null;
+}
+export function renderClaimedByMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
+  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
+  // parser matches case-insensitively, but the claim lifecycle
+  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
+  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
+  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
+  // through verbatim.
+  const supersedes =
+    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
+      ? 'none'
+      : supersedesToken;
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  const branch = normalizeBranchToken(payload?.branch);
+  if (!agentId || !claimId || !timestamp || !branch) {
+    throw new Error('invalid claimed-by marker payload');
+  }
+  return [
+    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
+    '',
+    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderActivationNonceMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const nonce = normalizeNonWhitespaceToken(payload?.nonce);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !claimId || !nonce || !timestamp) {
+    throw new Error('invalid activation-nonce marker payload');
+  }
+  return [
+    `<!-- activation-nonce: ${agentId} ${claimId} ${nonce} ${timestamp} -->`,
+    '',
+    `_${agentId}: claim activation nonce — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderReviewWatermarkMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
+  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
+  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    maxActivityAt === null ||
+    totalItemCount === null ||
+    ciCompletedAt === null
+  ) {
+    throw new Error('invalid review-watermark marker payload');
+  }
+  return [
+    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
+    '',
+    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderReviewBaselineMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
+  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error('invalid review-baseline marker payload');
+  }
+  return [
+    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
+    '',
+    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+// --- Write-side companion renderers (#1047) ---
+//
+// The post-idd-marker helper POSTs the same operational markers an agent emits
+// per cycle, so it needs a renderer for every type it can post. claim /
+// watermark / baseline already have renderers above; these three cover the
+// remaining post-idd-marker types so the body formats stay single-sourced.
+export function renderUnclaimedByMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !claimId || !timestamp) {
+    throw new Error('invalid unclaimed-by marker payload');
+  }
+  return [
+    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
+    '',
+    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
+// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
+// trailing visible note would break them. They carry the PR HEAD SHA (not a
+// claim id) per the AW3 protocol.
+export function renderAdvisoryWaitMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait marker payload');
+  }
+  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
+}
+/**
+ * Normalize a claimed positive-integer token (e.g. an attempt number):
+ * accepts a JS number or a purely-numeric string, rejects anything else
+ * (fractional, negative, zero, non-numeric, or unsafe magnitude). Returns
+ * `null` on any invalid input so callers can fail closed.
+ */
+function normalizePositiveIntegerToken(value) {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 1 ? value : null;
+  }
+  const trimmed = String(value ?? '').trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+/**
+ * `#1572`: extended to OPTIONALLY bind the active claim and an attempt
+ * number, in addition to the original agent/HEAD/timestamp triple. Passing
+ * neither `claimId` nor `attempt` renders the exact legacy 3-field body
+ * (byte-for-byte unchanged, preserving the shipped AW3-R recovery flow that
+ * calls this renderer today without those fields). Passing both appends the
+ * bound suffix. Passing only one of the two throws -- a half-bound marker
+ * would be ambiguous evidence, so this fails closed rather than silently
+ * omitting the partial field.
+ */
+export function renderAdvisoryWaitRecoveryMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait-recovery marker payload');
+  }
+  const claimIdProvided =
+    payload?.claimId !== undefined &&
+    payload?.claimId !== null &&
+    payload?.claimId !== '';
+  const attemptProvided =
+    payload?.attempt !== undefined &&
+    payload?.attempt !== null &&
+    payload?.attempt !== '';
+  if (!claimIdProvided && !attemptProvided) {
+    return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
+  }
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const attempt = normalizePositiveIntegerToken(payload?.attempt);
+  if (!claimId || attempt === null) {
+    throw new Error(
+      'invalid advisory-wait-recovery marker payload: claimId and attempt must both be provided together',
+    );
+  }
+  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp} claim:${claimId} attempt:${attempt}`;
+}
+/**
+ * `#1572`: brand-new terminal marker, no legacy unbound form -- agent,
+ * claim, HEAD, and attempt number are all unconditionally required (unlike
+ * {@link renderAdvisoryWaitRecoveryMarker}'s optional binding). Rendering
+ * this marker does not decide *when* to post it; that policy belongs to the
+ * sibling execution/routing tracks (#1571/#1570).
+ */
+export function renderCopilotUnavailableMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const attempt = normalizePositiveIntegerToken(payload?.attempt);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    attempt === null ||
+    !timestamp
+  ) {
+    throw new Error('invalid copilot-unavailable marker payload');
+  }
+  return `copilot-unavailable: ${agentId} ${headSha} ${timestamp} claim:${claimId} attempt:${attempt}`;
+}
+// #1511: advisory-reroll is ALSO a PLAIN-TEXT marker (no visible note), same
+// reasoning as advisory-wait/advisory-wait-recovery above -- AW6's recognizer
+// anchors on `\s*$` with no trailing note. It carries the PR HEAD SHA (not a
+// claim id), matching the advisory-wait family's shape exactly, since it is
+// the same "which HEAD is this about" question, just for a distinct bounded
+// budget kept separate from REQUEST_CAP.
+export function renderAdvisoryRerollMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-reroll marker payload');
+  }
+  return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
+}
+// #1905: the grammar's positional claim-id field
+// (`{agent-id} {claim-id|none} {head-sha} ...`) already accepts an
+// arbitrary non-whitespace token, so the case-insensitive literal `none`
+// sentinel parses through the SAME `(\S+)` capture as any other claim id --
+// no regex change needed here. `parsed.claimId` carries the token verbatim
+// (case preserved); see `ParsedExternalCheckWaiver.claimId`'s doc comment
+// for how the consumer resolves the sentinel.
+export function parseExternalCheckWaiverComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*idd-external-check-waiver:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+check:(\\S+)\\s+reason:(\\S+)\\s+expires:(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match) {
+    return null;
+  }
+  const checkSelector = normalizeExternalCheckWaiverField(
+    decodeExternalCheckWaiverField(match[4]),
+  );
+  const reason = normalizeExternalCheckWaiverField(
+    decodeExternalCheckWaiverField(match[5]),
+  );
+  const expiresAt = normalizeIsoTimestamp(match[6]);
+  if (!checkSelector || !reason || !expiresAt) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    headSha: match[3].toLowerCase(),
+    checkSelector,
+    reason,
+    expiresAt,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+export function parseReviewWatermarkComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*review-watermark:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+(\\S+)\\s+(\\d+)\\s+(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match) {
+    return null;
+  }
+  const maxActivityUpdatedAt = match[4];
+  const latestCiCompletedAt = match[6];
+  if (
+    maxActivityUpdatedAt !== 'none' &&
+    !isValidIsoTimestamp(maxActivityUpdatedAt)
+  ) {
+    return null;
+  }
+  if (
+    latestCiCompletedAt !== 'none' &&
+    !isValidIsoTimestamp(latestCiCompletedAt)
+  ) {
+    return null;
+  }
+  const totalItemCount = Number.parseInt(match[5], 10);
+  if (!Number.isInteger(totalItemCount) || totalItemCount < 0) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    // #1693: the `i` flag accepts an uppercase-hex SHA (the documented
+    // manual hand-composed fallback path), but downstream comparisons
+    // (diffReviewSnapshot in protocol-helpers.mts) match exactly against
+    // the always-lowercase live head SHA. Returning match[3] verbatim let a
+    // hand-composed uppercase watermark parse as valid yet never satisfy
+    // the F2 currency check, producing an unexplained head-changed
+    // repost loop. Lowercase here, matching parseExternalCheckWaiverComment's
+    // existing headSha.toLowerCase() below.
+    headSha: match[3].toLowerCase(),
+    maxActivityUpdatedAt,
+    totalItemCount,
+    latestCiCompletedAt,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+/**
+ * Shared parser for the bound `{prefix}: {agentId} {headSha} {timestamp}
+ * claim:{claimId} attempt:{attempt}` shape used by both
+ * `advisory-wait-recovery:` (when bound) and `copilot-unavailable:` (always
+ * bound). Returns `null` on any structural mismatch, including the legacy
+ * unbound `advisory-wait-recovery:` form -- that form is still recognized as
+ * an operational marker by `OPERATIONAL_MARKERS`, but is not usable evidence
+ * for recovery-cycle counting or terminal-clock anchoring (#1572 AC3: fail
+ * closed, exclude rather than guess).
+ */
+function parseBoundAdvisoryEvidenceMarker(prefix, body) {
+  const match = body.trimEnd().match(
+    new RegExp(
+      // Fractional seconds, when present, sit before the `Z` designator
+      // per ISO 8601 (e.g. `00:00:00.123Z`) -- this must match the
+      // OPERATIONAL_MARKERS `advisory-wait-recovery:` / `copilot-unavailable:`
+      // patterns exactly, or a fractional embedded timestamp could be
+      // recognized as an operational marker but rejected here (or vice
+      // versa). `ISO8601_UTC_PATTERN` itself has no fractional-seconds
+      // slot, so it is not reused for this group.
+      // attempt requires a positive integer ([1-9]\d*, no leading zero,
+      // no zero) -- matching OPERATIONAL_MARKERS' recognizer patterns
+      // exactly, so `attempt:0` is rejected structurally by BOTH the
+      // recognizer and the parser instead of being recognized as a
+      // well-formed marker here and then discarded post-parse.
+      `^${prefix}:\\s+(\\S+)\\s+([0-9a-f]{40})\\s+(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)\\s+claim:(\\S+)\\s+attempt:([1-9]\\d*)\\s*$`,
+    ),
+  );
+  if (!match) {
+    return null;
+  }
+  const attempt = Number.parseInt(match[5], 10);
+  if (!Number.isSafeInteger(attempt) || attempt < 1) {
+    // Unreachable given the regex above already excludes 0 and non-digits;
+    // kept as defense-in-depth against a future regex edit that widens the
+    // attempt group without updating this guard.
+    return null;
+  }
+  return {
+    agentId: match[1],
+    headSha: match[2].toLowerCase(),
+    timestamp: match[3],
+    claimId: match[4],
+    attempt,
+  };
+}
+/**
+ * Parse a bound `advisory-wait-recovery:` marker (#1572). Returns `null` for
+ * the legacy 3-field form (no claim/attempt binding) -- callers must treat
+ * that as unusable recovery-cycle evidence, not a parse failure to retry.
+ */
+export function parseAdvisoryRecoveryComment(body, createdAt) {
+  const parsed = parseBoundAdvisoryEvidenceMarker(
+    'advisory-wait-recovery',
+    body,
+  );
+  if (!parsed) {
+    return null;
+  }
+  return {
+    ...parsed,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+/** Parse a `copilot-unavailable:` terminal marker (#1572). */
+export function parseCopilotUnavailableComment(body, createdAt) {
+  const parsed = parseBoundAdvisoryEvidenceMarker('copilot-unavailable', body);
+  if (!parsed) {
+    return null;
+  }
+  return {
+    ...parsed,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+export function operationalMarkerPrefix(body) {
+  const normalized = body.trimEnd();
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.pattern.test(normalized),
+  );
+  if (!marker) {
+    return null;
+  }
+  if (
+    marker.label === '<!-- forced-handoff:' &&
+    !isValidForcedHandoffOperationalMarker(normalized)
+  ) {
+    return null;
+  }
+  return marker.label;
+}
+export function operationalMarkerPrefixByStart(body) {
+  const normalized = body.trimStart();
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.startPattern.test(normalized),
+  );
+  if (!marker) {
+    return null;
+  }
+  if (
+    marker.label === '<!-- forced-handoff:' &&
+    !isValidForcedHandoffOperationalMarker(normalized)
+  ) {
+    return null;
+  }
+  return marker.label;
+}
+/**
+ * Detects a `claimed-by` / `unclaimed-by` / `activation-nonce` /
+ * `review-watermark` / `review-baseline` comment whose body starts with a
+ * structurally valid marker token but whose whole body does not match the
+ * canonical, strict
+ * `pattern` -- for **any** reason: content appended directly after the
+ * token with no note, a well-intentioned human rationale appended after an
+ * otherwise-canonical token + note (the motivating case), a note that does
+ * not satisfy the required note grammar (e.g. missing the required `IDD`
+ * word), or any other departure from the canonical token-then-optional-
+ * single-note shape. Such a body already fails `operationalMarkerPrefix`'s
+ * whole-body anchor and is therefore never treated as a live marker for
+ * state resolution (`parseClaimComment`, `resolveActiveClaim`, and friends
+ * keep returning `null` / ignoring it, unchanged by this function's
+ * existence); this gives a caller that wants one a **distinct** "malformed
+ * marker" signal instead of the comment silently reading as ordinary,
+ * unremarkable content (#1316).
+ *
+ * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
+ * body is malformed in that specific way, or `null` when the body is either
+ * a well-formed marker (not malformed) or not marker-shaped at all.
+ *
+ * Anti-spoofing is preserved: like `pattern`, `malformedPrefixPattern`
+ * anchors `^` at byte 0 with no leading-whitespace tolerance, so a marker
+ * merely quoted or embedded mid-prose -- i.e. not literally the first bytes
+ * of the body -- matches neither pattern and is never flagged here.
+ */
+export function detectMalformedOperationalMarker(body) {
+  if (operationalMarkerPrefix(body) !== null) {
+    // Already a well-formed marker (or otherwise-recognized marker type) --
+    // not malformed. Checking this first avoids double-classifying the
+    // happy path that `parseClaimComment` and friends already handle.
+    return null;
+  }
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.malformedPrefixPattern?.test(body),
+  );
+  return marker ? marker.label : null;
+}
+function normalizeNonWhitespaceToken(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    /\s/.test(trimmed) ||
+    trimmed.includes('<!--') ||
+    trimmed.includes('-->')
+  ) {
+    return '';
+  }
+  return trimmed;
+}
+function pickPayloadValue(payload, ...keys) {
+  for (const key of keys) {
+    if (Object.hasOwn(payload, key)) {
+      return payload[key];
+    }
+  }
+  return undefined;
+}
+function hasConflictingPayloadAliases(payload, firstKey, secondKey) {
+  if (!Object.hasOwn(payload, firstKey) || !Object.hasOwn(payload, secondKey)) {
+    return false;
+  }
+  return (
+    String(payload[firstKey] ?? '').trim() !==
+    String(payload[secondKey] ?? '').trim()
+  );
+}
+function normalizeBranchToken(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || token.includes('>')) {
+    return '';
+  }
+  return token;
+}
+function normalizeForcedHandoffReason(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed || /[\r\n]/.test(trimmed) || trimmed.includes('-->')) {
+    return '';
+  }
+  return trimmed;
+}
+function normalizeIsoTimestamp(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !isValidIsoTimestamp(trimmed)) {
+    return '';
+  }
+  return trimmed;
+}
+function normalizeSecondPrecisionIsoTimestamp(value) {
+  const timestamp = normalizeIsoTimestamp(value);
+  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
+    return '';
+  }
+  return timestamp;
+}
+function normalizeContextScope(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return FORCED_HANDOFF_CONTEXT_SCOPES.has(trimmed) ? trimmed : '';
+}
+function normalizeLinkedPr(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || !FORCED_HANDOFF_LINKED_PR_PATTERN.test(token)) {
+    return '';
+  }
+  return token;
+}
+function isValidForcedHandoffOperationalMarker(body) {
+  return parseForcedHandoffComment(body, '') !== null;
+}
+export function isValidIsoTimestamp(value) {
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return false;
+  const normalize = (ts) => ts.replace('.000Z', 'Z');
+  return normalize(new Date(time).toISOString()) === normalize(value);
+}

--- a/scripts/marker-regex.mjs
+++ b/scripts/marker-regex.mjs
@@ -1,0 +1,35 @@
+// idd-generated-from: src/scripts/marker-regex.mts
+//
+// The scripts/marker-regex.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Shared helpers for building marker-detection regexes from a configurable
+// marker prefix. Centralizing escapeRegex + createMarkerRegex keeps the
+// discover-phase helpers (orphan filter, readiness check) from re-deriving
+// the escaping rules, so an adopter's namespaced marker prefix flows through
+// one regex builder instead of a per-file hardcoded literal.
+/**
+ * Escape every RegExp metacharacter in `value` so it can be embedded as a
+ * literal inside a larger pattern. Used to make a configurable marker prefix
+ * (which a namespaced adopter may write with `.`, `+`, `(`, ... ) safe to
+ * interpolate into a marker regex.
+ */
+export function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+/**
+ * Build a case-insensitive detection regex for an HTML-comment marker of the
+ * form `<!-- {prefix}-{suffix} ... -->`. The prefix is regex-escaped so a
+ * namespaced adopter prefix cannot corrupt the pattern; the suffix is a fixed
+ * internal literal (e.g. `roadmap-id`, `blocked-by`). The pattern is
+ * detection-only — no capture group and non-global — so callers that must
+ * extract the marker value build their own capturing regex from
+ * {@link escapeRegex}.
+ */
+export function createMarkerRegex(prefix, suffix) {
+  return new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-${suffix}\\b[\\s\\S]*?-->`,
+    'i',
+  );
+}

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -1,0 +1,565 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/minimize-superseded-markers.mts
+//
+// The scripts/minimize-superseded-markers.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+// Deliberately NOT importing the shared config-loader module (see #1208's
+// PR discussion): docs/idd-helper-scripts.md documents that this helper
+// "stays self-contained so the template copy works without
+// protocol-helpers.mjs" — the curated idd-template/scripts/ mirror
+// carries only this one file, so any cross-file import (even a small one)
+// breaks the template copy with ERR_MODULE_NOT_FOUND. This applies
+// regardless of extension, so keep this local copy in both the .mts
+// source and its generated .mjs/template-mirror artifacts.
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
+}
+// #1675: this file is deliberately self-contained (see the "Deliberately
+// NOT importing the shared config-loader module" comment above) and so
+// cannot import gh-exec.mts's shared DEFAULT_GH_TIMEOUT_MS -- duplicating
+// the same 30s value locally is the narrow, documented exception to
+// routing every gh call through gh-exec.mts. Declared here, above the
+// import.meta.main trigger below, rather than alongside runGh further
+// down: the trigger block calls runGh() synchronously at
+// module-evaluation time, and a const declared after that point is still
+// in the temporal dead zone when the trigger fires (see
+// discover-readiness-check.mts's / ci-wait-policy.mts's identical note).
+const GH_TIMEOUT_MS = 30_000;
+const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
+const ALLOWED_FORMATS = new Set(['json', 'table']);
+const MINIMIZABLE_TYPENAMES = new Set([
+  'IssueComment',
+  'PullRequestReview',
+  'PullRequestReviewComment',
+]);
+// GitHub's GraphQL node(id:) query returns this message (independent of
+// subject type) whenever an id cannot be resolved — including, but NOT
+// limited to, a REST numeric id passed where a GraphQL global node id is
+// required. The same text also covers a syntactically valid node id whose
+// object was deleted or is inaccessible, so this pattern alone cannot
+// distinguish "wrong id shape" from "right shape, gone object": pair it with
+// REST_SHAPED_SUBJECT_ID_PATTERN below before assuming the former. Shared by
+// probeSubject's error path and --help so the guidance never drifts between
+// the two surfaces.
+const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+// REST numeric ids (issue comment / PR review / PR review comment) are
+// always bare positive integers with no leading zero; GraphQL global node
+// ids never are. Gating the enhanced guidance on this shape keeps it from
+// misfiring on a GraphQL-shaped id that legitimately failed to resolve
+// (deleted or inaccessible), where the raw gh error remains the accurate
+// reason. `[1-9]\d*` (rather than `\d+`) excludes "0" and leading-zero forms
+// like "0001", which no real REST id ever takes.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^[1-9]\d*$/;
+const NODE_ID_CONVERSION_COMMANDS = [
+  "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
+  "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
+  "  PR review comment: gh api repos/{owner}/{repo}/pulls/comments/{comment_id} -q '.node_id'",
+].join('\n');
+if (import.meta.main) {
+  let args;
+  try {
+    args = parseMinimizeArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exit(2);
+  }
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (!ALLOWED_CLASSIFIERS.has(args.classifier)) {
+    console.error(
+      `error: --classifier must be one of ${[...ALLOWED_CLASSIFIERS].join(', ')} (got "${args.classifier}")`,
+    );
+    process.exit(2);
+  }
+  if (!ALLOWED_FORMATS.has(args.format)) {
+    console.error(
+      `error: --format must be one of ${[...ALLOWED_FORMATS].join(', ')} (got "${args.format}")`,
+    );
+    process.exit(2);
+  }
+  if (args.subjectIds.length === 0) {
+    console.error('error: --subject-ids must contain at least one ID');
+    process.exit(2);
+  }
+  const { actors: trustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+  const trustedSet = new Set(trustedActors);
+  if (trustedSet.size === 0 && !args.allowUntrusted) {
+    console.error(
+      'error: no trusted marker logins supplied. Pass --trusted-marker-logins, set IDD_TRUSTED_MARKER_ACTORS, or list trustedMarkerActors in .github/idd/config.json; or pass --allow-untrusted to explicitly opt out of the author gate.',
+    );
+    process.exit(2);
+  }
+  const report = runMinimize({
+    subjectIds: args.subjectIds,
+    classifier: args.classifier,
+    trustedSet,
+    apply: args.apply,
+    allowUntrusted: args.allowUntrusted,
+  });
+  report.trustedMarkerActors = [...trustedSet].sort();
+  report.trustedMarkerActorsSource = trustedMarkerActorsSource;
+  if (args.format === 'table') {
+    printTable(report);
+  } else {
+    console.log(JSON.stringify(report, null, 2));
+  }
+  const exitCode = computeExitCode(report);
+  process.exit(exitCode);
+}
+export function runMinimize({
+  subjectIds,
+  classifier,
+  trustedSet,
+  apply,
+  allowUntrusted,
+}) {
+  const report = {
+    mode: apply ? 'apply' : 'dry-run',
+    classifier,
+    counts: {
+      eligible: 0,
+      alreadyMinimized: 0,
+      cannotMinimize: 0,
+      untrusted: 0,
+      unsupportedType: 0,
+      applied: 0,
+      failed: 0,
+    },
+    items: [],
+  };
+  for (const subjectId of subjectIds) {
+    const probe = probeSubject(subjectId);
+    if (!probe.ok) {
+      report.items.push({ subjectId, status: 'failed', reason: probe.reason });
+      report.counts.failed += 1;
+      continue;
+    }
+    const { author, isMinimized, viewerCanMinimize, url, typename } =
+      probe.node;
+    if (!MINIMIZABLE_TYPENAMES.has(String(typename))) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'unsupported-type',
+      });
+      report.counts.unsupportedType += 1;
+      continue;
+    }
+    if (isMinimized) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'already-minimized',
+      });
+      report.counts.alreadyMinimized += 1;
+      continue;
+    }
+    if (!viewerCanMinimize) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'viewer-cannot-minimize',
+      });
+      report.counts.cannotMinimize += 1;
+      continue;
+    }
+    if (!allowUntrusted && !isTrustedAuthor(author, trustedSet)) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'untrusted-author',
+        author,
+      });
+      report.counts.untrusted += 1;
+      continue;
+    }
+    report.counts.eligible += 1;
+    if (!apply) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'would-apply',
+        author,
+      });
+      continue;
+    }
+    const mutation = applyMinimize(subjectId, classifier);
+    if (mutation.ok) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'applied',
+        author,
+      });
+      report.counts.applied += 1;
+    } else {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'failed',
+        reason: mutation.reason,
+      });
+      report.counts.failed += 1;
+    }
+  }
+  return report;
+}
+// cspell:ignore Wpaqs
+// probeSubject requires a GraphQL global node id (e.g.
+// IC_kwDOSWpaqs8AAAABIk9VAg) — REST responses instead surface a numeric id
+// (e.g. 4870591746). A bare integer is never auto-converted here: it could
+// belong to an issue comment, a PR review, or a PR review comment, each
+// served by a different REST endpoint, so guessing which one risks querying
+// the wrong resource. Point the caller at the exact conversion command
+// instead.
+function unresolvableNodeIdReason(subjectId) {
+  return (
+    `unresolvable-node-id: "${subjectId}" is not a GraphQL node ID. ` +
+    "probeSubject queries GitHub's GraphQL node(id: $id) API, which " +
+    'requires a GraphQL global node ID (e.g. IC_kwDOSWpaqs8AAAABIk9VAg), ' +
+    'not a REST numeric ID (e.g. 4870591746). Convert the REST ID to its ' +
+    `node ID first, using the command for the subject type:\n${NODE_ID_CONVERSION_COMMANDS}`
+  );
+}
+// Both conditions must hold: the subject id must itself look REST-shaped
+// (see REST_SHAPED_SUBJECT_ID_PATTERN above), not just the error text —
+// otherwise a valid-but-deleted/inaccessible GraphQL node id would be
+// misreported as "not a GraphQL node ID".
+function isUnresolvableRestShapedId(subjectId, errorText) {
+  return (
+    REST_SHAPED_SUBJECT_ID_PATTERN.test(subjectId) &&
+    UNRESOLVABLE_NODE_ID_PATTERN.test(errorText)
+  );
+}
+export function probeSubject(subjectId) {
+  const result = runGh([
+    'api',
+    'graphql',
+    '-f',
+    `query=query($id:ID!){
+        node(id:$id){
+          __typename
+          ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+          ... on PullRequestReview{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+          ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+        }
+      }`,
+    '-f',
+    `id=${subjectId}`,
+  ]);
+  if (!result.ok) {
+    if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
+    return {
+      ok: false,
+      reason: `gh-graphql-error: ${result.stderr.slice(0, 200)}`,
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `gh-graphql-parse: ${error.message}`,
+    };
+  }
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    const joinedErrors = parsed.errors
+      .map((e) => String(e.message ?? ''))
+      .filter(Boolean)
+      .join('; ');
+    if (isUnresolvableRestShapedId(subjectId, joinedErrors)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
+    return {
+      ok: false,
+      reason: `gh-graphql-errors: ${joinedErrors.slice(0, 200)}`,
+    };
+  }
+  const node = parsed?.data?.node;
+  if (!node) {
+    return { ok: false, reason: 'node-missing' };
+  }
+  return {
+    ok: true,
+    node: {
+      typename: node.__typename,
+      url: node.url,
+      isMinimized: node.isMinimized,
+      viewerCanMinimize: node.viewerCanMinimize,
+      author: node.author?.login,
+    },
+  };
+}
+export function applyMinimize(subjectId, classifier) {
+  const result = runGh([
+    'api',
+    'graphql',
+    '-f',
+    `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+      minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+        minimizedComment{
+          __typename
+          ... on IssueComment{id isMinimized minimizedReason}
+          ... on PullRequestReview{id isMinimized minimizedReason}
+          ... on PullRequestReviewComment{id isMinimized minimizedReason}
+        }
+      }
+    }`,
+    '-f',
+    `id=${subjectId}`,
+    '-f',
+    `classifier=${classifier}`,
+  ]);
+  if (!result.ok) {
+    return {
+      ok: false,
+      reason: `mutation-error: ${result.stderr.slice(0, 200)}`,
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (error) {
+    return { ok: false, reason: `mutation-parse: ${error.message}` };
+  }
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    return {
+      ok: false,
+      reason: `mutation-graphql-errors: ${parsed.errors
+        .map((e) => String(e.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    };
+  }
+  const minimized = parsed?.data?.minimizeComment?.minimizedComment;
+  if (minimized?.isMinimized !== true) {
+    return {
+      ok: false,
+      reason: `mutation-no-confirmation: minimizedComment.isMinimized was not true`,
+    };
+  }
+  return { ok: true };
+}
+export function normalizeTrustedMarkerLogins(logins) {
+  return [
+    ...new Set(
+      (Array.isArray(logins) ? logins : [])
+        .map((login) =>
+          String(login ?? '')
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+// Local flag > env > config ladder mirroring the shared
+// resolveTrustedMarkerActors() contract. This helper stays
+// self-contained because the template mirror ships without
+// protocol-helpers.mjs.
+export function resolveTrustedActors({
+  flagValue = '',
+  envValue = '',
+  config = null,
+} = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(splitLoginCsv(flagValue));
+  if (fromFlag.length > 0) {
+    return { actors: fromFlag, source: 'flag' };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(splitLoginCsv(envValue));
+  if (fromEnv.length > 0) {
+    return { actors: fromEnv, source: 'env' };
+  }
+  const configActors = config?.trustedMarkerActors;
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(configActors) ? configActors : [],
+  );
+  if (fromConfig.length > 0) {
+    return { actors: fromConfig, source: 'config' };
+  }
+  return { actors: [], source: 'none' };
+}
+function splitLoginCsv(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((login) => login.trim())
+    .filter((login) => login.length > 0);
+}
+export function isTrustedAuthor(author, trustedSet) {
+  if (!author) {
+    return false;
+  }
+  return trustedSet.has(String(author).toLowerCase());
+}
+export function computeExitCode(report) {
+  if (report.counts.failed > 0) {
+    return 1;
+  }
+  return 0;
+}
+function printTable(report) {
+  console.log(`mode: ${report.mode}  classifier: ${report.classifier}`);
+  const c = report.counts;
+  console.log(
+    `counts: eligible=${c.eligible} applied=${c.applied} failed=${c.failed} already=${c.alreadyMinimized} blocked=${c.cannotMinimize} untrusted=${c.untrusted} unsupported=${c.unsupportedType}`,
+  );
+  for (const item of report.items) {
+    const url = item.url ?? '(no url)';
+    const reason = item.reason ?? '';
+    console.log(`  [${item.status}] ${item.subjectId}  ${url}  ${reason}`);
+  }
+}
+function runGh(argv) {
+  try {
+    const stdout = execFileSync('gh', argv, {
+      encoding: 'utf8',
+      timeout: GH_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout };
+  } catch (error) {
+    const e = error;
+    return {
+      ok: false,
+      stderr: String(e.stderr?.toString?.() ?? e.message ?? 'unknown error'),
+    };
+  }
+}
+// Calls node:util's parseArgs directly rather than the shared
+// src/scripts/cli-args.mts wrapper: cli-args.mts is a `./`-relative
+// import, which would break this file's self-contained invariant (see the
+// loadIddConfig() comment above) — node:util is a built-in, so it does
+// not. This file has zero integer flags, so it needs none of the
+// wrapper's extra canonical-integer / single-dash-disambiguation helpers.
+// See kurone-kito/idd-skill#1486 for the full disposition writeup.
+//
+// Narrow, deliberate behavior deltas from the previous hand-rolled
+// for/switch loop (none is exercised by tests/minimize-superseded-markers.test.mts,
+// and docs/idd-helper-scripts.md does not name any of their exact wording —
+// the same class of accepted delta already shipped for this file's
+// if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged
+// try/catch in the import.meta.main entrypoint above (which calls this
+// function), same as the behavior they replace:
+//   - A value-taking flag with genuinely nothing after it (end of argv)
+//     now throws parseArgs' own "Option '--x <value>' argument missing"
+//     instead of this file's old per-flag `--x requires a value` text.
+//     (The *empty-string* case -- `--x ''` -- is unaffected: the explicit
+//     post-parse check below still throws the exact original message for
+//     that case, which is the behavior kurone-kito/idd-skill#1451 was
+//     actually concerned with.)
+//   - An unknown flag or unexpected bare argument now surfaces parseArgs'
+//     own "Unknown option '--x'" / "Unexpected argument 'x'..." text
+//     instead of this file's old uniform `unknown argument: <token>`.
+//   - A dash-shaped value passed to a string flag (e.g.
+//     `--subject-ids --apply`) is now rejected up front ("argument is
+//     ambiguous", exit 2) where the old loop silently accepted it as a
+//     literal string value -- previously this often still failed, but
+//     later and indirectly, once the bogus value's `gh` probe lookup
+//     failed (a per-item failure, exit 1 via computeExitCode).
+//   - `--apply=<value>` (or any other boolean flag with `=`) now throws
+//     "does not take an argument" instead of falling through to
+//     `unknown argument: --apply=<value>`.
+//   - Conversely, `--subject-ids=<value>` (or `=` on any other string
+//     flag) is now silently *accepted* as an alternate value syntax; the
+//     old loop's exact `arg === '--subject-ids'` comparison never matched
+//     the `=`-joined form, so it fell through to
+//     `unknown argument: --subject-ids=<value>`. The empty-string form
+//     (`--subject-ids=`) is unaffected either way -- it still hits the
+//     post-parse check below exactly like `--subject-ids ''` does.
+//   - A bare trailing `--` (the POSIX end-of-options marker) is now
+//     silently accepted as a no-op, where the old loop's exact-match
+//     fallthrough rejected it as `unknown argument: --`. Not expected to
+//     matter in practice: this helper is only ever invoked from fixed,
+//     known argument lists (CI workflows, documented manual commands),
+//     never arbitrary/untrusted argv.
+function parseMinimizeArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      apply: { type: 'boolean' },
+      'allow-untrusted': { type: 'boolean' },
+      'subject-ids': { type: 'string' },
+      classifier: { type: 'string', default: 'OUTDATED' },
+      // '--trusted-marker-logins' is the one flag whose empty string is a
+      // meaningful, accepted value (an explicit empty override in
+      // resolveTrustedActors()'s flag > env > config ladder) -- unlike
+      // the three flags checked below, it gets no post-parse empty-string
+      // rejection; parseArgs' own "argument missing" error already covers
+      // the genuinely-absent case.
+      'trusted-marker-logins': { type: 'string', default: '' },
+      format: { type: 'string', default: 'json' },
+    },
+    strict: true,
+  });
+  // parseArgs accepts an explicit empty string for every string flag (only
+  // a genuinely missing value throws), but --subject-ids/--classifier/
+  // --format never treated '' as meaningful -- reproduce that rejection
+  // explicitly, matching the original `if (!value)` guards' exact message.
+  for (const flag of ['subject-ids', 'classifier', 'format']) {
+    if (values[flag] === '') {
+      throw new Error(`--${flag} requires a value`);
+    }
+  }
+  return {
+    subjectIds: (values['subject-ids'] ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+    classifier: values.classifier ?? 'OUTDATED',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    apply: values.apply ?? false,
+    allowUntrusted: values['allow-untrusted'] ?? false,
+    format: values.format ?? 'json',
+    help: values.help ?? false,
+  };
+}
+function printUsage() {
+  console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
+
+The trusted-author gate is mandatory by default: supply trusted logins
+via --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or the
+trustedMarkerActors list in .github/idd/config.json (flag > env >
+config precedence) so the helper rejects markers from untrusted GitHub
+actors. Use --allow-untrusted only when you intentionally want to
+minimize markers regardless of author, and the caller has already
+verified the subject IDs are operationally safe to hide.
+
+--subject-ids must be GraphQL global node IDs (e.g.
+IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
+Convert a REST ID to its node ID first, using the command for the
+subject type:
+${NODE_ID_CONVERSION_COMMANDS}`);
+}

--- a/scripts/phase-id-resolver.mjs
+++ b/scripts/phase-id-resolver.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/phase-id-resolver.mts
+//
+// The scripts/phase-id-resolver.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+// Canonical machine-facing phase IDs. This set must cover every phase route
+// `resume-route-selection` can emit (documented enum
+// `D1|D4|E1|E15|Esync|F1|F2|stop`) so a route the resume helper selects always
+// resolves here instead of throwing `unknown_phase_id`;
+// `tests/phase-id-resolver.test.mts` guards that union. `Esync` (the E-phase
+// branch-resync route) is therefore listed below. Two deliberate boundaries:
+//   - `stop` is a terminal control signal (stop-and-report), not a phase, so it
+//     is intentionally NOT canonical and resolves to `unknown_phase_id`.
+//   - bare `A` is the collapsed routing-graph-only node in
+//     `schemas/phase-graph.json`; `resume-route-selection` never emits it, and
+//     this list enumerates the concrete discovery sub-phases `A0..A5` instead,
+//     so bare `A` is intentionally non-canonical (it resolves to
+//     `unknown_phase_id`) rather than being added here.
+import { parseCliArgs } from './cli-args.mjs';
+
+const DEFAULT_CANONICAL_PHASE_IDS = [
+  'A0',
+  'A0_O',
+  'A0_T',
+  'A1',
+  'A1_5',
+  'A2',
+  'A3',
+  'A3_5',
+  'A4',
+  'A4_5',
+  'A5',
+  'B1',
+  'B2',
+  'B3',
+  'C1',
+  'C2',
+  'C3',
+  'C4',
+  'C5',
+  'C6',
+  'D1',
+  'D2',
+  'D3',
+  'D4',
+  'E1',
+  'E2',
+  'E3',
+  'E4',
+  'E5',
+  'E6',
+  'E7',
+  'E8',
+  'E9',
+  'E10',
+  'E11',
+  'E12',
+  'E13',
+  'E14',
+  'E15',
+  'Esync',
+  'F1',
+  'F2',
+  'F2_5',
+  'F3',
+  'F4',
+  'F5',
+  'Resume',
+];
+const DEFAULT_LEGACY_ALIASES = {
+  A0_O: ['A0-O', 'A0O'],
+  A0_T: ['A0-T', 'A0T'],
+  A1_5: ['A1.5', 'A1-5', 'A15'],
+  A3_5: ['A3.5', 'A3-5', 'A35'],
+  A4_5: ['A4.5', 'A4-5', 'A45'],
+  F2_5: ['F2.5', 'F2-5', 'F25'],
+};
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `phase-id:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --phase-id spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const PHASE_ID_RESOLVER_FLAG_SPEC = {
+  '--phase-id': { type: 'string' },
+  '--verbose': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+export function resolvePhaseId(input, options = {}) {
+  const resolver = createPhaseIdResolver(options);
+  return resolver.resolve(input);
+}
+export function createPhaseIdResolver({
+  canonicalPhaseIds = DEFAULT_CANONICAL_PHASE_IDS,
+  legacyAliases = DEFAULT_LEGACY_ALIASES,
+} = {}) {
+  const canonicalByKey = new Map();
+  const aliasHits = new Map();
+  const canonicalOrder = [];
+  const legacyAliasMap = {};
+  for (const candidate of canonicalPhaseIds) {
+    const normalized = normalizePhaseIdToken(candidate, { allowEmpty: false });
+    if (!isCanonicalToken(normalized)) {
+      throw buildResolverError(
+        'invalid_canonical_phase_id',
+        `Canonical phase ID must be alphanumeric with underscores: ${candidate}`,
+      );
+    }
+    if (canonicalByKey.has(normalized)) {
+      continue;
+    }
+    // Store the configured spelling as the canonical value and order (only
+    // the normalized form is the lookup key), so a mixed-case canonical ID
+    // such as `Resume` is emitted as `Resume`, not `RESUME`.
+    const spelling = String(candidate).trim();
+    canonicalByKey.set(normalized, spelling);
+    canonicalOrder.push(spelling);
+  }
+  for (const [canonical, aliases] of Object.entries(legacyAliases ?? {})) {
+    const normalizedCanonical = normalizePhaseIdToken(canonical, {
+      allowEmpty: false,
+    });
+    if (!canonicalByKey.has(normalizedCanonical)) {
+      throw buildResolverError(
+        'unknown_canonical_phase_id',
+        `Legacy aliases reference unknown canonical phase ID: ${canonical}`,
+      );
+    }
+    const list = Array.isArray(aliases) ? aliases : [aliases];
+    for (const alias of list) {
+      const normalizedAlias = normalizeAliasToken(alias);
+      if (normalizedAlias === normalizedCanonical) {
+        continue;
+      }
+      const owners = aliasHits.get(normalizedAlias) ?? new Set();
+      owners.add(normalizedCanonical);
+      aliasHits.set(normalizedAlias, owners);
+      if (!legacyAliasMap[normalizedCanonical]) {
+        legacyAliasMap[normalizedCanonical] = [];
+      }
+      if (!legacyAliasMap[normalizedCanonical].includes(normalizedAlias)) {
+        legacyAliasMap[normalizedCanonical].push(normalizedAlias);
+      }
+    }
+  }
+  const ambiguousAliases = [...aliasHits.entries()]
+    .filter(([, owners]) => owners.size > 1)
+    .map(([alias, owners]) => ({
+      alias,
+      canonicalPhaseIds: [...owners].sort(),
+    }));
+  if (ambiguousAliases.length > 0) {
+    throw buildResolverError(
+      'ambiguous_alias_configuration',
+      `Legacy alias map contains ambiguous entries: ${ambiguousAliases
+        .map((entry) => `${entry.alias}=>${entry.canonicalPhaseIds.join('|')}`)
+        .join(', ')}`,
+      { ambiguousAliases },
+    );
+  }
+  const aliasToCanonical = new Map(
+    [...aliasHits.entries()].map(([alias, owners]) => [alias, [...owners][0]]),
+  );
+  return {
+    canonicalPhaseIds: canonicalOrder,
+    legacyAliasMap,
+    resolve(rawInput) {
+      const aliasInputKey = normalizeAliasToken(rawInput);
+      const normalizedInput = normalizePhaseIdToken(rawInput, {
+        allowEmpty: false,
+      });
+      if (!isSupportedInputToken(String(rawInput ?? ''))) {
+        throw buildResolverError(
+          'invalid_phase_id',
+          `Phase ID contains unsupported characters: ${String(rawInput)}`,
+        );
+      }
+      if (
+        isCanonicalToken(aliasInputKey) &&
+        canonicalByKey.has(aliasInputKey)
+      ) {
+        return {
+          canonicalPhaseId: canonicalByKey.get(aliasInputKey),
+          matchedBy: 'canonical',
+          normalizedInput,
+        };
+      }
+      const aliasCanonical = aliasToCanonical.get(aliasInputKey);
+      if (aliasCanonical) {
+        return {
+          canonicalPhaseId:
+            canonicalByKey.get(aliasCanonical) ?? aliasCanonical,
+          matchedBy: 'legacy-alias',
+          normalizedInput,
+        };
+      }
+      // Separator-normalized fallback: `A4---5`, `A4/5`, and `A4 5` all
+      // normalize to `A4_5` via normalizePhaseIdToken, but normalizeAliasToken
+      // keeps the raw separators so the lookups above miss them. Resolve such
+      // inputs against the canonical map by their fully-normalized form.
+      if (
+        isCanonicalToken(normalizedInput) &&
+        canonicalByKey.has(normalizedInput)
+      ) {
+        return {
+          canonicalPhaseId: canonicalByKey.get(normalizedInput),
+          matchedBy: 'canonical',
+          normalizedInput,
+        };
+      }
+      throw buildResolverError(
+        'unknown_phase_id',
+        `Unknown phase ID: ${String(rawInput)} (normalized: ${normalizedInput})`,
+        { normalizedInput },
+      );
+    },
+  };
+}
+export function normalizePhaseIdToken(input, { allowEmpty = true } = {}) {
+  const source = String(input ?? '');
+  const normalized = source
+    .trim()
+    .toUpperCase()
+    .replace(/[.\-/:\\\s]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!allowEmpty && normalized.length === 0) {
+    throw buildResolverError('invalid_phase_id', 'Phase ID must not be empty.');
+  }
+  return normalized;
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.phaseId) {
+    throw new Error('--phase-id is required');
+  }
+  const resolver = createPhaseIdResolver();
+  const result = resolver.resolve(args.phaseId);
+  const output = {
+    input: args.phaseId,
+    normalizedInput: result.normalizedInput,
+    canonicalPhaseId: result.canonicalPhaseId,
+    matchedBy: result.matchedBy,
+    canonicalPhaseIds: args.verbose ? resolver.canonicalPhaseIds : undefined,
+    legacyAliasMap: args.verbose ? resolver.legacyAliasMap : undefined,
+  };
+  process.stdout.write(`${JSON.stringify(compactObject(output), null, 2)}\n`);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, PHASE_ID_RESOLVER_FLAG_SPEC);
+  return {
+    // Defaulting to '' (not left undefined) matches the pre-migration
+    // shape exactly: an omitted --phase-id and an explicit --phase-id ''
+    // both read back as '', and runCli's existing `!args.phaseId` check
+    // already treats both the same way (required-but-missing).
+    phaseId: values['phase-id'] ?? '',
+    verbose: values.verbose,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/phase-id-resolver.mjs --phase-id <value> [--verbose]',
+      '',
+      'Resolve an IDD phase identifier to its canonical machine-facing ID.',
+      'Legacy aliases (e.g. A4.5, A4-5) are normalized to canonical IDs (e.g. A4_5).',
+    ].join('\n'),
+  );
+  process.stdout.write('\n');
+}
+function isCanonicalToken(token) {
+  return /^[A-Z0-9]+(?:_[A-Z0-9]+)*$/.test(token);
+}
+function isSupportedInputToken(rawInput) {
+  return /^[A-Za-z0-9.\-/:\\_\s]+$/.test(rawInput.trim());
+}
+function normalizeAliasToken(input) {
+  return String(input ?? '')
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, ' ');
+}
+function buildResolverError(code, message, details = {}) {
+  const error = new Error(message);
+  error.code = code;
+  error.details = details;
+  return error;
+}
+function compactObject(value) {
+  const output = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) {
+      output[key] = entry;
+    }
+  }
+  return output;
+}

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -1,0 +1,740 @@
+// idd-generated-from: src/scripts/policy-helpers.mts
+//
+// The scripts/policy-helpers.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+const HELPER_RUNTIME_PROFILES = new Set([
+  'package-manager',
+  'vendored-node',
+  'ephemeral-npx',
+  'instructions-only',
+]);
+const HELPER_RUNTIME_KEYS = new Set(['profile', 'packageSpec']);
+const ISSUE_SCOPES = new Set(['roadmap', 'roadmap-first', 'orphan-first']);
+const ORPHAN_FIRST_POLICIES = new Set([
+  'none',
+  'maintainer-approved',
+  'public-disabled',
+]);
+const APPROVAL_ACTOR_POLICIES = new Set([
+  'owners-and-maintainers-only',
+  'all-write-permission-actors',
+]);
+const FORCED_HANDOFF_MODES = new Set(['disabled', 'human-gated']);
+const ADVISORY_CAP_ROUTES = new Set(['phase-specific', 'hold']);
+const ADVISORY_CONVERGENCE_SCOPES = new Set(['all-prs', 'idd-claimed']);
+const SELECTION_DESYNC_MODES = new Set(['off', 'session-offset']);
+const EXTERNAL_CHECK_WAIVER_MODES = new Set([
+  'disabled',
+  'maintainer-authorized',
+]);
+const CHECK_SELECTOR_MATCH_MODES = new Set(['exact', 'glob']);
+const LEGACY_ADVISORY_CAP_ROUTE_ALIASES = new Map([
+  ['phase-default', 'phase-specific'],
+  ['strict-hold', 'hold'],
+]);
+// Matches the schema enum and ci-wait-policy.mts's own RERUN_POLICIES set
+// (both accept `hold`); this set previously omitted it, silently
+// downgrading a configured `hold` to `rerun-once` for any future consumer
+// of normalizePolicyConfig(...).ciWait (see #1359).
+const CI_RERUN_POLICIES = new Set(['rerun-once', 'hold']);
+const LABEL_FRESHNESS_MODES = new Set(['presence-only', 'event-freshness']);
+// #1521: `auto-admin-retry` is the distributed default (F3 retries once with
+// `--admin` when the Gate checklist is fully green, the only merge-command
+// failure is the self-CODEOWNER "base branch policy prohibits the merge"
+// error, and the topology fact proves the PR author is the sole eligible
+// codeowner). `hold-and-report` opts a repository into the pre-#1521
+// unconditional hold-and-report behavior instead.
+const MERGE_GATE_SOLO_CODEOWNER_ADMIN_FALLBACK_MODES = new Set([
+  'auto-admin-retry',
+  'hold-and-report',
+]);
+const ISO_DURATION_RE =
+  /^P(?=\d|T\d)(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/;
+const ADVISORY_WHOLE_MINUTE_DURATION_RE =
+  /^P(?=(?:\d+D|T\d+[HM]))(?=.*(?:[1-9]\d*[DHM]))(?:\d+D)?(?:T(?=\d+[HM])(?:\d+H)?(?:\d+M)?)?$/;
+const DURATION_RE =
+  /^P(?:(?<days>\d+)D)?(?:T(?:(?<hours>\d+)H)?(?:(?<minutes>\d+)M)?(?:(?<seconds>\d+)S)?)?$/;
+// Mirrors schemas/policy.schema.json's helperRuntime.packageSpec pattern: a
+// non-empty, shell-safe character allowlist (letters, digits, and
+// `@:/_.+^#%-`), not merely "no whitespace" (idd-skill#1803 review). The
+// value is embedded raw and unquoted into copy-pasteable shell command
+// text (`npx --package <spec> ...`, `<manager> add <spec>`) -- a bare
+// whitespace check still lets shell metacharacters (`;`, `&`, `|`, `$`,
+// backticks, quotes, parens) through, which can corrupt or inject into
+// that command when an operator copies it. The allowlist covers realistic
+// npm specs (`@scope/name@version`, `github:owner/repo#ref`), HTTPS/git+
+// URLs, and tarball paths while excluding every shell metacharacter in
+// that list.
+const PACKAGE_SPEC_RE = /^[A-Za-z0-9@:/_.+^#%-]+$/;
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+export const POLICY_DEFAULTS = Object.freeze({
+  issueScope: 'roadmap-first',
+  orphanFirstPolicy: 'none',
+  skipIssueAuthorApprovalGate: false,
+  maintainerApprovalActorPolicy: 'owners-and-maintainers-only',
+  stallRecovery: Object.freeze({
+    quietWindow: 'PT30M',
+  }),
+  // The write-gate claim-staleness window (#1310). isStaleAt's hardcoded 24h
+  // literal remains the fallback baked into protocol-helpers.mts; this is the
+  // one canonical config parse point every write-gate caller should read
+  // instead of hand-rolling `config?.claimTiming?.staleAge` access.
+  claimTiming: Object.freeze({
+    staleAge: 'PT24H',
+  }),
+  forcedHandoff: Object.freeze({
+    mode: 'disabled',
+    authorityPolicy: 'owners-and-maintainers-only',
+  }),
+  markerTrust: Object.freeze({
+    allowCollaboratorMarkers: false,
+  }),
+  advisoryWait: Object.freeze({
+    requestCap: 30,
+    pendingWindow: 'PT30M',
+    settledWindow: 'PT10M',
+    pollInterval: 'PT2M',
+    capExhaustedRoute: 'phase-specific',
+    convergenceScope: 'all-prs',
+    // #1906: opt-in, off by default -- no behavior change for a
+    // repository that does not explicitly set this to `true`.
+    exemptBotAuthoredPrs: false,
+  }),
+  ciWait: Object.freeze({
+    runningTimeout: 'PT30M',
+    generationTimeout: 'PT10M',
+    rerunPolicy: 'rerun-once',
+  }),
+  ciGate: Object.freeze({
+    externalChecks: Object.freeze({
+      advisory: Object.freeze([]),
+      waivable: Object.freeze([]),
+    }),
+    externalCheckWaivers: Object.freeze({
+      mode: 'disabled',
+      authorityPolicy: 'owners-and-maintainers-only',
+      maxValidity: 'PT24H',
+    }),
+    // #1377: default false fails closed on a masked-403-as-404 branch-
+    // protection/ruleset read instead of trusting it as genuinely empty.
+    trustEmptyProtectionReads: false,
+    // #1689: default false fails closed on a required check whose ruleset
+    // entry carries an `app_id`/`integration_id` (source-pinned) -- this
+    // repository has no way to verify the live check-run instance actually
+    // came from that pinned integration (see the option's own doc comment
+    // on `summarizeRequiredChecks` in protocol-helpers.mts), so a pinned
+    // check's green state stays untrusted by default rather than silently
+    // treated as passing.
+    trustSourcePinnedRequiredChecks: false,
+  }),
+  discover: Object.freeze({
+    activeClaimPreScanBatchSize: 10,
+    selectionDesync: 'off',
+    legacyRoots: Object.freeze([]),
+  }),
+  claim: Object.freeze({
+    verifySettleDelay: 'PT5S',
+  }),
+  critiqueLoop: Object.freeze({
+    cPhaseLowSeveritySkipAfter: 3,
+    e10NoProgressHoldAfter: 3,
+  }),
+  reviewEscalation: Object.freeze({
+    changesRequestedFirstEscalation: 'PT24H',
+    changesRequestedSecondEscalation: 'PT48H',
+  }),
+  approvalSignals: Object.freeze({
+    readyLabelName: 'idd:ready',
+    labelFreshnessMode: 'presence-only',
+  }),
+  issueAuthoring: Object.freeze({
+    maxClarificationRounds: 3,
+    authoringLabelName: 'status:authoring',
+    authoringStaleAge: 'PT4H',
+  }),
+  // Added in #1272; the discover-roadmap-graph, discover-orphan-filter,
+  // discover-readiness-check, idd-roadmap-audit-execute,
+  // suitability-triage, and idd-doctor label lookups were wired to this
+  // namespace in #1273.
+  labels: Object.freeze({
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
+  }),
+  // Added in #1521 (solo-CODEOWNER autonomous `--admin` merge fallback).
+  mergeGate: Object.freeze({
+    soloCodeownerAdminFallback: 'auto-admin-retry',
+  }),
+});
+export function parseProjectCommandRows(text) {
+  const commands = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^\|\s*\*\*([^*]+)\*\*\s*\|\s*`([^`]+)`\s*\|/.exec(line);
+    if (!match) {
+      continue;
+    }
+    commands.set(match[1].trim(), match[2].trim());
+  }
+  return commands;
+}
+export function inspectHelperRuntimeConfig(config) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'invalid', reason: 'config must be a non-null object' };
+  }
+  if (!hasOwn(config, 'helperRuntime')) {
+    return { status: 'absent' };
+  }
+  const helperRuntime = config.helperRuntime;
+  if (
+    typeof helperRuntime !== 'object' ||
+    helperRuntime === null ||
+    Array.isArray(helperRuntime)
+  ) {
+    return {
+      status: 'invalid',
+      reason: 'helperRuntime must be an object when present',
+    };
+  }
+  const unexpectedKeys = Object.keys(helperRuntime).filter(
+    (key) => !HELPER_RUNTIME_KEYS.has(key),
+  );
+  if (unexpectedKeys.length > 0) {
+    return {
+      status: 'invalid',
+      reason: `unsupported helperRuntime keys: ${unexpectedKeys.join(', ')}`,
+    };
+  }
+  const profile = helperRuntime.profile;
+  if (typeof profile !== 'string' || profile.length === 0) {
+    return {
+      status: 'invalid',
+      reason: 'helperRuntime.profile must be a non-empty string',
+    };
+  }
+  if (!HELPER_RUNTIME_PROFILES.has(profile)) {
+    return {
+      status: 'invalid',
+      reason: `unsupported helperRuntime.profile "${profile}"`,
+    };
+  }
+  // Optional: absent by default (existing behavior, existing profile-only
+  // callers/tests are unaffected). When present, it must be a non-empty
+  // string in the shell-safe character allowlist -- mirrors
+  // schemas/policy.schema.json's pattern so the JSON Schema validator and
+  // this runtime guard never disagree.
+  if (hasOwn(helperRuntime, 'packageSpec')) {
+    const packageSpec = helperRuntime.packageSpec;
+    if (typeof packageSpec !== 'string' || !PACKAGE_SPEC_RE.test(packageSpec)) {
+      return {
+        status: 'invalid',
+        reason:
+          'helperRuntime.packageSpec must be a non-empty string using only shell-safe characters (letters, digits, and @:/_.+^#%-)',
+      };
+    }
+    return { status: 'ok', profile, packageSpec };
+  }
+  return { status: 'ok', profile };
+}
+export function normalizePolicyConfig(config) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return clone(POLICY_DEFAULTS);
+  }
+  const c = config;
+  const forcedHandoffAuthorityAlias = firstAcceptedString(
+    APPROVAL_ACTOR_POLICIES,
+    c?.forcedHandoff?.authorityPolicy,
+    c?.['forced-handoff']?.authorityPolicy,
+    c?.forcedHandoffAuthority,
+    c?.['forced-handoff-authority'],
+  );
+  const forcedHandoffModeAlias = firstAcceptedString(
+    FORCED_HANDOFF_MODES,
+    c?.forcedHandoff?.mode,
+    c?.['forced-handoff']?.mode,
+    c?.forcedHandoffMode,
+    c?.['forced-handoff-mode'],
+  );
+  const markerTrustAlias = firstBoolean(
+    c?.markerTrust?.allowCollaboratorMarkers,
+    c?.markerTrustAllowCollaboratorMarkers,
+    c?.allowCollaboratorMarkers,
+  );
+  return {
+    issueScope: parseEnum(
+      c?.issueScope,
+      ISSUE_SCOPES,
+      POLICY_DEFAULTS.issueScope,
+    ),
+    orphanFirstPolicy: parseEnum(
+      c?.orphanFirstPolicy,
+      ORPHAN_FIRST_POLICIES,
+      POLICY_DEFAULTS.orphanFirstPolicy,
+    ),
+    skipIssueAuthorApprovalGate: c?.skipIssueAuthorApprovalGate === true,
+    maintainerApprovalActorPolicy: parseEnum(
+      c?.maintainerApprovalActorPolicy,
+      APPROVAL_ACTOR_POLICIES,
+      POLICY_DEFAULTS.maintainerApprovalActorPolicy,
+    ),
+    stallRecovery: {
+      quietWindow: parseDuration(
+        c?.stallRecovery?.quietWindow,
+        POLICY_DEFAULTS.stallRecovery.quietWindow,
+      ),
+    },
+    claimTiming: {
+      staleAge: parsePositiveDuration(
+        c?.claimTiming?.staleAge,
+        POLICY_DEFAULTS.claimTiming.staleAge,
+      ),
+    },
+    forcedHandoff: {
+      mode: parseEnum(
+        forcedHandoffModeAlias,
+        FORCED_HANDOFF_MODES,
+        POLICY_DEFAULTS.forcedHandoff.mode,
+      ),
+      authorityPolicy: parseEnum(
+        forcedHandoffAuthorityAlias,
+        APPROVAL_ACTOR_POLICIES,
+        POLICY_DEFAULTS.forcedHandoff.authorityPolicy,
+      ),
+    },
+    markerTrust: {
+      allowCollaboratorMarkers:
+        markerTrustAlias ??
+        POLICY_DEFAULTS.markerTrust.allowCollaboratorMarkers,
+    },
+    advisoryWait: {
+      requestCap: parsePositiveInteger(
+        c?.advisoryWait?.requestCap,
+        POLICY_DEFAULTS.advisoryWait.requestCap,
+      ),
+      pendingWindow: parseAdvisoryWholeMinuteDuration(
+        c?.advisoryWait?.pendingWindow,
+        POLICY_DEFAULTS.advisoryWait.pendingWindow,
+      ),
+      settledWindow: parseAdvisoryWholeMinuteDuration(
+        c?.advisoryWait?.settledWindow,
+        POLICY_DEFAULTS.advisoryWait.settledWindow,
+      ),
+      pollInterval: parseAdvisoryWholeMinuteDuration(
+        c?.advisoryWait?.pollInterval,
+        POLICY_DEFAULTS.advisoryWait.pollInterval,
+      ),
+      capExhaustedRoute: parseAdvisoryCapRoute(
+        c?.advisoryWait?.capExhaustedRoute,
+        POLICY_DEFAULTS.advisoryWait.capExhaustedRoute,
+      ),
+      convergenceScope: parseEnum(
+        c?.advisoryWait?.convergenceScope,
+        ADVISORY_CONVERGENCE_SCOPES,
+        POLICY_DEFAULTS.advisoryWait.convergenceScope,
+      ),
+      // #1906: same simple-boolean coercion style as
+      // `skipIssueAuthorApprovalGate` above -- only a literal `true`
+      // opts in, everything else (including a malformed value) keeps
+      // the conservative `false` default.
+      exemptBotAuthoredPrs: c?.advisoryWait?.exemptBotAuthoredPrs === true,
+    },
+    ciWait: {
+      runningTimeout: parseDuration(
+        c?.ciWait?.runningTimeout,
+        POLICY_DEFAULTS.ciWait.runningTimeout,
+      ),
+      generationTimeout: parseDuration(
+        c?.ciWait?.generationTimeout,
+        POLICY_DEFAULTS.ciWait.generationTimeout,
+      ),
+      rerunPolicy: parseEnum(
+        c?.ciWait?.rerunPolicy,
+        CI_RERUN_POLICIES,
+        POLICY_DEFAULTS.ciWait.rerunPolicy,
+      ),
+    },
+    ciGate: {
+      externalChecks: {
+        advisory: parseCheckSelectors(
+          c?.ciGate?.externalChecks?.advisory,
+          POLICY_DEFAULTS.ciGate.externalChecks.advisory,
+        ),
+        waivable: parseCheckSelectors(
+          c?.ciGate?.externalChecks?.waivable,
+          POLICY_DEFAULTS.ciGate.externalChecks.waivable,
+        ),
+      },
+      externalCheckWaivers: {
+        mode: parseEnum(
+          c?.ciGate?.externalCheckWaivers?.mode,
+          EXTERNAL_CHECK_WAIVER_MODES,
+          POLICY_DEFAULTS.ciGate.externalCheckWaivers.mode,
+        ),
+        authorityPolicy: parseEnum(
+          c?.ciGate?.externalCheckWaivers?.authorityPolicy,
+          APPROVAL_ACTOR_POLICIES,
+          POLICY_DEFAULTS.ciGate.externalCheckWaivers.authorityPolicy,
+        ),
+        maxValidity: parsePositiveDuration(
+          c?.ciGate?.externalCheckWaivers?.maxValidity,
+          POLICY_DEFAULTS.ciGate.externalCheckWaivers.maxValidity,
+        ),
+      },
+      trustEmptyProtectionReads: c?.ciGate?.trustEmptyProtectionReads === true,
+      trustSourcePinnedRequiredChecks:
+        c?.ciGate?.trustSourcePinnedRequiredChecks === true,
+    },
+    discover: {
+      activeClaimPreScanBatchSize: parsePositiveInteger(
+        c?.discover?.activeClaimPreScanBatchSize,
+        POLICY_DEFAULTS.discover.activeClaimPreScanBatchSize,
+      ),
+      selectionDesync: parseEnum(
+        c?.discover?.selectionDesync,
+        SELECTION_DESYNC_MODES,
+        POLICY_DEFAULTS.discover.selectionDesync,
+      ),
+      legacyRoots: parsePositiveIntegerArray(
+        c?.discover?.legacyRoots,
+        POLICY_DEFAULTS.discover.legacyRoots,
+      ),
+    },
+    claim: {
+      verifySettleDelay: parseDuration(
+        c?.claim?.verifySettleDelay,
+        POLICY_DEFAULTS.claim.verifySettleDelay,
+      ),
+    },
+    critiqueLoop: {
+      cPhaseLowSeveritySkipAfter: parsePositiveInteger(
+        c?.critiqueLoop?.cPhaseLowSeveritySkipAfter,
+        POLICY_DEFAULTS.critiqueLoop.cPhaseLowSeveritySkipAfter,
+      ),
+      e10NoProgressHoldAfter: parsePositiveInteger(
+        c?.critiqueLoop?.e10NoProgressHoldAfter,
+        POLICY_DEFAULTS.critiqueLoop.e10NoProgressHoldAfter,
+      ),
+    },
+    reviewEscalation: {
+      changesRequestedFirstEscalation: parseDuration(
+        c?.reviewEscalation?.changesRequestedFirstEscalation,
+        POLICY_DEFAULTS.reviewEscalation.changesRequestedFirstEscalation,
+      ),
+      changesRequestedSecondEscalation: parseDuration(
+        c?.reviewEscalation?.changesRequestedSecondEscalation,
+        POLICY_DEFAULTS.reviewEscalation.changesRequestedSecondEscalation,
+      ),
+    },
+    approvalSignals: {
+      readyLabelName: parseNonEmptyString(
+        c?.approvalSignals?.readyLabelName,
+        POLICY_DEFAULTS.approvalSignals.readyLabelName,
+      ),
+      labelFreshnessMode: parseEnum(
+        c?.approvalSignals?.labelFreshnessMode,
+        LABEL_FRESHNESS_MODES,
+        POLICY_DEFAULTS.approvalSignals.labelFreshnessMode,
+      ),
+    },
+    issueAuthoring: {
+      maxClarificationRounds: parsePositiveInteger(
+        c?.issueAuthoring?.maxClarificationRounds,
+        POLICY_DEFAULTS.issueAuthoring.maxClarificationRounds,
+      ),
+      authoringLabelName: parseNonEmptyString(
+        c?.issueAuthoring?.authoringLabelName,
+        POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
+      ),
+      authoringStaleAge: parseDuration(
+        c?.issueAuthoring?.authoringStaleAge,
+        POLICY_DEFAULTS.issueAuthoring.authoringStaleAge,
+      ),
+    },
+    // Added in #1272 for shape parity with the clone(POLICY_DEFAULTS)
+    // early-return branch above (non-object input); wired to the
+    // consuming helpers' label lookups in #1273 (see the POLICY_DEFAULTS
+    // comment above for the exact file list).
+    labels: {
+      roadmapLabelName: parseNonEmptyString(
+        c?.labels?.roadmapLabelName,
+        POLICY_DEFAULTS.labels.roadmapLabelName,
+      ),
+      blockedByHumanLabelName: parseNonEmptyString(
+        c?.labels?.blockedByHumanLabelName,
+        POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      ),
+      needsDecisionLabelName: parseNonEmptyString(
+        c?.labels?.needsDecisionLabelName,
+        POLICY_DEFAULTS.labels.needsDecisionLabelName,
+      ),
+    },
+    mergeGate: {
+      soloCodeownerAdminFallback: parseEnum(
+        c?.mergeGate?.soloCodeownerAdminFallback,
+        MERGE_GATE_SOLO_CODEOWNER_ADMIN_FALLBACK_MODES,
+        POLICY_DEFAULTS.mergeGate.soloCodeownerAdminFallback,
+      ),
+    },
+  };
+}
+export function resolveCollaboratorMarkerTrust(config, envValue = '') {
+  if (hasConfiguredCollaboratorMarkerTrust(config)) {
+    return normalizePolicyConfig(config).markerTrust.allowCollaboratorMarkers;
+  }
+  return isTruthy(envValue);
+}
+export function parseIsoDurationToMs(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const match = DURATION_RE.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  const days = Number.parseInt(match.groups?.days ?? '0', 10);
+  const hours = Number.parseInt(match.groups?.hours ?? '0', 10);
+  const minutes = Number.parseInt(match.groups?.minutes ?? '0', 10);
+  const seconds = Number.parseInt(match.groups?.seconds ?? '0', 10);
+  const totalMs =
+    days * DAY_MS + hours * HOUR_MS + minutes * MINUTE_MS + seconds * SECOND_MS;
+  return totalMs > 0 ? totalMs : null;
+}
+export function getReviewEscalationChangesRequestedPolicy(config = {}) {
+  const normalized = normalizePolicyConfig(config);
+  const firstEscalationMs = parseIsoDurationToMs(
+    normalized.reviewEscalation.changesRequestedFirstEscalation,
+  );
+  const secondEscalationMs = parseIsoDurationToMs(
+    normalized.reviewEscalation.changesRequestedSecondEscalation,
+  );
+  const defaultFirstEscalationMs =
+    parseIsoDurationToMs(
+      POLICY_DEFAULTS.reviewEscalation.changesRequestedFirstEscalation,
+    ) ?? 0;
+  const defaultSecondEscalationMs =
+    parseIsoDurationToMs(
+      POLICY_DEFAULTS.reviewEscalation.changesRequestedSecondEscalation,
+    ) ?? 0;
+  const resolvedFirstEscalationMs = isFiniteNumber(firstEscalationMs)
+    ? firstEscalationMs
+    : defaultFirstEscalationMs;
+  const resolvedSecondEscalationMs = isFiniteNumber(secondEscalationMs)
+    ? secondEscalationMs
+    : defaultSecondEscalationMs;
+  const defaultPostEscalationMs =
+    defaultSecondEscalationMs - defaultFirstEscalationMs;
+  const resolvedPostEscalationMs =
+    resolvedSecondEscalationMs > resolvedFirstEscalationMs
+      ? resolvedSecondEscalationMs - resolvedFirstEscalationMs
+      : defaultPostEscalationMs;
+  return {
+    escalateAfterMs: resolvedFirstEscalationMs,
+    releaseAfterEscalationMs: resolvedPostEscalationMs,
+  };
+}
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+/**
+ * Deterministically pick an index within a same-score tie band for the
+ * Discover A4 Step 2 selection desync (`discover.selectionDesync:
+ * session-offset`). Pure and network-free: the same session token always
+ * maps to the same index, while distinct tokens spread across the band, so
+ * concurrent autopilot sessions stop colliding on the lowest-numbered
+ * candidate. Returns `0` — the lowest-numbered, i.e. the default
+ * deterministic pick — for an empty/singleton band or a non-string/empty
+ * token, so `off`, no-tie, and no-token behavior is unchanged.
+ *
+ * The band is the caller's ascending-issue-number ordering; this only
+ * chooses an offset within it and never reorders across score bands or
+ * affects branch naming.
+ */
+export function selectDesyncedIndex(token, bandSize) {
+  const size =
+    typeof bandSize === 'number' && Number.isInteger(bandSize) && bandSize > 0
+      ? bandSize
+      : 0;
+  if (size <= 1) {
+    return 0;
+  }
+  if (typeof token !== 'string' || token.length === 0) {
+    return 0;
+  }
+  // FNV-1a 32-bit hash — deterministic, dependency-free, well-spread.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < token.length; i += 1) {
+    hash ^= token.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) % size;
+}
+/**
+ * Deep-clone helper for this module's own trusted defaults (#1449).
+ *
+ * Exported only so its equivalence can be unit-tested directly; every
+ * production call site stays inside this file. `structuredClone` (global
+ * since Node 17, well below this repo's `^22.22.2 || >=24` floor) replaces
+ * the previous `JSON.parse(JSON.stringify(value))` round-trip.
+ * `structuredClone` differs from a JSON round-trip on several axes —
+ * non-exhaustively: it throws on functions; it preserves `Date`, `Map`,
+ * and `undefined`-valued keys that JSON drops or converts; and it also
+ * diverges on `BigInt`, `RegExp`, typed arrays, and `NaN`/`Infinity`/`-0`
+ * normalization. This list is deliberately not treated as exhaustive —
+ * what matters for this swap is not enumerating every divergence axis,
+ * but that `POLICY_DEFAULTS` (below) never contains a value on *any* of
+ * them. All 8 call sites in this file were enumerated before making this
+ * swap: `normalizePolicyConfig`'s `clone(POLICY_DEFAULTS)`, plus 7 calls
+ * across `parsePositiveIntegerArray` and `parseCheckSelectors`, which
+ * only ever clone `POLICY_DEFAULTS` itself or one of its own frozen
+ * sub-arrays (`discover.legacyRoots`, `ciGate.externalChecks.advisory`,
+ * `.waivable` — all `[]`). `POLICY_DEFAULTS` is a plain, deeply-frozen
+ * literal of strings, finite numbers, booleans, and empty arrays only —
+ * no function, `Date`, `Map`, `BigInt`, `RegExp`, typed array, exotic
+ * number, or `undefined`-valued property appears anywhere in it, so none
+ * of `structuredClone`'s divergences from a JSON round-trip is ever
+ * exercised by a real caller (Copilot review, #1463).
+ */
+export function clone(value) {
+  return structuredClone(value);
+}
+function _firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return '';
+}
+function firstAcceptedString(accepted, ...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && accepted.has(value)) {
+      return value;
+    }
+  }
+  return '';
+}
+function firstBoolean(...values) {
+  for (const value of values) {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+  }
+  return null;
+}
+function parseEnum(value, accepted, fallback) {
+  if (typeof value === 'string' && accepted.has(value)) {
+    return value;
+  }
+  return fallback;
+}
+function parseDuration(value, fallback) {
+  if (typeof value === 'string' && ISO_DURATION_RE.test(value)) {
+    return value;
+  }
+  return fallback;
+}
+function parseAdvisoryWholeMinuteDuration(value, fallback) {
+  if (
+    typeof value === 'string' &&
+    ADVISORY_WHOLE_MINUTE_DURATION_RE.test(value)
+  ) {
+    return value;
+  }
+  return fallback;
+}
+function parseAdvisoryCapRoute(value, fallback) {
+  if (typeof value === 'string') {
+    if (ADVISORY_CAP_ROUTES.has(value)) {
+      return value;
+    }
+    return LEGACY_ADVISORY_CAP_ROUTE_ALIASES.get(value) ?? fallback;
+  }
+  return fallback;
+}
+function parsePositiveDuration(value, fallback) {
+  return typeof value === 'string' &&
+    ISO_DURATION_RE.test(value) &&
+    parseIsoDurationToMs(value) !== null
+    ? value
+    : fallback;
+}
+function parsePositiveInteger(value, fallback) {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1
+    ? value
+    : fallback;
+}
+/**
+ * Parse a config array of positive integers (e.g. issue numbers), such as
+ * `discover.legacyRoots`. Mirrors `parseCheckSelectors`'s fail-closed shape:
+ * a non-array, empty array, or any entry that is not a positive integer
+ * falls back to `fallback` as a whole rather than dropping just the bad
+ * entries, so a typo'd issue number cannot silently vanish from the set.
+ */
+function parsePositiveIntegerArray(value, fallback) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return clone(fallback);
+  }
+  const normalized = [];
+  for (const entry of value) {
+    if (typeof entry !== 'number' || !Number.isInteger(entry) || entry < 1) {
+      return clone(fallback);
+    }
+    normalized.push(entry);
+  }
+  return normalized;
+}
+function parseNonEmptyString(value, fallback) {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+function parseCheckSelectors(value, fallback) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return clone(fallback);
+  }
+  const entries = value;
+  const normalized = [];
+  for (const entry of entries) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return clone(fallback);
+    }
+    const candidate = entry;
+    const entryKeys = Object.keys(candidate);
+    if (entryKeys.some((key) => key !== 'selector' && key !== 'matchMode')) {
+      return clone(fallback);
+    }
+    const selector = parseNonEmptyString(candidate.selector, '');
+    if (!selector) {
+      return clone(fallback);
+    }
+    if (hasOwn(candidate, 'matchMode')) {
+      if (
+        typeof candidate.matchMode !== 'string' ||
+        !CHECK_SELECTOR_MATCH_MODES.has(candidate.matchMode)
+      ) {
+        return clone(fallback);
+      }
+    }
+    normalized.push({
+      selector,
+      matchMode:
+        typeof candidate.matchMode === 'string' ? candidate.matchMode : 'exact',
+    });
+  }
+  return normalized;
+}
+function hasConfiguredCollaboratorMarkerTrust(config) {
+  const c = config;
+  return (
+    typeof c?.markerTrust?.allowCollaboratorMarkers === 'boolean' ||
+    typeof c?.markerTrustAllowCollaboratorMarkers === 'boolean' ||
+    typeof c?.allowCollaboratorMarkers === 'boolean'
+  );
+}
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
+}
+function hasOwn(value, key) {
+  return Object.hasOwn(value ?? {}, key);
+}

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -1,0 +1,743 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/post-idd-marker.mts
+//
+// The scripts/post-idd-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Write-side companion to emit-marker (#1047). IDD operational markers are
+// HTML-comment-first, so an agent must POST them as a JSON body — the
+// `gh issue comment` / `gh api -f body=` paths silently reject HTML-only
+// bodies. This helper renders the canonical body for each operational marker
+// type (reusing the single-sourced protocol-helpers renderers so formats are
+// not duplicated) and POSTs it via the reliable JSON path.
+//
+// It is a single-marker render+POST primitive with NO claim/state gating, by
+// design (the emit-marker philosophy). The calling phase runs its
+// claim-revalidation gate immediately before invoking `--apply`, exactly as the
+// manual POST path it replaces already requires.
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { requireFlag } from './cli-args.mjs';
+import { ghText } from './gh-exec.mjs';
+import {
+  renderActivationNonceMarker,
+  renderAdvisoryRerollMarker,
+  renderAdvisoryWaitMarker,
+  renderAdvisoryWaitRecoveryMarker,
+  renderClaimedByMarker,
+  renderCopilotUnavailableMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+  renderUnclaimedByMarker,
+} from './protocol-helpers.mjs';
+export const MARKER_TYPES = [
+  'claim',
+  'unclaim',
+  'activation-nonce',
+  'watermark',
+  'baseline',
+  'advisory',
+  'advisory-recovery',
+  'advisory-reroll',
+  'copilot-unavailable',
+];
+/**
+ * The marker `type`s that accept `--from-pr <n>`. `watermark` derives all
+ * four snapshot fields via the full {@link runReviewActivitySnapshot}
+ * composition; the three advisory types (`advisory` / `advisory-recovery` /
+ * `advisory-reroll`, added in #1889) derive only `--head-sha` via the
+ * lighter {@link headShaFromPr} single `gh pr view` call, since those
+ * renderers accept no other snapshot-shaped field.
+ */
+export const FROM_PR_MARKER_TYPES = [
+  'watermark',
+  'advisory',
+  'advisory-recovery',
+  'advisory-reroll',
+];
+/**
+ * The kebab-case `--flag` field names each marker `type` requires, keyed
+ * the same way {@link buildMarkerBody}'s own switch reads `fields` --
+ * consulted by the `import.meta.main` CLI entry point below to report a
+ * missing required field BY NAME (via `requireFlag`, cli-args.mts) before
+ * `buildMarkerBody` is ever called, instead of surfacing that renderer's
+ * own aggregate "invalid ... marker payload" guard with no indication of
+ * which flag was absent (#1722). `supersedes` (claim), `max-activity-at` /
+ * `ci-completed-at` (watermark) are deliberately OMITTED: the underlying
+ * renderers default an absent or empty value to the `none` sentinel, so
+ * requiring them here would reject input the renderer itself accepts.
+ * `advisory-recovery`'s optional `claim-id` / `attempt` pair is also
+ * omitted for the same reason -- passing neither renders the legacy
+ * 3-field form; the renderer's own "must both be provided together"
+ * message already names that half-bound case precisely. This CLI-layer
+ * check stays defense-in-depth-complementary to, never a replacement for,
+ * `buildMarkerBody`'s own per-type validation -- a direct caller of
+ * `buildMarkerBody` (bypassing this CLI) still gets that renderer's
+ * aggregate guard.
+ */
+const REQUIRED_FIELDS_BY_TYPE = {
+  claim: ['agent-id', 'claim-id', 'timestamp', 'branch'],
+  unclaim: ['agent-id', 'claim-id', 'timestamp'],
+  'activation-nonce': ['agent-id', 'claim-id', 'nonce', 'timestamp'],
+  watermark: ['agent-id', 'claim-id', 'head-sha', 'total-item-count'],
+  baseline: ['agent-id', 'claim-id', 'sha'],
+  advisory: ['agent-id', 'head-sha', 'timestamp'],
+  'advisory-recovery': ['agent-id', 'head-sha', 'timestamp'],
+  'advisory-reroll': ['agent-id', 'head-sha', 'timestamp'],
+  'copilot-unavailable': [
+    'agent-id',
+    'claim-id',
+    'head-sha',
+    'attempt',
+    'timestamp',
+  ],
+};
+export const TARGET_KINDS = ['issue', 'pr'];
+/**
+ * Build the canonical ready-to-post body for one operational marker type.
+ * Pure and network-free: it dispatches to the single-sourced protocol-helpers
+ * renderer for `type`, so the body stays byte-identical to what emit-marker and
+ * the written marker formats produce. Throws on an unknown type or an invalid
+ * field set (the renderer's own validation).
+ */
+export function buildMarkerBody(type, fields) {
+  switch (type) {
+    case 'claim':
+      return renderClaimedByMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        supersedes: fields.supersedes,
+        timestamp: fields.timestamp,
+        branch: fields.branch,
+      });
+    case 'unclaim':
+      return renderUnclaimedByMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        timestamp: fields.timestamp,
+      });
+    case 'activation-nonce':
+      return renderActivationNonceMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        nonce: fields.nonce,
+        timestamp: fields.timestamp,
+      });
+    case 'watermark':
+      return renderReviewWatermarkMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        headSha: fields['head-sha'],
+        maxActivityAt: fields['max-activity-at'],
+        totalItemCount: fields['total-item-count'],
+        ciCompletedAt: fields['ci-completed-at'],
+      });
+    case 'baseline':
+      return renderReviewBaselineMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        sha: fields.sha,
+      });
+    case 'advisory':
+      return renderAdvisoryWaitMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    case 'advisory-recovery':
+      // #1572: --claim-id / --attempt are OPTIONAL here so the shipped
+      // AW3-R recovery flow's existing 3-field call keeps working
+      // unchanged; passing both binds the marker for recovery-cycle
+      // accounting (see renderAdvisoryWaitRecoveryMarker's own doc comment
+      // for the fail-closed behavior on a half-bound pair).
+      return renderAdvisoryWaitRecoveryMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+        ...(fields['claim-id'] !== undefined
+          ? { claimId: fields['claim-id'] }
+          : {}),
+        ...(fields.attempt !== undefined ? { attempt: fields.attempt } : {}),
+      });
+    case 'advisory-reroll':
+      return renderAdvisoryRerollMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    case 'copilot-unavailable':
+      return renderCopilotUnavailableMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        headSha: fields['head-sha'],
+        attempt: fields.attempt,
+        timestamp: fields.timestamp,
+      });
+    default:
+      throw new Error(
+        `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
+      );
+  }
+}
+/**
+ * Map a `review-activity-snapshot` JSON object to the four snapshot-derived
+ * `--type watermark` field flags, so `--from-pr` can fill them automatically
+ * instead of the agent hand-copying a 40-char HEAD SHA and three timestamps.
+ *
+ * `ci-completed-at` is taken from `latestPassingCiCompletedAt` — the latest
+ * *passing* (or treated-as-passed) CI completion — NOT `latestCiCompletedAt`.
+ * That matches the E1 Step 2 `{latest-ci-completed-at}` definition and the
+ * pre-merge-readiness currency diff, which compares the watermark CI field
+ * against the live `latestPassingCiCompletedAt`; using the all-completed field
+ * would post a value that differs from the hand-computed one and trips a false
+ * F2 `ci-pass-drift`.
+ *
+ * The snapshot emits the `none` sentinel string (never `null`) for empty
+ * timestamps; both are tolerated and forwarded as `none`. Throws (fail-closed)
+ * when `headSha` / `totalItemCount` are absent or malformed so a broken
+ * snapshot can never post a bogus watermark. ISO/count shape validation is left
+ * to the single-sourced `renderReviewWatermarkMarker` reached via
+ * `buildMarkerBody`.
+ */
+export function watermarkFieldsFromSnapshot(snapshot) {
+  const snap = snapshot ?? {};
+  const headSha = snap.headSha;
+  const totalItemCount = snap.totalItemCount;
+  if (typeof headSha !== 'string' || headSha.trim() === '') {
+    throw new Error('review-activity-snapshot is missing a usable headSha');
+  }
+  if (
+    typeof totalItemCount !== 'number' ||
+    !Number.isInteger(totalItemCount) ||
+    totalItemCount < 0
+  ) {
+    throw new Error(
+      'review-activity-snapshot is missing a usable totalItemCount',
+    );
+  }
+  const isoOrNone = (value) =>
+    typeof value === 'string' && value.trim() !== '' ? value : 'none';
+  return {
+    'head-sha': headSha,
+    'max-activity-at': isoOrNone(snap.maxActivityUpdatedAt),
+    'total-item-count': String(totalItemCount),
+    'ci-completed-at': isoOrNone(snap.latestPassingCiCompletedAt),
+  };
+}
+/**
+ * #1833: diagnostic-only warnings for a `--from-pr` watermark whose fresh
+ * `review-activity-snapshot` already carries `dispositionEvidence` evidence
+ * -- comments and/or threads with NO disposition reply at all, per the same
+ * `summarizeDispositionEvidenceForGate` the F2 `missing-disposition-evidence`
+ * gate uses. This is deliberately NOT `ackOnly.items`: that evidence is the
+ * carve-out `diffReviewSnapshot` reads to treat post-disposition advisory-bot
+ * courtesy acks as safe to fold into the watermark, so it is populated on
+ * the routine, benign path (an ack after a correct disposition) and would
+ * warn on exactly the cases that are fine. `dispositionEvidence`'s counters
+ * are the opposite: genuinely undispositioned items, which the watermark is
+ * about to silently mark "already reviewed" by folding their activity into
+ * its `max-activity-at` / `total-item-count` fields. Surfacing that now, in
+ * this command's own success output, lets the caller see it at post time
+ * instead of discovering it only later via the readiness report's
+ * `missing-disposition-evidence` route (or, if the item happens to look
+ * ack-only-shaped, via `reviewCurrency.comparisonRoute`).
+ *
+ * Returns `[]` when the snapshot carries no such evidence, including when
+ * `dispositionEvidence` is absent or malformed (diagnostic-only: fails open,
+ * never blocks or alters what gets POSTed).
+ */
+export function describeUnaddressedActivity(snapshot) {
+  const snap = snapshot ?? {};
+  const missingComments = Number(
+    snap.dispositionEvidence?.missingRegularCommentCount ?? 0,
+  );
+  const missingThreads = Number(
+    snap.dispositionEvidence?.missingThreadCount ?? 0,
+  );
+  const commentCount =
+    Number.isInteger(missingComments) && missingComments > 0
+      ? missingComments
+      : 0;
+  const threadCount =
+    Number.isInteger(missingThreads) && missingThreads > 0 ? missingThreads : 0;
+  if (commentCount === 0 && threadCount === 0) {
+    return [];
+  }
+  const parts = [];
+  if (commentCount > 0) {
+    parts.push(`${commentCount} comment${commentCount === 1 ? '' : 's'}`);
+  }
+  if (threadCount > 0) {
+    parts.push(`${threadCount} thread${threadCount === 1 ? '' : 's'}`);
+  }
+  const itemTotal = commentCount + threadCount;
+  const verb = itemTotal === 1 ? 'has' : 'have';
+  const pronoun = itemTotal === 1 ? 'it' : 'them';
+  return [
+    `${parts.join(' and ')} ${verb} no disposition evidence as of this ` +
+      `watermark, but its max-activity-at/total-item-count already cover ` +
+      `${pronoun} -- dispose ${pronoun} (or re-run --from-pr after doing ` +
+      'so) before relying on this watermark.',
+  ];
+}
+/**
+ * Parse a whole-token positive integer, failing closed on a suffixed typo
+ * (`1047abc`), a non-numeric token, or a non-positive / unsafe magnitude — a
+ * mis-parsed target number could POST a marker to the wrong issue/PR.
+ */
+function parsePositiveIntToken(token, label) {
+  const parsed = Number.parseInt(token, 10);
+  if (!/^\d+$/.test(token) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label}: ${token}`);
+  }
+  return parsed;
+}
+// Excluded from the #1446 cli-args.mts wrapper: `fields` below collects
+// per-marker-type keys dynamically (each `--type` accepts a different
+// field set) rather than a fixed declared spec. `util.parseArgs`'s
+// `strict: true` rejects any option not named in its static spec, and
+// `strict: false` would instead coerce every unrecognized flag to `true`
+// -- neither matches this file's "accept whatever fields this marker type
+// needs" contract.
+export function parseArgs(argv) {
+  const args = {
+    type: '',
+    target: '',
+    number: null,
+    fromPr: null,
+    expectedHeadSha: '',
+    apply: false,
+    owner: '',
+    repo: '',
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
+    help: false,
+    fields: {},
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (token === '--apply') {
+      args.apply = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      // The sole positional argument is the issue/PR number. Match the whole
+      // token as a positive integer BEFORE converting: Number.parseInt would
+      // silently accept a suffixed typo like `1047abc` / `1047-draft` as 1047
+      // and, with --apply, post the marker to the wrong target. Fail closed.
+      if (args.number !== null) {
+        throw new Error(`unexpected positional argument: ${token}`);
+      }
+      args.number = parsePositiveIntToken(token, 'invalid issue/PR number');
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    index += 1;
+    if (token === '--type') {
+      args.type = value;
+    } else if (token === '--target') {
+      args.target = value;
+    } else if (token === '--from-pr') {
+      args.fromPr = parsePositiveIntToken(value, 'invalid --from-pr number');
+    } else if (token === '--expected-head-sha') {
+      args.expectedHeadSha = value;
+    } else if (token === '--owner') {
+      args.owner = value;
+    } else if (token === '--repo') {
+      args.repo = value;
+    } else if (token === '--trusted-marker-logins') {
+      args.trustedMarkerLogins = value;
+    } else if (token === '--advisory-bot-logins') {
+      args.advisoryBotLogins = value;
+    } else {
+      // Any other --flag is a renderer field, stored under its kebab name.
+      args.fields[token.slice(2)] = value;
+    }
+  }
+  return args;
+}
+const USAGE = `usage: node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> [field flags...] [--apply]
+
+Render the canonical HTML-comment-first body for an IDD operational marker
+(advisory markers are plain-text per the AW3 protocol) and POST it via the
+reliable JSON path. Default mode is dry-run, which prints a JSON envelope whose
+\`body\` field is the marker; --apply POSTs it and prints the created comment
+id/URL. This helper performs no claim/state gating — the calling phase must run
+its claim-revalidation gate before --apply, as the manual POST path it replaces.
+
+  --type <type>        one of: ${MARKER_TYPES.join(', ')}
+  --target <issue|pr>  the comment target kind (both use the issues comments API)
+  <number>             issue or PR number (positional; required unless --from-pr)
+  --from-pr <n>        watermark: derive --head-sha / --max-activity-at /
+                       --total-item-count / --ci-completed-at from the live
+                       review-activity-snapshot of PR <n>. advisory /
+                       advisory-recovery / advisory-reroll (#1889): derive
+                       only --head-sha from PR <n>'s live current head commit
+                       (a single lightweight gh pr view call, not the full
+                       snapshot). Either way the marker posts to PR <n>, so
+                       --head-sha never needs hand-typing (always targets the
+                       PR; an explicit non-pr --target is rejected). Not
+                       network-free.
+  --expected-head-sha <sha>  --from-pr --type watermark only: the E1 Step 1
+                       stored {head-SHA}. Fails closed (posts nothing) if the
+                       fresh snapshot's live HEAD no longer matches it, i.e.
+                       the branch moved between E1 Step 1 and this Step 2
+                       call.
+  --apply              POST the marker (default: dry-run prints it in a JSON envelope)
+  --owner <owner>      repo owner (default: gh repo view)
+  --repo <repo>        repo name (default: gh repo view)
+  -h, --help           show this help
+
+Per-type field flags:
+  claim              --agent-id --claim-id --supersedes --timestamp --branch
+  unclaim            --agent-id --claim-id --timestamp
+  activation-nonce   --agent-id --claim-id --nonce --timestamp
+  watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+                     (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
+  baseline           --agent-id --claim-id --sha
+  advisory           --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
+  advisory-recovery  --agent-id --head-sha --timestamp [--claim-id --attempt]
+                     (or --agent-id --from-pr <n> --timestamp [--claim-id --attempt])
+  advisory-reroll    --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
+  copilot-unavailable --agent-id --claim-id --head-sha --attempt --timestamp
+
+--claim-id / --attempt on advisory-recovery are OPTIONAL (#1572): passing
+both binds the marker to the active claim and an attempt number for
+recovery-cycle accounting (advisory-wait-state.mjs); passing neither renders
+the legacy 3-field form the shipped AW3-R recovery flow already posts.
+Passing only ONE of the two throws (half-bound, ambiguous) -- always pass
+both together or neither. This pairing works unchanged together with
+--from-pr.
+copilot-unavailable is a brand-new terminal marker with no legacy form, so
+all five fields are required.
+
+--from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
+the snapshot child (--type watermark only) so its counts match the manual
+review-activity-snapshot path.
+--expected-head-sha pins a --type watermark --from-pr to the Step 1 stored
+HEAD and fails closed (no post) on drift instead of silently posting a newer
+HEAD than Step 1 saw.
+`;
+/**
+ * POST the marker body as a JSON document (`{"body": …}`) read from stdin via
+ * `gh api --input -`. The JSON path is mandatory because HTML-comment-first
+ * bodies are silently dropped by `gh issue comment` / `gh api -f body=`.
+ *
+ * Both `--target issue` and `--target pr` POST to the same
+ * `repos/{owner}/{repo}/issues/{number}/comments` endpoint (a PR is an issue
+ * for the comments API); `target` is descriptive-only and never changes routing.
+ */
+function postMarker(owner, repo, number, body) {
+  const out = ghText(
+    [
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/issues/${number}/comments`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }) },
+  );
+  return JSON.parse(out);
+}
+/**
+ * Fetch PR `<n>`'s current head commit SHA via a single lightweight `gh pr
+ * view` call -- the `--from-pr` derivation path for the three advisory
+ * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`),
+ * which need only `--head-sha`, unlike `watermark`'s `--from-pr`, which
+ * composes the full four-field snapshot via
+ * {@link runReviewActivitySnapshot}. This is deliberately network-lighter
+ * than that snapshot: no CI checks, review threads, or comment pagination,
+ * just the one `headRefOid` field.
+ *
+ * Throws (fail-closed) when `headRefOid` comes back empty or missing, so a
+ * malformed `gh pr view` response can never post a marker with a blank
+ * `head-sha` -- mirrors {@link watermarkFieldsFromSnapshot}'s guard on the
+ * watermark path.
+ */
+function headShaFromPr(prNumber, owner, repo) {
+  const headSha = ghText([
+    'pr',
+    'view',
+    String(prNumber),
+    '-R',
+    `${owner}/${repo}`,
+    '--json',
+    'headRefOid',
+    '--jq',
+    '.headRefOid',
+  ]);
+  // Validate the shape here (not just non-empty): a non-SHA value (e.g. the
+  // literal text "null" if `gh` ever printed that instead of a real SHA)
+  // would otherwise pass this check and only fail later inside
+  // buildMarkerBody's renderer with a generic "invalid ... marker payload"
+  // message that does not name the actual cause. Fail closed here instead
+  // with a targeted error (Copilot review, #1889/#1891).
+  if (!/^[0-9a-f]{40}$/i.test(headSha)) {
+    throw new Error(
+      `PR ${prNumber} has no usable headRefOid (expected a 40-hex-character SHA, got: ${headSha || '(empty)'})`,
+    );
+  }
+  return headSha;
+}
+/**
+ * Run the sibling read-only `review-activity-snapshot.mjs` for a PR and return
+ * its parsed JSON. This is the `--from-pr` half of the "compose the two existing
+ * helpers" path; the snapshot stays the single source of the activity/CI metrics
+ * and this write-side helper only renders+posts the watermark over them.
+ *
+ * The sibling is resolved relative to this module (both generated artifacts live
+ * in `scripts/`), so it works from any cwd. `--owner` / `--repo` are forwarded
+ * to avoid an extra `gh repo view` in the child, and the optional marker-actor
+ * lists are forwarded so the child's `totalItemCount` / `maxActivityUpdatedAt`
+ * filtering matches the manual `review-activity-snapshot` invocation.
+ */
+function runReviewActivitySnapshot(
+  prNumber,
+  owner,
+  repo,
+  trustedMarkerLogins,
+  advisoryBotLogins,
+) {
+  const script = resolve(import.meta.dirname, 'review-activity-snapshot.mjs');
+  const snapshotArgs = [
+    script,
+    '--pr',
+    String(prNumber),
+    '--owner',
+    owner,
+    '--repo',
+    repo,
+  ];
+  if (trustedMarkerLogins) {
+    snapshotArgs.push('--trusted-marker-logins', trustedMarkerLogins);
+  }
+  if (advisoryBotLogins) {
+    snapshotArgs.push('--advisory-bot-logins', advisoryBotLogins);
+  }
+  const out = execFileSync(process.execPath, snapshotArgs, {
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+if (import.meta.main) {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+    throw error;
+  }
+  // #1833: populated only by the `--from-pr` snapshot-derivation branch
+  // below; carried into both the dry-run and `--apply` result envelopes.
+  let warnings = [];
+  if (args.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (!MARKER_TYPES.includes(args.type)) {
+    process.stderr.write(
+      `--type is required and must be one of: ${MARKER_TYPES.join(', ')}\n`,
+    );
+    process.exit(1);
+  }
+  // --expected-head-sha only guards the --from-pr --type watermark
+  // derivation below; in manual mode the caller already supplies --head-sha
+  // directly, so there is nothing to compare it against. It has no meaning
+  // for the three advisory --from-pr types (#1889): they have no E1 Step
+  // 1/Step 2 pinning concept, so reject the combination the same way rather
+  // than silently ignoring it.
+  if (args.expectedHeadSha && args.fromPr === null) {
+    process.stderr.write(
+      '--expected-head-sha is only valid together with --from-pr\n',
+    );
+    process.exit(1);
+  }
+  if (
+    args.expectedHeadSha &&
+    args.fromPr !== null &&
+    args.type !== 'watermark'
+  ) {
+    process.stderr.write(
+      '--expected-head-sha is only valid together with --from-pr --type watermark\n',
+    );
+    process.exit(1);
+  }
+  // `--from-pr <n>` derivation mode: default the post target to PR <n>,
+  // reject the manually-supplied derived field(s) as ambiguous, then derive
+  // those fields from a live PR <n> read before the shared render +
+  // dry-run/apply path below. owner/repo are resolved here because the
+  // derivation needs them and the dry-run branch returns before the
+  // apply-path resolution.
+  //
+  // `--type watermark` derives all four snapshot fields via the full
+  // review-activity-snapshot composition (unchanged since #1134). The three
+  // advisory types (#1889: `advisory` / `advisory-recovery` /
+  // `advisory-reroll`) derive only `--head-sha`, via the lighter
+  // single-`gh pr view`-call `headShaFromPr` -- those renderers accept no
+  // other snapshot-shaped field, so composing the full snapshot for them
+  // would be needless extra network work.
+  if (args.fromPr !== null) {
+    if (!FROM_PR_MARKER_TYPES.includes(args.type)) {
+      process.stderr.write(
+        `--from-pr is only valid for --type ${FROM_PR_MARKER_TYPES.join(', ')}\n`,
+      );
+      process.exit(1);
+    }
+    const isWatermark = args.type === 'watermark';
+    // --from-pr always posts the marker to PR <n>. `--target` is
+    // descriptive-only (issue/pr both POST to the same /issues/<n>/comments
+    // endpoint), but an `issue`-targeted PR-derived marker is incoherent, so
+    // fail closed on an explicit non-pr target rather than recording it.
+    if (args.target && args.target !== 'pr') {
+      process.stderr.write(
+        `--from-pr always targets the PR; remove --target ${args.target}\n`,
+      );
+      process.exit(1);
+    }
+    args.target = 'pr';
+    if (args.number === null) {
+      args.number = args.fromPr;
+    } else if (args.number !== args.fromPr) {
+      process.stderr.write(
+        'in --from-pr mode the positional number must be omitted or equal --from-pr\n',
+      );
+      process.exit(1);
+    }
+    const derivedFlags = isWatermark
+      ? ['head-sha', 'max-activity-at', 'total-item-count', 'ci-completed-at']
+      : ['head-sha'];
+    const conflicting = derivedFlags.filter((flag) => flag in args.fields);
+    if (conflicting.length > 0) {
+      process.stderr.write(
+        `--from-pr derives ${derivedFlags.join(' / ')} from the live ${isWatermark ? 'snapshot' : 'PR'}; do not also pass: ${conflicting
+          .map((flag) => `--${flag}`)
+          .join(', ')}\n`,
+      );
+      process.exit(1);
+    }
+    // Resolve owner/repo inside the try: in --from-pr mode they are read
+    // eagerly (the derivation needs them and the dry-run branch returns
+    // before the apply-path resolution), so a `gh` failure here is part of
+    // "derive from PR" and should report cleanly, not throw a raw stack.
+    try {
+      args.owner =
+        args.owner ||
+        ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+      args.repo =
+        args.repo ||
+        ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+      if (isWatermark) {
+        const snapshot = runReviewActivitySnapshot(
+          args.fromPr,
+          args.owner,
+          args.repo,
+          args.trustedMarkerLogins,
+          args.advisoryBotLogins,
+        );
+        Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+        warnings = describeUnaddressedActivity(snapshot);
+      } else {
+        args.fields['head-sha'] = headShaFromPr(
+          args.fromPr,
+          args.owner,
+          args.repo,
+        );
+      }
+    } catch (error) {
+      process.stderr.write(
+        `failed to derive ${isWatermark ? 'watermark fields' : 'head-sha'} from PR ${args.fromPr}: ${error.message}\n`,
+      );
+      process.exit(1);
+    }
+    // Fail closed (this repository's fail-closed default) when the branch
+    // moved between E1 Step 1 (which stored {head-SHA} and must not re-read
+    // HEAD through Step 3) and this Step 2 call: posting a watermark keyed to
+    // a HEAD newer than the one E1 Step 1 actually snapshotted would silently
+    // violate that single-stored-value invariant. Refuse to post; the caller
+    // reruns E1 from Step 1 against the moved branch instead. Watermark-only:
+    // --expected-head-sha is rejected above for the advisory --from-pr types,
+    // so this never fires for them.
+    const liveHeadSha = args.fields['head-sha'];
+    if (
+      isWatermark &&
+      args.expectedHeadSha &&
+      liveHeadSha.toLowerCase() !== args.expectedHeadSha.toLowerCase()
+    ) {
+      process.stderr.write(
+        `refusing to post watermark: PR ${args.fromPr}'s live HEAD (${liveHeadSha}) no longer matches the Step 1 stored --expected-head-sha (${args.expectedHeadSha}); the branch moved between E1 Step 1 and Step 2. Re-run E1 from Step 1 against the new HEAD.\n`,
+      );
+      process.exit(1);
+    }
+  }
+  if (!TARGET_KINDS.includes(args.target)) {
+    process.stderr.write(
+      `--target is required and must be one of: ${TARGET_KINDS.join(', ')}\n`,
+    );
+    process.exit(1);
+  }
+  if (args.number === null) {
+    process.stderr.write('a positional issue/PR <number> is required\n');
+    process.exit(1);
+  }
+  let body;
+  try {
+    // #1722: report a missing required field BY NAME before buildMarkerBody
+    // (and the renderer it dispatches to) ever sees the payload -- runs
+    // AFTER --from-pr derivation above, so a watermark's --head-sha /
+    // --total-item-count are already populated by the time this checks
+    // them in that mode. See REQUIRED_FIELDS_BY_TYPE's own doc comment for
+    // which fields are deliberately excluded (renderer-defaulted or
+    // half-bound-optional).
+    for (const field of REQUIRED_FIELDS_BY_TYPE[args.type]) {
+      requireFlag(args.fields[field], `--${field}`);
+    }
+    body = buildMarkerBody(args.type, args.fields);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+    throw error;
+  }
+  const number = args.number;
+  if (!args.apply) {
+    const result = {
+      mode: 'dry-run',
+      type: args.type,
+      target: args.target,
+      number,
+      body,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exit(0);
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const posted = postMarker(owner, repo, number, body);
+  const result = {
+    mode: 'apply',
+    type: args.type,
+    target: args.target,
+    number,
+    commentId: posted.id,
+    url: posted.html_url,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exit(0);
+}

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -1,0 +1,1230 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/pre-merge-readiness.mts
+//
+// The scripts/pre-merge-readiness.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import {
+  readAdvisoryPrimaryBotLogin,
+  readAdvisoryRecoveryCycleCap,
+  readAdvisoryTerminalWindowMinutes,
+  readAdvisoryWaitPolicy,
+} from './advisory-wait-policy.mjs';
+import { buildCopilotRecoverySummary } from './advisory-wait-state.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_OPTIONS,
+  ghText,
+  safeGhText,
+} from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import {
+  normalizePolicyConfig,
+  parseIsoDurationToMs,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mjs';
+import {
+  buildPreMergeReadinessSummary,
+  DEFAULT_STALE_AGE_MS,
+  deriveIddAgentLogins,
+  findLastCopilotReviewCommit,
+  normalizeTrustedMarkerLogins,
+  operationalMarkerPrefix,
+  parsePaginatedGhNdjson,
+  resolveAdvisoryBotLogins,
+  resolveCodeownersForFiles,
+  resolvePrFirstCommitAt,
+  resolveRulesetDetailPath,
+  resolveTrustedMarkerActors,
+  selectCodeownersText,
+} from './protocol-helpers.mjs';
+
+// GitHub's GraphQL `DateTime` scalar can't be null, so a `CheckRun` that
+// has not completed yet (and a `StatusContext`, which has no completedAt
+// field at all) reports this zero-value sentinel instead -- the same
+// convention `gh pr checks` already surfaces and `isCompletedCiTimestamp`
+// (protocol-helpers.mts) already treats as "not completed".
+const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
+// The commit-status `state` GraphQL enum (`StatusState`) has its own
+// 5-value vocabulary (`EXPECTED`, `ERROR`, `FAILURE`, `PENDING`,
+// `SUCCESS`; confirmed via schema introspection -- an earlier version of
+// this comment underclaimed 4, missing `EXPECTED`) that only partly
+// overlaps the check-run vocabulary `classifyCiChecks` understands
+// (`FAILURE`, `CANCELLED`, `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`,
+// `SKIPPED`, `NEUTRAL`, `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE`
+// already coincide, but the other three have no direct match -- left
+// unmapped, each would silently fall into `classifyCiChecks`'s `unknown`
+// bucket instead of the `failed` / `pending` bucket a caller actually
+// needs (PR review finding, #1483: `gh pr checks`'s prior flattened read
+// normalized both vocabularies into one `state` field; this
+// data-source swap makes normalizing them this module's own
+// responsibility). Map every divergent token onto its check-run
+// equivalent before classification ever sees it: `ERROR` (a distinct
+// "reporting error" state, not `FAILURE`) maps to `FAILURE`; `PENDING`
+// (still running) and `EXPECTED` (a required status check configured for
+// this ref but not yet reported at all -- also still "not done", not a
+// failure) both map to `IN_PROGRESS`. This is always a "still failing" /
+// "still running" outcome, never a false pass, so even an unmapped
+// future commit-status token would only ever fail closed into `unknown`,
+// not `success`.
+const STATUS_CONTEXT_STATE_ALIASES = {
+  ERROR: 'FAILURE',
+  PENDING: 'IN_PROGRESS',
+  EXPECTED: 'IN_PROGRESS',
+};
+/**
+ * Normalize one raw `statusCheckRollup` entry into the `CheckPayload`
+ * shape `classifyCiChecks` / `summarizeRequiredChecks` expect (#1483).
+ *
+ * `state` is derived to match what `gh pr checks --json state` already
+ * reported for the same underlying data (verified empirically against
+ * this repository's own live PRs across `SUCCESS` / `FAILURE` /
+ * `IN_PROGRESS`): a completed check-run reports its `conclusion` (falling
+ * back to `UNKNOWN` if absent); an incomplete one reports its raw `status`
+ * (`QUEUED` / `IN_PROGRESS` / `WAITING`, also falling back to `UNKNOWN` if
+ * absent -- a missing status is never silently coerced to an empty
+ * string, which `classifyCiChecks` would not recognize as any known
+ * bucket); a legacy commit-status reports its `state`, translated through
+ * `STATUS_CONTEXT_STATE_ALIASES` for the three tokens with no direct
+ * check-run equivalent. This keeps classification behavior identical to
+ * before #1483 for every single-producer case that existed pre-#1483 --
+ * only the producer-identity discriminator (`type` / `workflowName`) and
+ * the commit-status vocabulary mapping are new.
+ */
+export function normalizeStatusCheckRollupEntry(entry) {
+  if (String(entry?.__typename ?? '').trim() === 'StatusContext') {
+    const rawState = String(entry?.state ?? '')
+      .trim()
+      .toUpperCase();
+    return {
+      name: String(entry?.context ?? '').trim(),
+      state: STATUS_CONTEXT_STATE_ALIASES[rawState] ?? rawState,
+      completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+      type: 'status-context',
+      workflowName: '',
+    };
+  }
+  const status = String(entry?.status ?? '')
+    .trim()
+    .toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '')
+    .trim()
+    .toUpperCase();
+  return {
+    name: String(entry?.name ?? '').trim(),
+    state:
+      status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN',
+    completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+    type: 'check-run',
+    workflowName: String(entry?.workflowName ?? '').trim(),
+  };
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. Both the
+// canonical and deprecated spellings of the claim/agent-id flags are
+// declared as separate spec entries (strict parseArgs requires every
+// accepted flag to be declared) -- flag-name-matrix.test.mts's deprecated-
+// alias tests scan for exactly these quoted literals.
+const PRE_MERGE_READINESS_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--claim-issue': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--trusted-marker-logins': { type: 'string' },
+  '--idd-agent-logins': { type: 'string' },
+  '--advisory-bot-logins': { type: 'string' },
+  '--claim-id': { type: 'string' },
+  '--expected-claim-id': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--expected-agent-id': { type: 'string' },
+  '--nonce': { type: 'string' },
+  '--now': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+/**
+ * Fetch live GitHub state for the PR + claim issue and build the
+ * read-only pre-merge readiness report. Shared by this CLI and the
+ * `idd-merge-execute` helper so the F2/F3 gate logic is collected from
+ * exactly one place (no duplicated gh plumbing or gate evaluation).
+ */
+export function collectPreMergeReadiness(argv) {
+  const args = parseArgs(argv);
+  // --help used to exit from inside the parseArgs token loop; relocated
+  // here (the wrapper's help path) per #1451. Same external contract: the
+  // sole caller (idd-merge-execute.mts) never passes --help, so this is a
+  // pure relocation, not a behavior change.
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  if (!args.claimIssueNumber) {
+    throw new Error('missing required --claim-issue <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText(
+    ['api', 'user', '--jq', '.login'],
+    GH_TEXT_LOOP_OPTIONS,
+  ).toLowerCase();
+  const viewerAppSlug = safeGhText(
+    ['api', 'app', '--jq', '.slug // .app_slug // empty'],
+    GH_TEXT_LOOP_OPTIONS,
+  ).toLowerCase();
+  const iddConfig = loadIddConfig();
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
+  const pr = ghJson([
+    'pr',
+    'view',
+    String(args.prNumber),
+    '-R',
+    repoRef,
+    '--json',
+    // #1513: `mergeable,mergeStateStatus` added to this existing call (no
+    // new network round-trip) so the branch-currency gate below can pair a
+    // live `BEHIND` state with the up-to-date-head requirement resolved
+    // from `branchRules`/`branchProtection`.
+    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus',
+    '--jq',
+    '.',
+  ]);
+  const prHeadSha = String(pr.headRefOid ?? '');
+  const baseRefName = String(pr.baseRefName ?? '');
+  const prUrl = String(pr.url ?? '');
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const reviewDecision = String(pr.reviewDecision ?? '');
+  const mergeable = String(pr.mergeable ?? '');
+  const mergeStateStatus = String(pr.mergeStateStatus ?? '');
+  const encodedBaseRefName = encodeURIComponent(baseRefName);
+  // #1483: sourced from the same `gh pr view` call above (the
+  // `statusCheckRollup` field), not a separate `gh pr checks` call --
+  // `statusCheckRollup`'s GraphQL union already tags each entry with a
+  // real producer identity (`__typename`: `CheckRun` vs. `StatusContext`,
+  // plus `workflowName` for check-runs), which a flattened `gh pr checks`
+  // read cannot expose. Joining two separately-fetched lists by name would
+  // reintroduce the exact ambiguity this fix removes (confirmed live: two
+  // successive calls a few seconds apart returned different check-run
+  // counts for the same PR), so this is the single source of truth for
+  // both the check identity and its dedup discriminator.
+  const checks = (pr.statusCheckRollup ?? []).map(
+    normalizeStatusCheckRollupEntry,
+  );
+  const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
+  const branchRulesRead = fetchGovernanceJson(
+    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
+    true,
+    trustEmptyProtectionReads,
+    [],
+  );
+  const branchRules = branchRulesRead.value;
+  const branchRulesetsRead = fetchBranchRulesets(
+    owner,
+    repo,
+    branchRules,
+    trustEmptyProtectionReads,
+  );
+  const branchRulesets = branchRulesetsRead.value;
+  const branchProtectionRead = fetchGovernanceJson(
+    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
+    false,
+    trustEmptyProtectionReads,
+    {},
+  );
+  const branchProtection = branchProtectionRead.value;
+  // #1377: a masked-403-as-404 on either read means the required-check set
+  // this call collected cannot be trusted as complete, so the F2/F3 CI gate
+  // must not fall through to `noRequiredChecksConfigured` on it (see
+  // `summarizeRequiredChecks` in protocol-helpers.mts).
+  const protectionReadsUnreadable =
+    branchRulesRead.unreadable || branchProtectionRead.unreadable;
+  // #1380: a masked-403-as-404 on a ruleset's *detail* read is a distinct
+  // surface from the required-check reads above -- `branchRulesets` only
+  // feeds `summarizeReviewerStates`'s ruleset-bypass/CODEOWNER detection,
+  // never `summarizeRequiredChecks` (see `summarizeBranchReviewRequirements`
+  // in protocol-helpers.mts, which reads only `branchRules` /
+  // `branchProtection`) -- so it is threaded separately rather than folded
+  // into `protectionReadsUnreadable`.
+  const branchRulesetsUnreadable = branchRulesetsRead.unreadable;
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  );
+  const requestedReviewers = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
+    false,
+  );
+  const timelineEvents = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
+    true,
+    ['-H', 'Accept: application/vnd.github+json'],
+  );
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  );
+  const claimComments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
+    true,
+  );
+  const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const changedFiles = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/files`,
+    true,
+  )
+    .map((file) => String(file.filename ?? ''))
+    .filter(Boolean);
+  const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
+  const {
+    eligible: eligibleCodeownerUserLogins,
+    unreadable: eligibleCodeownerUserLoginsUnreadable,
+  } = resolveEligibleCodeownerUserLogins(
+    owner,
+    repo,
+    resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
+  );
+  const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
+    owner,
+    viewerLogin,
+    branchProtection,
+  );
+  const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+          ...comments,
+          ...claimComments,
+        ])
+      : []),
+  ]);
+  const iddAgentLogins = deriveIddAgentLogins({
+    viewerLogin,
+    iddAgentLogins: splitCsv(args.iddAgentLogins),
+    trustedMarkerLogins,
+    operationalComments: [...comments, ...claimComments],
+  });
+  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against a PR-backed claim. This allowance is applied on the merge side
+  // only; resume-claim-routing.mts intentionally never passes prFirstCommitAt
+  // (an issue-only handoff against a PR-backed claim stays rejected there) —
+  // the merge-only half of the documented strict-resume vs. lenient-relay-merge
+  // split (see docs/idd-design-rationale.md, "Claim resolution"). Resolve it
+  // only when forced handoffs are enabled, and fail closed to `null` (reject)
+  // on any lookup/parse error so a transient commits-API failure never aborts
+  // the readiness gate.
+  let prFirstCommitAt = null;
+  if (forcedHandoffEnabled) {
+    try {
+      const prCommits = ghApiJson(
+        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+        true,
+      );
+      prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
+    } catch {
+      prFirstCommitAt = null;
+    }
+  }
+  const forcedHandoffPermissionCache = new Map();
+  const waivableCheckSelectors = readWaivableCheckSelectors();
+  const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
+  const trustSourcePinnedRequiredChecks = readTrustSourcePinnedRequiredChecks();
+  const staleAgeMs = readClaimStaleAgeMs();
+  const now = args.now || new Date().toISOString().replace('.000Z', 'Z');
+  const normalizedComments = comments.map(normalizeComment);
+  const normalizedReviews = reviews.map(normalizeReview);
+  // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
+  // here (the CLI/orchestration layer) rather than inside
+  // `buildPreMergeReadinessSummary` (protocol-helpers.mts), which cannot
+  // import `buildCopilotRecoverySummary` without an import cycle back
+  // through advisory-wait-state.mts (see that function's own module notes).
+  // Bound to the SAME expected claim already threaded to
+  // `summarizeClaimValidation` below (`--expected-claim-id`/
+  // `--expected-agent-id`), matching the active claim that would have
+  // posted any `advisory-wait-recovery:` cycle markers. Deliberately
+  // uncaught: an unexpected error here must not silently collapse to
+  // `copilotUnavailable: false` (a permissive default that could mask a
+  // real terminal-unavailable condition behind an ancillary-evidence bug
+  // -- flagged by CodeRabbit on PR #1646). Letting it throw matches this
+  // repo's documented helper-failure contract (see
+  // `idd-review-snapshot.instructions.md`'s "Helpers remain evidence
+  // collectors only"): a crash here is evidence collection failing
+  // loudly, and callers already know to fall back to the portable
+  // gh/jq/API procedure rather than trust a helper that could not run.
+  const lastCopilotCommit = findLastCopilotReviewCommit(
+    normalizedReviews,
+    primaryBotLogin,
+  );
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments: normalizedComments, prHeadSha, lastCopilotCommit },
+    {
+      now,
+      trustedMarkerLogins,
+      claimId: args.expectedClaimId,
+      agentId: args.expectedAgentId,
+      recoveryCycleCap: readAdvisoryRecoveryCycleCap(),
+      terminalWindowMinutes: readAdvisoryTerminalWindowMinutes(),
+    },
+  );
+  const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
+  const summary = buildPreMergeReadinessSummary(
+    {
+      prHeadSha,
+      comments: normalizedComments,
+      reviews: normalizedReviews,
+      threads: threads.map(normalizeThread),
+      checks,
+      branchRules,
+      branchRulesets,
+      branchProtection,
+      protectionReadsUnreadable,
+      branchRulesetsUnreadable,
+      requestedReviewers: requestedReviewers.users ?? [],
+      timelineEvents,
+      claimEvents: claimComments.map(normalizeClaimComment),
+      changedFiles,
+      codeownersText,
+      eligibleCodeownerUserLogins,
+      eligibleCodeownerUserLoginsUnreadable,
+      // #1837: `reviews` above is fetched by the uncaught `ghApiJson` call
+      // a few lines up (no `fetchGovernanceJson`-style tolerance) -- a
+      // fetch failure throws and crashes this whole CLI invocation rather
+      // than reaching `buildPreMergeReadinessSummary` with partial data.
+      // This caller therefore never has genuinely-unclassifiable review
+      // data; pass `false` explicitly (rather than relying on the default)
+      // so the reason is documented at the one real call site instead of
+      // only in protocol-helpers.mts's option comment.
+      reviewsUnreadable: false,
+      reviewDecision,
+      mergeStateStatus,
+      mergeable,
+    },
+    {
+      now,
+      trustedMarkerLogins,
+      iddAgentLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource,
+      prAuthorLogin,
+      expectedClaimId: args.expectedClaimId,
+      expectedAgentId: args.expectedAgentId,
+      expectedNonce: args.nonce,
+      includeDispositionEvidence: true,
+      requestCap: advisoryWaitPolicy.requestCap,
+      pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+      primaryBotLogin,
+      copilotUnavailable,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity,
+      trustSourcePinnedRequiredChecks,
+      staleAgeMs,
+      forcedHandoffEnabled,
+      expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      prFirstCommitAt,
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+      viewerLogin,
+      viewerTeamSlugs,
+      viewerAppSlug,
+      configuredTrustedActors,
+      collaboratorTrustEnabled,
+    },
+  );
+  return {
+    ...summary,
+    trustedMarkerActors: configuredTrustedActors,
+    trustedMarkerActorsSource,
+  };
+}
+// CLI: emit the readiness report as JSON when invoked directly.
+if (import.meta.main) {
+  process.stdout.write(
+    `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
+  );
+}
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts. A plain `argv.lastIndexOf(flag)`
+ * only matches the exact bare token, so `--claim-id=1` would silently
+ * fail to count as an occurrence of `--claim-id` (Copilot review
+ * finding on this PR) -- checked here via an exact match OR a
+ * `${flag}=` prefix match, scanning from the end so the first hit is
+ * the true last occurrence.
+ */
+function findLastFlagOccurrenceIndex(argv, flag) {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+/**
+ * Resolve a canonical/deprecated flag pair using the pre-migration
+ * token-loop's exact assignment-order semantics: each occurrence
+ * overwrote the same field as the loop walked argv left to right, so
+ * whichever flag's LAST occurrence comes later in argv wins -- not
+ * "canonical always wins" -- when both spellings are given together.
+ * `-1` (never given) sorts before any real index, so an absent flag
+ * never wins against one that was actually passed.
+ */
+function resolveLastGivenAlias(
+  argv,
+  canonicalFlag,
+  canonicalValue,
+  deprecatedFlag,
+  deprecatedValue,
+) {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, PRE_MERGE_READINESS_FLAG_SPEC);
+  // Positive-integer guard shared by both numeric flags, preserving each
+  // flag's own custom "invalid <flag> value: <raw>" message (test-locked
+  // in tests/pre-merge-readiness.test.mts) rather than the wrapper's
+  // generic message.
+  const requirePositiveInteger = (token, flagName) => {
+    if (token === undefined) {
+      return null;
+    }
+    if (!/^[1-9]\d*$/.test(token)) {
+      throw new Error(`invalid ${flagName} value: ${token}`);
+    }
+    return Number(token);
+  };
+  // Deprecated aliases: both spellings are declared flags (see the spec
+  // above). warnDeprecatedFlag fires whenever the deprecated spelling is
+  // present at all, matching the pre-migration per-token loop exactly
+  // (which warned unconditionally the moment the deprecated token was
+  // seen, regardless of whether the canonical spelling also appeared).
+  // When BOTH spellings are given together, resolveLastGivenAlias below
+  // replicates the pre-migration token-loop's assignment-order semantics
+  // exactly: whichever flag's token appears LAST in argv wins (Codex
+  // review finding on this PR -- an earlier draft always preferred the
+  // canonical spelling here, which silently diverged from the original
+  // "last write wins" contract for this specific double-flag case).
+  const claimId = resolveLastGivenAlias(
+    argv,
+    '--claim-id',
+    values['claim-id'],
+    '--expected-claim-id',
+    values['expected-claim-id'],
+  );
+  const expectedClaimIdToken = values['expected-claim-id'];
+  if (expectedClaimIdToken !== undefined) {
+    warnDeprecatedFlag('--expected-claim-id', '--claim-id');
+  }
+  const agentId = resolveLastGivenAlias(
+    argv,
+    '--agent-id',
+    values['agent-id'],
+    '--expected-agent-id',
+    values['expected-agent-id'],
+  );
+  const expectedAgentIdToken = values['expected-agent-id'];
+  if (expectedAgentIdToken !== undefined) {
+    warnDeprecatedFlag('--expected-agent-id', '--agent-id');
+  }
+  return {
+    prNumber: requirePositiveInteger(values.pr, '--pr'),
+    claimIssueNumber: requirePositiveInteger(
+      values['claim-issue'],
+      '--claim-issue',
+    ),
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    iddAgentLogins: values['idd-agent-logins'] ?? '',
+    advisoryBotLogins: values['advisory-bot-logins'] ?? '',
+    expectedClaimId: claimId ?? '',
+    expectedAgentId: agentId ?? '',
+    nonce: values.nonce ?? '',
+    now: values.now ?? '',
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--nonce <token>] [--now <ISO8601>]
+  Deprecated aliases (one release): --expected-claim-id -> --claim-id, --expected-agent-id -> --agent-id
+
+  --nonce <token>  this session's own recorded activation-nonce (#1522): when
+                    given alongside --claim-id, the merge-time write-gate also
+                    requires it to equal the winning trusted
+                    <!-- activation-nonce: ... --> marker for that claim-id,
+                    catching a second, independent activation of the same
+                    claim-id as a collision. Omit --nonce, or leave it empty,
+                    to skip this comparison entirely (backward compatible).
+`);
+}
+/**
+ * Normalize a raw `gh api .../issues/{n}/comments` entry into the
+ * summarizer-shape `CommentLike` `buildPreMergeReadinessSummary`
+ * (protocol-helpers.mts) expects. Exported for direct unit testing (#1708):
+ * previously local-only and unreferenced by any test, so a REST
+ * field-mapping drift (e.g. `user.login` -> `author.login`) would surface
+ * only in production.
+ */
+export function normalizeComment(comment) {
+  return {
+    id: String(comment.id ?? ''),
+    author: { login: comment.user?.login ?? '' },
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    updatedAt: comment.updated_at ?? comment.created_at ?? '',
+  };
+}
+/**
+ * Normalize a raw claim-issue comment entry into the `CommentLike` shape
+ * the claim-validation gate expects. Deliberately narrower than
+ * {@link normalizeComment} (no `id`/`updatedAt`): the claim gate only ever
+ * reads `body`/`createdAt`/`author.login`. Exported for direct unit
+ * testing (#1708), see {@link normalizeComment}'s doc comment.
+ */
+export function normalizeClaimComment(comment) {
+  return {
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  };
+}
+/**
+ * Normalize a raw `gh api .../pulls/{n}/reviews` entry into the
+ * summarizer-shape `ReviewLike`. Exported for direct unit testing (#1708),
+ * see {@link normalizeComment}'s doc comment.
+ */
+export function normalizeReview(review) {
+  return {
+    author: { login: review.user?.login ?? '' },
+    state: review.state ?? '',
+    commitId: review.commit_id ?? '',
+    submittedAt: review.submitted_at ?? '',
+    createdAt: review.submitted_at ?? '',
+    updatedAt: review.updated_at ?? review.submitted_at ?? '',
+  };
+}
+/**
+ * Normalize a raw GraphQL `reviewThreads` node into the summarizer-shape
+ * `ThreadLike`. Exported for direct unit testing (#1708), see
+ * {@link normalizeComment}'s doc comment.
+ */
+export function normalizeThread(thread) {
+  return {
+    id: thread.id,
+    isResolved: Boolean(thread.isResolved),
+    updatedAt: '',
+    reviewerReopenedAt: inferReviewerReopenedAt(thread),
+    comments: {
+      pageInfo: {
+        hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage),
+      },
+      nodes: (thread.comments?.nodes ?? []).map((comment) => ({
+        author: { login: comment.author?.login ?? '' },
+        body: comment.body ?? '',
+        createdAt: comment.createdAt ?? '',
+        updatedAt: comment.updatedAt ?? comment.createdAt ?? '',
+        pullRequestReview: { id: comment.pullRequestReview?.id ?? null },
+      })),
+    },
+  };
+}
+function inferReviewerReopenedAt(thread) {
+  return thread.reviewerReopenedAt ?? '';
+}
+function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
+  const markerAuthors = [
+    ...new Set(
+      comments
+        .filter(
+          (comment) => operationalMarkerPrefix(comment.body ?? '') !== null,
+        )
+        .map((comment) => comment.user?.login ?? '')
+        .filter(Boolean),
+    ),
+  ];
+  return markerAuthors.filter((login) => {
+    const permission = safeGhText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).toLowerCase();
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+}
+/**
+ * Exported for direct unit testing (matching this file's established
+ * `fetchBranchRulesets`/`fetchGovernanceJson` injectable-fetch pattern) --
+ * `fetchPermission` defaults to the real live `gh api .../permission` call
+ * and is overridden in tests to simulate a 404 vs. a transient failure
+ * without mocking `execFileSync`.
+ */
+export function resolveEligibleCodeownerUserLogins(
+  owner,
+  repo,
+  logins,
+  fetchPermission = (login) =>
+    ghText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ),
+) {
+  let unreadable = false;
+  const eligible = normalizeTrustedMarkerLogins(logins).filter((login) => {
+    let permission;
+    try {
+      permission = fetchPermission(login).toLowerCase();
+    } catch (error) {
+      // A 404 means this login genuinely has no collaborator record on
+      // this repository (e.g. a stale CODEOWNERS entry for someone who
+      // was removed) -- the pre-#1521 behavior of excluding it is correct
+      // and unchanged. Any OTHER failure (403 permission denial, 5xx,
+      // timeout, network) cannot be told apart from "genuinely not a
+      // collaborator" by the caller, so it must not silently narrow the
+      // eligible set the same way -- flag `unreadable` instead.
+      if (deriveGhHttpStatus(error) === 404) {
+        return false;
+      }
+      unreadable = true;
+      return false;
+    }
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+  return { eligible, unreadable };
+}
+function fetchCodeownersText(owner, repo, ref) {
+  const payloads = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS'].map(
+    (path) => {
+      return ghApiJson(
+        `repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+        false,
+        [],
+        { allowHttpStatuses: [404] },
+      );
+    },
+  );
+  return selectCodeownersText(payloads);
+}
+/**
+ * Fetch each referenced ruleset's detail, discriminating a masked `404`
+ * (unreadable) from a genuine deletion race.
+ *
+ * Every `ruleset_id` passed in via `branchRules` was already confirmed to
+ * exist moments earlier by the `rules/branches/{base}` list read in the same
+ * call (see `collectPreMergeReadiness`), so a genuine deletion between that
+ * read and this one is possible but unlikely. That timing alone would not
+ * justify treating every `404` as unreadable -- the real justification is
+ * that the response itself cannot distinguish the two cases. GitHub's "Get a
+ * repository ruleset" reference documents only `200`/`404`/`500` for this
+ * endpoint -- no `403` --
+ * (<https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset>),
+ * the same masked-403-as-404 pattern `#1377` documented for the other two
+ * governance reads (see `fetchGovernanceJson`'s doc comment for the full
+ * citation set, including GitHub's REST troubleshooting guide). A `404`
+ * here is therefore **unreadable** by default: the ruleset is still dropped
+ * from the returned array (the caller has no usable detail either way, so
+ * `#1380` cannot invent one), but `unreadable` is set so
+ * `summarizeReviewerStates` can distinguish "no bypass configured" from
+ * "could not determine" instead of asserting an unjustified certain
+ * `deadlock`. `trustEmptyReads` (`ciGate.trustEmptyProtectionReads`, the
+ * same policy key `fetchGovernanceJson` reads) restores the pre-`#1380`
+ * trusting behavior.
+ *
+ * Any other thrown status (`403`, rate limit, transient failure, …) is
+ * still re-thrown unchanged, preserving the existing fail-closed behavior
+ * for an explicit permission error (`#1371`) instead of fabricating a "no
+ * ruleset" result that would silently over-block a legitimately configured
+ * bypass.
+ *
+ * The 404 must be discriminated on the *thrown* status: `gh api` writes a 404
+ * response body to stdout, so `allowHttpStatuses: [404]` would return that
+ * non-empty error object and the `Object.keys(...).length > 0` filter would
+ * keep it as a junk ruleset. Letting the 404 throw and matching it here yields
+ * the empty/skipped result the gate expects.
+ *
+ * `fetchRulesetDetail` is injectable for tests; production uses the default
+ * `gh api` call.
+ */
+export function fetchBranchRulesets(
+  owner,
+  repo,
+  branchRules,
+  trustEmptyReads = false,
+  fetchRulesetDetail = (path) =>
+    ghApiJson(path, false, ['-H', 'Accept: application/vnd.github+json']),
+) {
+  const rulesetPaths = [];
+  const seenPaths = new Set();
+  for (const rule of branchRules ?? []) {
+    const rulesetId = Number.parseInt(String(rule?.ruleset_id ?? ''), 10);
+    if (!Number.isInteger(rulesetId)) {
+      continue;
+    }
+    const path = resolveRulesetDetailPath(owner, repo, rule, rulesetId);
+    if (seenPaths.has(path)) {
+      continue;
+    }
+    seenPaths.add(path);
+    rulesetPaths.push(path);
+  }
+  let unreadable = false;
+  const value = rulesetPaths
+    .map((path) => {
+      try {
+        return fetchRulesetDetail(path);
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          if (!trustEmptyReads) {
+            unreadable = true;
+          }
+          return {};
+        }
+        throw error;
+      }
+    })
+    .filter((ruleset) => Object.keys(ruleset).length > 0);
+  return { value, unreadable };
+}
+function resolveViewerClassicBypassTeamSlugs(
+  owner,
+  viewerLogin,
+  branchProtection,
+) {
+  if (!viewerLogin) {
+    return [];
+  }
+  const teams =
+    branchProtection.required_pull_request_reviews
+      ?.bypass_pull_request_allowances?.teams ?? [];
+  const viewerTeams = new Set();
+  for (const team of teams) {
+    const slug = String(team?.slug ?? '')
+      .trim()
+      .toLowerCase();
+    if (!slug) {
+      continue;
+    }
+    const org = String(
+      team?.organization?.login ??
+        extractTeamOrgFromHtmlUrl(team?.html_url) ??
+        owner,
+    ).trim();
+    const state = safeGhText(
+      [
+        'api',
+        `orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}/memberships/${encodeURIComponent(viewerLogin)}`,
+        '--jq',
+        '.state',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).toLowerCase();
+    if (state === 'active') {
+      viewerTeams.add(slug);
+    }
+  }
+  return [...viewerTeams].sort();
+}
+function extractTeamOrgFromHtmlUrl(htmlUrl) {
+  const match = String(htmlUrl ?? '').match(/\/orgs\/([^/]+)\/teams\//);
+  return match?.[1] ?? '';
+}
+function fetchReviewThreads(owner, repo, prNumber) {
+  const nodes = [];
+  let cursor = null;
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  comments(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      body
+                      createdAt
+                      updatedAt
+                      author { login }
+                      pullRequestReview { id }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+      {
+        owner,
+        repo,
+        number: Number.parseInt(String(prNumber), 10),
+        cursor,
+      },
+    );
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        // hasNextPage with a missing thread id or cursor is a malformed
+        // payload; fail fast with a clear message instead of a confusing
+        // GraphQL error or a silently truncated thread.
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes.push(
+          ...fetchThreadCommentPages(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        );
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) {
+      break;
+    }
+    // hasNextPage with a missing cursor would re-fetch the first page
+    // forever; fail fast on the malformed payload instead.
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+function fetchThreadCommentPages(threadId, afterCursor) {
+  const nodes = [];
+  let cursor = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  body
+                  createdAt
+                  updatedAt
+                  author { login }
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }`,
+      { id: threadId, cursor },
+    );
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
+  }
+  return nodes;
+}
+function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+function ghJson(args, options = {}) {
+  return JSON.parse(runGh(args, options).trim() || '[]');
+}
+function ghApiJson(path, paginate = false, extraArgs = [], options = {}) {
+  const args = ['api', path, ...extraArgs];
+  if (paginate) {
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    args.push('--paginate', '--jq', '.[]');
+  }
+  const raw = runGh(args, options).trim();
+  if (!raw) {
+    return paginate ? [] : {};
+  }
+  if (paginate) {
+    return parsePaginatedGhNdjson(raw);
+  }
+  return JSON.parse(raw);
+}
+/**
+ * Decide how a thrown `gh` failure is tolerated, returning the string result to
+ * use or `undefined` when the caller must re-throw.
+ *
+ * - `allowHttpStatuses` matches the HTTP status derived from the gh error via
+ *   the shared `deriveGhHttpStatus` (the same extractor `fetchBranchRulesets`
+ *   uses) and yields an **empty** string. `gh api` writes the JSON error body to
+ *   stdout on a non-2xx response (a 404 prints `{"message":"Not Found",…}`), so
+ *   returning that body would make `ghApiJson` parse the error object instead of
+ *   `{}` / `[]`. An allowed status never carries useful data, so the empty
+ *   result lets `ghApiJson` resolve it to an empty object / array.
+ * - `allowStatuses` matches the process exit code and returns stdout **only**
+ *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
+ *   yet still print the data, e.g. the checks rollup).
+ *
+ * The HTTP-status branch is checked **first**: an explicitly tolerated HTTP
+ * status must always yield empty, even when the exit code is also tolerated and
+ * the error body on stdout happens to be JSON. Checking `allowStatuses` first
+ * would return that error body and reintroduce the very parsing bug this guards
+ * against. No current caller sets both options, so the order is behavior-neutral
+ * today; it keeps the resolver correct for any future combined call.
+ */
+export function resolveToleratedGhFailure(error, options = {}) {
+  const httpStatus = deriveGhHttpStatus(error);
+  if (
+    httpStatus !== null &&
+    (options.allowHttpStatuses ?? []).includes(httpStatus)
+  ) {
+    return '';
+  }
+  const status = Number(error?.status ?? -1);
+  if ((options.allowStatuses ?? []).includes(status)) {
+    const stdout = String(error?.stdout ?? '');
+    if (/^\s*[[{]/.test(stdout)) {
+      return stdout;
+    }
+  }
+  return undefined;
+}
+function runGh(args, options = {}) {
+  try {
+    return ghText(args, {
+      ...GH_TEXT_LOOP_OPTIONS,
+      ...(args.includes('--paginate')
+        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
+        : {}),
+    });
+  } catch (error) {
+    const tolerated = resolveToleratedGhFailure(error, options);
+    if (tolerated !== undefined) {
+      return tolerated;
+    }
+    throw error;
+  }
+}
+function splitCsv(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
+}
+function readCollaboratorTrustEnabled() {
+  try {
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
+  } catch {
+    // Fall through to env-var fallback.
+  }
+  return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+// Configured waivable external-check selectors (`ciGate.externalChecks.
+// waivable`). The F2 gate only lets a valid waiver fold a check into
+// `requiredChecksPassing` when that check sits on this surface; an absent or
+// unreadable config yields an empty list (nothing waivable).
+function readWaivableCheckSelectors() {
+  try {
+    return [
+      ...normalizePolicyConfig(
+        JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      ).ciGate.externalChecks.waivable,
+    ];
+  } catch {
+    return [];
+  }
+}
+// Configured external-check waiver validity window (`ciGate.
+// externalCheckWaivers.maxValidity`). The consume side re-enforces it so a
+// waiver whose `expiresAt - createdAt` outlives the policy window cannot count
+// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an absent
+// or unreadable config falls back to the same authoring default.
+function readExternalCheckWaiverMaxValidity() {
+  try {
+    return normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).ciGate.externalCheckWaivers.maxValidity;
+  } catch {
+    return 'PT24H';
+  }
+}
+// Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
+// to milliseconds so the write-gate claim resolver honors it instead of the
+// hardcoded 24h `isStaleAt` default. Reuses the shared `loadIddConfig`
+// loader (already imported by this file) instead of a per-helper
+// `readFileSync + JSON.parse` copy; `loadIddConfig` already fails safe to
+// `null` and `normalizePolicyConfig(null)` already defaults to `PT24H`, so
+// no separate try/catch is needed here. An absent, unreadable, or
+// unparseable config falls back to the shared `DEFAULT_STALE_AGE_MS`
+// (protocol-helpers.mts) rather than a second local 24h literal, so
+// behavior is unchanged for repos on the default and there is exactly one
+// hardcoded-24h source of truth.
+function readClaimStaleAgeMs() {
+  const staleAge = normalizePolicyConfig(loadIddConfig()).claimTiming.staleAge;
+  return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
+}
+// Configured governance-read trust opt-in (`ciGate.trustEmptyProtectionReads`,
+// #1377). Reuses the shared `loadIddConfig` loader (already imported by this
+// file); an absent, unreadable, or unparseable config fails safe to the
+// `false` default via `normalizePolicyConfig(null)`, matching
+// `readClaimStaleAgeMs`'s pattern above.
+function readTrustEmptyProtectionReads() {
+  return (
+    normalizePolicyConfig(loadIddConfig()).ciGate.trustEmptyProtectionReads ===
+    true
+  );
+}
+// Configured source-pinned required-check trust opt-in
+// (`ciGate.trustSourcePinnedRequiredChecks`, #1689). Same pattern as
+// `readTrustEmptyProtectionReads` above; see `summarizeRequiredChecks`'s
+// (protocol-helpers.mts) doc comment on the option of the same name for the
+// full rationale.
+function readTrustSourcePinnedRequiredChecks() {
+  return (
+    normalizePolicyConfig(loadIddConfig()).ciGate
+      .trustSourcePinnedRequiredChecks === true
+  );
+}
+/**
+ * Fetch a branch-governance read that GitHub's documented status-code
+ * contracts never pair with `403` — `branches/{branch}/protection`
+ * documents only `200`/`404`, and `rules/branches/{branch}` can also
+ * surface a permission failure as `404` per GitHub's REST troubleshooting
+ * guide (see `idd-ci.instructions.md`'s Required-check discovery step 4
+ * for the citations `#1377` gathered). Because the response body cannot
+ * distinguish "genuinely nothing configured" from "the token cannot read
+ * this," a `404` here is **unreadable** by default: the caller still gets
+ * a valid empty shape (`emptyValue`) to keep working with, but
+ * `unreadable` is set so the CI gate can fail closed instead of silently
+ * accepting a vacuous "no required checks" result. `trustEmptyReads`
+ * (from `ciGate.trustEmptyProtectionReads`) restores the pre-`#1377`
+ * trusting behavior for a repository whose operator has git-committed
+ * that its automation token is known to carry full read access to these
+ * endpoints — an explicit, auditable policy decision, not a runtime
+ * signal a narrower-scoped token could spoof. Any other thrown status
+ * (`403`, `500`, a transient failure, …) still re-throws unchanged,
+ * preserving `#1363`'s existing fail-closed behavior for an explicit
+ * permission error.
+ *
+ * `fetchJson` is injectable for tests (mirrors `fetchBranchRulesets`'s
+ * `fetchRulesetDetail` parameter); production uses the default `gh api` call.
+ */
+export function fetchGovernanceJson(
+  path,
+  paginate,
+  trustEmptyReads,
+  emptyValue,
+  fetchJson = (p, pg) => ghApiJson(p, pg, []),
+) {
+  try {
+    return { value: fetchJson(path, paginate), unreadable: false };
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return { value: emptyValue, unreadable: !trustEmptyReads };
+    }
+    throw error;
+  }
+}

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1,0 +1,5798 @@
+// idd-generated-from: src/scripts/protocol-helpers.mts
+//
+// The scripts/protocol-helpers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { Buffer } from 'node:buffer';
+import {
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  normalizeAdvisoryWaitRuntimeOptions,
+} from './advisory-wait-policy.mjs';
+
+// Re-exported so callers that already import advisory-bot-identity helpers
+// from this façade (merged-pr-feedback-sweep.mts,
+// disposition-non-review-notices.mts) can get the shared default-logins list
+// from the same module instead of reaching into advisory-wait-policy.mts
+// directly.
+export { DEFAULT_ADVISORY_BOT_LOGINS } from './advisory-wait-policy.mjs';
+// Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
+// marker render/parse primitive now lives in the marker-helpers module.
+// Re-exporting it here keeps every existing call site importing from
+// protocol-helpers unchanged. The named imports below are this module's own
+// internal uses of those moved names; see marker-helpers for the layering
+// rule (it must never import back from this file).
+export * from './marker-helpers.mjs';
+
+import {
+  findActivationNonceWinner,
+  IDD_AGENT_DERIVED_MARKERS,
+  isValidIsoTimestamp,
+  operationalMarkerPrefix,
+  operationalMarkerPrefixByStart,
+  parseClaimComment,
+  parseExternalCheckWaiverComment,
+  parseForcedHandoffComment,
+  parseReleaseComment,
+  parseReviewWatermarkComment,
+} from './marker-helpers.mjs';
+import {
+  getReviewEscalationChangesRequestedPolicy,
+  parseIsoDurationToMs,
+} from './policy-helpers.mjs';
+export const LIVE_STATUS_DIGEST_MARKER = '<!-- idd-live-status: current -->';
+const REVIEW_BOT_LOGINS = new Set([
+  'coderabbitai',
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector',
+  'chatgpt-codex-connector[bot]',
+]);
+const UNSAFE_TEXT_RULES = [
+  {
+    pattern: /\*\*Awaiting maintainer decision\*\*/i,
+    reason: 'contains an awaiting-maintainer-decision marker',
+  },
+  {
+    pattern: /\bactive hold\b/i,
+    reason: 'contains active hold context',
+  },
+  {
+    pattern:
+      /\bfailed[- ]ci\b|\bfailing ci\b|\bci failure\b|\bci failed\b|\bfailed checks?\b/i,
+    reason: 'contains failed-CI context',
+  },
+];
+const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
+export function parsePaginatedGhNdjson(raw) {
+  const text = String(raw ?? '').trim();
+  if (!text) {
+    return [];
+  }
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .flatMap((line) => {
+      const value = JSON.parse(line);
+      return Array.isArray(value) ? value : [value];
+    });
+}
+function matchCheckSelectorLocal(name, selector, matchMode) {
+  const n = String(name ?? '').trim();
+  const s = String(selector ?? '').trim();
+  if (!n || !s) return false;
+  // An explicit matchMode wins; otherwise infer glob from a `*` in the
+  // selector (the legacy behavior every existing two-argument caller relies
+  // on, e.g. waiver-selector vs check-name coverage matching).
+  const useGlob =
+    matchMode === undefined ? s.includes('*') : matchMode === 'glob';
+  if (useGlob) {
+    const source = s.replace(/[|\\{}()[\]^$+?.]/g, '\\$&').replace(/\*/g, '.*');
+    return new RegExp(`^${source}$`).test(n);
+  }
+  return n === s;
+}
+/**
+ * True when a concrete check `name` matches any configured waivable selector,
+ * honoring each selector's own `matchMode`. Used to gate whether a present
+ * check sits on the policy's waivable surface.
+ */
+function isCheckNameConfiguredWaivable(name, waivableSelectors) {
+  return waivableSelectors.some((sel) =>
+    matchCheckSelectorLocal(
+      name,
+      sel?.selector,
+      sel?.matchMode === 'glob' ? 'glob' : 'exact',
+    ),
+  );
+}
+/**
+ * True when a waiver's `checkSelector` can name a check that the policy
+ * declared waivable. Unlike a concrete check name, a waiver selector may
+ * itself be a glob, so this tests both directions: the waiver selector
+ * against each configured pattern, and each configured selector against the
+ * waiver pattern (glob inferred from `*`). Either direction means the two
+ * selectors can resolve to a common check — e.g. a glob waiver `Code*`
+ * overlaps an exact waivable `CodeRabbit`. This mirrors the creation-path
+ * gate in `planExternalCheckWaiver`, which validates glob waivers against the
+ * actual matched checks, so a legitimately created waiver is not wrongly
+ * bucketed as `notConfigured` at consumption.
+ */
+function waiverSelectorOverlapsConfiguredWaivable(
+  waiverSelector,
+  waivableSelectors,
+) {
+  return waivableSelectors.some(
+    (sel) =>
+      matchCheckSelectorLocal(
+        waiverSelector,
+        sel?.selector,
+        sel?.matchMode === 'glob' ? 'glob' : 'exact',
+      ) || matchCheckSelectorLocal(sel?.selector, waiverSelector),
+  );
+}
+export function summarizeExternalCheckWaivers(
+  comments,
+  {
+    prHeadSha = '',
+    activeClaimId = '',
+    trustedMarkerLogins = [],
+    now = '',
+    waivableSelectors = null,
+    maxValidity = '',
+  } = {},
+) {
+  const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
+  const nowMs = isValidIsoTimestamp(now) ? new Date(now).getTime() : Date.now();
+  const headShaLower = String(prHeadSha).toLowerCase();
+  const activeClaimLower = String(activeClaimId);
+  const maxValidityMs = parseIsoDurationToMs(maxValidity);
+  const valid = [];
+  const expired = [];
+  const wrongHead = [];
+  const wrongClaim = [];
+  const unauthorized = [];
+  const malformed = [];
+  const notConfigured = [];
+  for (const comment of comments ?? []) {
+    const body = String(comment?.body ?? '');
+    // Prefilter on a marker-start, case-insensitive match aligned with
+    // parseExternalCheckWaiverComment's anchor — a case-sensitive substring
+    // skipped odd-cased markers and misclassified prose mentions as malformed.
+    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
+    const authorLogin = String(
+      comment?.author?.login ?? comment?.user?.login ?? '',
+    )
+      .trim()
+      .toLowerCase();
+    const createdAt = String(comment?.created_at ?? comment?.createdAt ?? '');
+    const parsed = parseExternalCheckWaiverComment(body, createdAt);
+    if (!parsed) {
+      malformed.push({ authorLogin, bodyPreview: body.slice(0, 120) });
+      continue;
+    }
+    if (!trustedSet.has(authorLogin)) {
+      unauthorized.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
+    // Fail closed on an empty head SHA: an unbound waiver must never ride
+    // along when the gate cannot prove it targets the current PR HEAD.
+    if (!headShaLower || parsed.headSha !== headShaLower) {
+      wrongHead.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        waiverHeadSha: parsed.headSha,
+      });
+      continue;
+    }
+    // Fail closed on an empty active claim: when no claim resolves at the gate
+    // (`activeClaimLower === ''`), a waiver cannot be bound to an owner and is
+    // rejected rather than passing unbound. #1905's one narrow exception: the
+    // case-insensitive literal sentinel `none` in the marker's claimId field
+    // explicitly declares "this is a claimless waiver" -- it satisfies the
+    // claim-binding check ONLY when the gate independently confirms no claim
+    // resolves (`!activeClaimLower`). A non-empty `activeClaimLower` always
+    // requires an exact `claimId` match; `none` is never accepted there, so
+    // the sentinel can never route around a genuine claim mismatch. Every
+    // other combination is unchanged: a non-`none` claimId on an unclaimed PR
+    // still falls into `wrongClaim` -- the exact regression #1077 fixed.
+    const claimIdIsNoneSentinel = parsed.claimId.toLowerCase() === 'none';
+    const claimBindingSatisfied = activeClaimLower
+      ? parsed.claimId === activeClaimLower
+      : claimIdIsNoneSentinel;
+    if (!claimBindingSatisfied) {
+      wrongClaim.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        waiverClaimId: parsed.claimId,
+      });
+      continue;
+    }
+    const expiresMs = new Date(parsed.expiresAt).getTime();
+    if (!Number.isFinite(expiresMs) || expiresMs <= nowMs) {
+      expired.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
+    // Re-enforce the configured maxValidity window at consume time. Authoring
+    // already clamps `expiresAt - createdAt` (planExternalCheckWaiver's
+    // withinMaxValidity), but a hand-edited or policy-drifted marker can still
+    // carry an over-long window, so the shared merge gate re-checks it and
+    // fails closed when the creation timestamp is unknown (`createdAt: 'none'`).
+    if (typeof maxValidityMs === 'number' && Number.isFinite(maxValidityMs)) {
+      const createdMs = new Date(parsed.createdAt).getTime();
+      if (
+        !Number.isFinite(createdMs) ||
+        expiresMs - createdMs > maxValidityMs
+      ) {
+        expired.push({
+          authorLogin,
+          checkSelector: parsed.checkSelector,
+          expiresAt: parsed.expiresAt,
+        });
+        continue;
+      }
+    }
+    // When the policy declares its waivable surface, a valid waiver still only
+    // counts when its selector can name a configured-waivable check; otherwise
+    // it is reported but never folds a check in. The overlap test treats the
+    // waiver selector as a possible glob so a `Code*` waiver still matches an
+    // exact `CodeRabbit` surface. A null/undefined list disables the gate
+    // (legacy callers), an empty list waives nothing.
+    if (
+      Array.isArray(waivableSelectors) &&
+      !waiverSelectorOverlapsConfiguredWaivable(
+        parsed.checkSelector,
+        waivableSelectors,
+      )
+    ) {
+      notConfigured.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
+    valid.push({
+      authorLogin,
+      checkSelector: parsed.checkSelector,
+      reason: parsed.reason,
+      expiresAt: parsed.expiresAt,
+    });
+  }
+  return {
+    valid,
+    expired,
+    wrongHead,
+    wrongClaim,
+    unauthorized,
+    malformed,
+    notConfigured,
+  };
+}
+export function findLiveStatusDigestComments(comments) {
+  return comments.filter((comment) => {
+    return firstLine(comment.body ?? '') === LIVE_STATUS_DIGEST_MARKER;
+  });
+}
+export function renderLiveStatusDigest(fields) {
+  const normalized = normalizeLiveStatusDigestFields(fields);
+  return `${LIVE_STATUS_DIGEST_MARKER}
+
+| Field | Value |
+| --- | --- |
+| Phase | ${escapeMarkdownTableCell(normalized.phase)} |
+| Claim | ${escapeMarkdownTableCell(normalized.claim)} |
+| Branch | ${escapeMarkdownTableCell(normalized.branch)} |
+| Last checked | ${escapeMarkdownTableCell(normalized.lastChecked)} |
+| Open blockers | ${escapeMarkdownTableCell(normalized.openBlockers)} |
+| Next action | ${escapeMarkdownTableCell(normalized.nextAction)} |
+| Authoritative by | ${escapeMarkdownTableCell(normalized.authoritativeBy)} |
+`;
+}
+export function planLiveStatusDigestUpsert(comments, fields) {
+  const matches = findLiveStatusDigestComments(comments);
+  const nextBody = renderLiveStatusDigest(fields);
+  if (matches.length > 1) {
+    return {
+      action: 'duplicate',
+      canApply: false,
+      body: null,
+      duplicates: matches.map((comment) => ({
+        id: comment.id ?? null,
+        url: comment.html_url ?? comment.url ?? null,
+        createdAt: comment.created_at ?? comment.createdAt ?? null,
+        updatedAt: comment.updated_at ?? comment.updatedAt ?? null,
+      })),
+      repairPath: [
+        'Multiple current live status digest comments were found.',
+        'Do not delete or minimize any audit history during unattended execution.',
+        'Use trusted markers and GitHub state for workflow decisions until a maintainer selects one current digest and converts stale duplicate markers to non-current digest text.',
+      ].join(' '),
+    };
+  }
+  if (matches.length === 0) {
+    return {
+      action: 'create',
+      canApply: true,
+      body: nextBody,
+      duplicates: [],
+    };
+  }
+  const [current] = matches;
+  if (sameDigestBody(current.body ?? '', nextBody)) {
+    return {
+      action: 'noop',
+      canApply: true,
+      body: nextBody,
+      commentId: current.id ?? null,
+      url: current.html_url ?? current.url ?? null,
+      duplicates: [],
+    };
+  }
+  return {
+    action: 'update',
+    canApply: true,
+    body: nextBody,
+    commentId: current.id ?? null,
+    url: current.html_url ?? current.url ?? null,
+    duplicates: [],
+  };
+}
+/**
+ * Orchestrate the apply-time live-status-digest upsert: re-fetch and
+ * re-plan against the latest comments, then revalidate the active claim
+ * immediately before the create/update mutation, so a claim release or
+ * takeover that lands during the replan's network fetch is caught before
+ * the write. The side-effecting I/O is injected so the ordering invariant
+ * — replan, then claim check, then mutation, and no write when the claim
+ * check throws — is unit-testable apart from the live `gh` calls.
+ */
+export function applyDigestUpsert(io) {
+  const planned = io.refetchAndPlan();
+  if (planned.action === 'duplicate') {
+    return { planned, outcome: 'duplicate' };
+  }
+  if (!io.skipClaimCheck) {
+    io.assertClaim();
+  }
+  if (planned.action === 'create') {
+    const created = io.createComment(planned.body);
+    return {
+      planned,
+      outcome: 'created',
+      commentId: created.id ?? null,
+      url: created.html_url ?? created.url ?? null,
+    };
+  }
+  if (planned.action === 'update') {
+    if (planned.commentId === undefined || planned.commentId === null) {
+      throw new Error(
+        'cannot update digest because the current comment id is missing',
+      );
+    }
+    const updated = io.updateComment(planned.commentId, planned.body);
+    return {
+      planned,
+      outcome: 'updated',
+      commentId: updated.id ?? planned.commentId,
+      url: updated.html_url ?? updated.url ?? planned.url ?? null,
+    };
+  }
+  return { planned, outcome: 'noop' };
+}
+export function unsafeTextReason(body) {
+  for (const rule of UNSAFE_TEXT_RULES) {
+    if (rule.pattern.test(body)) {
+      return rule.reason;
+    }
+  }
+  return null;
+}
+export function isKnownReviewBot(login) {
+  const normalized = login.toLowerCase();
+  return (
+    REVIEW_BOT_LOGINS.has(normalized) ||
+    normalized.startsWith('copilot-pull-request-reviewer')
+  );
+}
+export function isCodeRabbitLogin(login) {
+  const normalized = login.toLowerCase();
+  return normalized === 'coderabbitai' || normalized === 'coderabbitai[bot]';
+}
+// The exact CodeRabbit summary-walkthrough marker. CodeRabbit prefixes its
+// auto-generated review summary with this HTML comment (distinct from the
+// `rate limited by coderabbit.ai` notice marker). Single-sourced here so the
+// comment-minimization classifier (`classifyRegularBotComment`) and the
+// disposition-evidence summary predicate (`isReviewSummaryComment`) recognize
+// byte-for-byte the same marker and cannot drift.
+export const CODERABBIT_SUMMARY_MARKER =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
+export function classifyRegularBotComment(
+  comment,
+  comments,
+  threads,
+  options = {},
+) {
+  const author = comment.author?.login ?? '';
+  if (!isCodeRabbitLogin(author)) {
+    return null;
+  }
+  if (hasUnresolvedKnownBotThreads(threads)) {
+    return null;
+  }
+  const body = (comment.body ?? '').trimStart();
+  if (body.startsWith(CODERABBIT_SUMMARY_MARKER)) {
+    if (/No actionable comments were generated/i.test(body)) {
+      return {
+        classifier: 'RESOLVED',
+        reason: 'CodeRabbit completed summary reported no actionable comments',
+      };
+    }
+    if (
+      hasExplicitDispositionAfter(comment, comments, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      }) ||
+      hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      })
+    ) {
+      return {
+        classifier: 'RESOLVED',
+        reason:
+          'CodeRabbit completed summary has matched IDD disposition evidence',
+      };
+    }
+    return null;
+  }
+  if (
+    body.startsWith('<!-- This is an auto-generated reply by CodeRabbit -->')
+  ) {
+    if (
+      /\b(Review triggered|Sure! I'll review|I'll review)\b/i.test(body) &&
+      hasExplicitDispositionAfter(comment, comments, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      })
+    ) {
+      return {
+        classifier: 'OUTDATED',
+        reason:
+          'stale CodeRabbit review-trigger acknowledgement after completed review',
+      };
+    }
+  }
+  return null;
+}
+export function indexLatestGatingReviewsByAuthor(reviews) {
+  const index = new Map();
+  for (const review of reviews) {
+    const state = String(review.state ?? '');
+    if (state === 'COMMENTED' || state === 'PENDING') {
+      continue;
+    }
+    const author = review.author?.login?.toLowerCase();
+    if (!author) {
+      continue;
+    }
+    const effectiveSubmittedAt = normalizeGatingReviewTimestamp(review, state);
+    if (!effectiveSubmittedAt) {
+      continue;
+    }
+    const current = index.get(author);
+    const currentTime = current
+      ? Date.parse(current.submittedAt ?? current.submitted_at ?? '')
+      : Number.NEGATIVE_INFINITY;
+    const reviewTime = Date.parse(effectiveSubmittedAt);
+    if (!current || reviewTime >= currentTime) {
+      index.set(author, {
+        ...review,
+        submittedAt: effectiveSubmittedAt,
+        submitted_at: effectiveSubmittedAt,
+      });
+    }
+  }
+  return index;
+}
+export function indexThreadsByReview(threads, options = {}) {
+  const index = new Map();
+  for (const thread of threads) {
+    const reviewIds = new Set(
+      (thread.comments?.nodes ?? [])
+        .map((comment) => comment.pullRequestReview?.id)
+        .filter(Boolean),
+    );
+    for (const reviewId of reviewIds) {
+      const current = index.get(reviewId) ?? {
+        total: 0,
+        unresolved: 0,
+        missingDisposition: 0,
+        incomplete: false,
+        threadIds: [],
+      };
+      current.total += 1;
+      if (!thread.isResolved) {
+        current.unresolved += 1;
+      }
+      if (
+        !hasFreshDisposition(thread, {
+          isDispositionAuthor: options.isDispositionAuthor,
+        })
+      ) {
+        current.missingDisposition += 1;
+      }
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        current.incomplete = true;
+      }
+      current.threadIds.push(thread.id);
+      index.set(reviewId, current);
+    }
+  }
+  return index;
+}
+export function routeRejectedChangesRequestedReview(input) {
+  const escalationPolicy = getReviewEscalationChangesRequestedPolicy(
+    input?.policyConfig ?? {},
+  );
+  const firstEscalationWindowMs = escalationPolicy.escalateAfterMs;
+  const postEscalationWindowMs = escalationPolicy.releaseAfterEscalationMs;
+  const totalWindowLabel = formatDurationLabel(
+    firstEscalationWindowMs + postEscalationWindowMs,
+  );
+  const firstWindowLabel = formatDurationLabel(firstEscalationWindowMs);
+  const reviewState = String(input.reviewState ?? '');
+  if (reviewState !== 'CHANGES_REQUESTED') {
+    return {
+      route: 'proceed',
+      reason: 'changes-requested state already cleared',
+    };
+  }
+  const reviewerDisposition = String(input.reviewerDisposition ?? 'none');
+  if (reviewerDisposition === 'disagreed') {
+    return {
+      route: 'return-to-e1',
+      reason:
+        'reviewer disagreed with the rejection and the feedback must return to triage',
+    };
+  }
+  if (reviewerDisposition === 'agreed-state-cleared') {
+    return {
+      route: 'hold-await-state-clear',
+      reason:
+        'reviewer agreement alone does not clear a changes-requested state',
+    };
+  }
+  if (reviewerDisposition === 'agreed-state-unchanged') {
+    return {
+      route: 'hold-await-state-clear',
+      reason:
+        'reviewer agreement alone does not clear a changes-requested state',
+    };
+  }
+  const maintainerDisposition = String(input.maintainerDisposition ?? 'none');
+  if (maintainerDisposition === 'agreed-state-unchanged') {
+    return {
+      route: 'hold-await-state-clear',
+      reason:
+        'maintainer agreement does not clear the original changes-requested state',
+    };
+  }
+  const elapsedMs =
+    Date.parse(input.now ?? '') -
+    Date.parse(input.rejectionCommentCreatedAt ?? '');
+  if (!Number.isFinite(elapsedMs)) {
+    return {
+      route: 'hold-for-evidence',
+      reason:
+        'elapsed time cannot be computed for the rejected changes-requested review',
+    };
+  }
+  if (elapsedMs < firstEscalationWindowMs) {
+    return {
+      route: 'hold-before-escalation',
+      reason: `still within the first ${firstWindowLabel} after the rejection reply`,
+    };
+  }
+  const escalationElapsedMs =
+    Date.parse(input.now ?? '') -
+    Date.parse(input.escalationCommentCreatedAt ?? '');
+  if (!Number.isFinite(escalationElapsedMs)) {
+    return {
+      route: 'escalate-maintainer',
+      reason: `the changes-requested review is still blocking after ${firstWindowLabel} with no reviewer response`,
+    };
+  }
+  if (escalationElapsedMs < postEscalationWindowMs) {
+    return {
+      route: 'hold-after-escalation',
+      reason: `still within ${formatDurationLabel(postEscalationWindowMs)} of the maintainer escalation comment`,
+    };
+  }
+  return {
+    route: 'label-and-release',
+    reason: `the changes-requested review is still blocking after ${totalWindowLabel} with no escalation response`,
+  };
+}
+function formatDurationLabel(milliseconds) {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
+    return '0 minutes';
+  }
+  if (milliseconds % (60 * 60 * 1000) === 0) {
+    const hours = milliseconds / (60 * 60 * 1000);
+    return `${hours} hour${hours === 1 ? '' : 's'}`;
+  }
+  if (milliseconds % (60 * 1000) === 0) {
+    const minutes = milliseconds / (60 * 1000);
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  const seconds = milliseconds / 1000;
+  return `${seconds} second${seconds === 1 ? '' : 's'}`;
+}
+export function diffReviewSnapshot(snapshot, live) {
+  if (String(live.headSha ?? '') !== String(snapshot.headSha ?? '')) {
+    return { route: 'return-to-e1', reason: 'head-changed' };
+  }
+  const snapshotMax = normalizeComparableTimestamp(
+    snapshot.maxActivityUpdatedAt,
+  );
+  const liveMax = normalizeComparableTimestamp(live.maxActivityUpdatedAt);
+  const snapshotCount = Number(snapshot.totalItemCount ?? 0);
+  const liveCount = Number(live.totalItemCount ?? 0);
+  // Structural ack-only carve-out (#858): when the only activity newer
+  // than the snapshot is post-disposition advisory-bot acknowledgement
+  // evidence, fall back to the effective values instead of re-opening.
+  // Absent evidence keeps the legacy behavior unchanged (fail-closed).
+  const ackItems = Array.isArray(live.ackOnly?.items) ? live.ackOnly.items : [];
+  const ackEvidencePresent =
+    live.ackOnly?.dispositionsPresent === true && ackItems.length > 0;
+  const effectiveMax = normalizeComparableTimestamp(
+    live.effective?.maxActivityUpdatedAt ?? 'none',
+  );
+  let ackOnlyApplied = false;
+  if (snapshotMax === 'none' && liveCount > 0) {
+    return { route: 'return-to-e1', reason: 'snapshot-was-empty-now-nonempty' };
+  }
+  if (
+    typeof snapshotMax === 'number' &&
+    liveCount > 0 &&
+    (liveMax === null || liveMax === 'none')
+  ) {
+    return { route: 'return-to-e1', reason: 'missing-live-activity-evidence' };
+  }
+  if (
+    typeof snapshotMax === 'number' &&
+    typeof liveMax === 'number' &&
+    liveMax > snapshotMax
+  ) {
+    const effectiveCurrent =
+      ackEvidencePresent &&
+      typeof live.effective === 'object' &&
+      live.effective !== null &&
+      (effectiveMax === 'none' ||
+        (typeof effectiveMax === 'number' && effectiveMax <= snapshotMax));
+    if (!effectiveCurrent) {
+      return { route: 'return-to-e1', reason: 'newer-activity' };
+    }
+    ackOnlyApplied = true;
+  }
+  if (liveCount > snapshotCount) {
+    // Only ack comments newer than the snapshot max may explain count
+    // growth; older acks were already inside the snapshot's count.
+    const ackNewerCount = ackItems.filter(
+      (item) =>
+        item.kind === 'comment' &&
+        isValidIsoTimestamp(item.activityAt) &&
+        typeof snapshotMax === 'number' &&
+        compareIsoTimestamps(item.activityAt, snapshot.maxActivityUpdatedAt) >
+          0,
+    ).length;
+    if (!(ackEvidencePresent && liveCount - ackNewerCount <= snapshotCount)) {
+      return { route: 'return-to-e1', reason: 'same-timestamp-count-growth' };
+    }
+    ackOnlyApplied = true;
+  }
+  const snapshotCi = normalizeComparableTimestamp(
+    snapshot.latestPassingCiCompletedAt ?? snapshot.latestCiCompletedAt,
+  );
+  const liveCi = normalizeComparableTimestamp(
+    live.latestPassingCiCompletedAt ?? live.latestCiCompletedAt,
+  );
+  if (snapshotCi === null || liveCi === null) {
+    return { route: 'return-to-e1', reason: 'missing-ci-evidence' };
+  }
+  if (snapshotCi !== liveCi) {
+    return { route: 'return-to-e1', reason: 'ci-pass-drift' };
+  }
+  return {
+    route: 'proceed',
+    reason: ackOnlyApplied ? 'ack-only-post-disposition' : 'snapshot-current',
+  };
+}
+export function classifyReviewThreadForGate(thread, options = {}) {
+  if (thread.isResolved) {
+    return { classification: 'resolved' };
+  }
+  if (thread.comments?.pageInfo?.hasNextPage) {
+    return { classification: 'actionable-blocking' };
+  }
+  const comments = thread.comments?.nodes ?? [];
+  const latestComment = comments.at(-1) ?? null;
+  const latestCommentAt = normalizeComparableTimestamp(
+    latestComment?.createdAt,
+  );
+  const latestAuthor = String(latestComment?.author?.login ?? '').toLowerCase();
+  const iddAgentLogins = new Set(
+    (options.iddAgentLogins ?? [])
+      .map((login) => String(login ?? '').toLowerCase())
+      .filter(Boolean),
+  );
+  const prAuthorLogin = String(options.prAuthorLogin ?? '').toLowerCase();
+  const latestIsIddAgent = iddAgentLogins.has(latestAuthor);
+  const latestIsPrAuthor =
+    Boolean(prAuthorLogin) && latestAuthor === prAuthorLogin;
+  let latestAmdIndex = -1;
+  for (let index = 0; index < comments.length; index += 1) {
+    const comment = comments[index];
+    const authorLogin = String(comment.author?.login ?? '').toLowerCase();
+    if (
+      iddAgentLogins.has(authorLogin) &&
+      AMD_MARKER_PATTERN.test(String(comment.body ?? '').trimStart())
+    ) {
+      latestAmdIndex = index;
+    }
+  }
+  const reviewerReopenedAt = normalizeComparableTimestamp(
+    inferReviewerReopenedAt(thread),
+  );
+  const reopenedAfterLatestComment =
+    typeof reviewerReopenedAt === 'number' &&
+    (typeof latestCommentAt !== 'number' ||
+      reviewerReopenedAt > latestCommentAt);
+  const amdAwaitsMaintainer =
+    latestAmdIndex >= 0 &&
+    !reopenedAfterLatestComment &&
+    !comments.slice(latestAmdIndex + 1).some((comment) => {
+      const authorLogin = String(comment.author?.login ?? '').toLowerCase();
+      return !iddAgentLogins.has(authorLogin) && authorLogin !== prAuthorLogin;
+    });
+  if (amdAwaitsMaintainer) {
+    return { classification: 'amd-blocking' };
+  }
+  if (!(latestIsIddAgent || latestIsPrAuthor)) {
+    return { classification: 'actionable-blocking' };
+  }
+  if (reopenedAfterLatestComment) {
+    return { classification: 'actionable-blocking' };
+  }
+  if (options.requiresConversationResolution) {
+    if (latestIsIddAgent) {
+      return { classification: 'conversation-resolve-agent' };
+    }
+    return { classification: 'conversation-resolve-author' };
+  }
+  return { classification: 'awaiting-reviewer' };
+}
+// Pre-merge gate invariant (review threads -> `threads.actionableCount`):
+// MERGE-BLOCKING. `computePreMergeReadinessBlockers` fails closed unless
+// `actionableCount === 0`. An IDD agent's (or the PR author's) latest thread
+// comment classifies `awaiting-reviewer`, which does NOT add to
+// `actionableCount`, so a recognition error here can fail OPEN: globally
+// promoting a non-agent into `iddAgentLogins` makes that actor's genuine
+// unresolved feedback classify `awaiting-reviewer` and stop blocking (when
+// conversation resolution is not required; otherwise it stays a blocking
+// `conversation-resolve-*`). This gate classifies each thread by its own
+// latest-author identity (IDD agent / PR author), not by disposition
+// recognition; never globally promote a non-agent into `iddAgentLogins`. See
+// the consolidated invariants above `summarizeDispositionEvidenceForGate`
+// (#1182 / PR #1184).
+export function summarizeReviewThreadsForGate(threads, options = {}) {
+  const summary = {
+    actionableCount: 0,
+    awaitingReviewerCount: 0,
+    amdBlockingCount: 0,
+    conversationResolveAgentCount: 0,
+    conversationResolveAuthorCount: 0,
+    classifications: [],
+  };
+  for (const thread of threads) {
+    const result = classifyReviewThreadForGate(thread, options);
+    if (result.classification === 'resolved') {
+      continue;
+    }
+    summary.classifications.push({
+      id: thread.id,
+      classification: result.classification,
+    });
+    if (result.classification === 'actionable-blocking') {
+      summary.actionableCount += 1;
+      continue;
+    }
+    if (result.classification === 'amd-blocking') {
+      summary.amdBlockingCount += 1;
+      summary.actionableCount += 1;
+      continue;
+    }
+    if (result.classification === 'awaiting-reviewer') {
+      summary.awaitingReviewerCount += 1;
+      continue;
+    }
+    if (result.classification === 'conversation-resolve-agent') {
+      summary.actionableCount += 1;
+      summary.conversationResolveAgentCount += 1;
+      continue;
+    }
+    if (result.classification === 'conversation-resolve-author') {
+      summary.actionableCount += 1;
+      summary.conversationResolveAuthorCount += 1;
+    }
+  }
+  return summary;
+}
+function inferReviewerReopenedAt(thread) {
+  const explicit = String(thread.reviewerReopenedAt ?? '');
+  if (isValidIsoTimestamp(explicit)) {
+    return explicit;
+  }
+  return '';
+}
+export function hasFreshDisposition(thread, options = {}) {
+  // IMPORTANT: The default disposition-author predicate rejects known bots but accepts any human.
+  // For F2/F3 merge-gate contexts (E7 disposition evidence), callers MUST pass
+  // options.isDispositionAuthor with an IDD-scoped predicate (e.g., via summarizeDispositionEvidenceForGate).
+  // Callers that require IDD-only dispositions (e.g., audit-pr-cleanup) should pass:
+  //   { isDispositionAuthor: (login) => iddAgentLogins.has(login) }
+  // This design trades stricter default behavior for backward compatibility with utility functions.
+  const dispositionAuthorPredicate =
+    typeof options.isDispositionAuthor === 'function'
+      ? options.isDispositionAuthor
+      : (login) => !isKnownReviewBot(login);
+  const comments = thread.comments?.nodes ?? [];
+  // A resolved thread may be terminally dispositioned with the documented
+  // `**Rejection confirmed by maintainer**` marker instead of a fresh
+  // `**Rejected**` re-post; recognize it as a disposition ONLY when the thread
+  // is resolved (an unresolved thread still needs an explicit disposition).
+  const threadResolved = Boolean(thread.isResolved);
+  const isDisposition = (comment) =>
+    isDispositionComment(comment) ||
+    (threadResolved && isRejectionConfirmedDisposition(comment));
+  const latestFeedbackAt = maxIsoTimestamp(
+    comments
+      .filter((comment) => {
+        const authorLogin = String(comment.author?.login ?? '')
+          .trim()
+          .toLowerCase();
+        return !(
+          isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
+        );
+      })
+      .map((comment) => effectiveThreadCommentActivityAt(comment))
+      .filter(isValidIsoTimestamp),
+  );
+  return comments.some((comment) => {
+    const authorLogin = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
+      return false;
+    }
+    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
+    if (!isValidIsoTimestamp(dispositionActivityAt)) {
+      return false;
+    }
+    return (
+      !latestFeedbackAt ||
+      compareIsoTimestamps(dispositionActivityAt, latestFeedbackAt) > 0
+    );
+  });
+}
+// A disposition marker may carry a single interior punctuation char `[.!:]`
+// immediately before the closing `**` — `**Accepted.**` (natural English
+// "Accepted. Fixed in…"), `**Accepted:**`, `**Accepted!**`, and the `Rejected`
+// equivalents — so a reply that punctuates the marker is still recognized. The
+// tolerance is bounded to that one char before `**`, so an interior-text body
+// like `**Accepted by reviewer, but…**` is NOT matched (fail-closed: a false
+// positive is a false merge). Start-anchored (`^`), so the marker must be the
+// first bytes of the body each caller passes: `isDispositionComment` uses
+// `trimEnd()` only, so leading whitespace is NOT stripped (preserving the
+// marker-first-bytes contract), while the notice / summary predicates below
+// `trimStart()` first.
+const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
+const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
+export function isDispositionComment(comment) {
+  const body = (comment.body ?? '').trimEnd();
+  return (
+    DISPOSITION_ACCEPTED_PREFIX_RE.test(body) ||
+    DISPOSITION_REJECTED_PREFIX_RE.test(body)
+  );
+}
+// Terminal AMD-rejection marker. When a maintainer agrees with a rejection the
+// agent replies `**Rejection confirmed by maintainer** — {summary}` and resolves
+// the thread, with no separate `**Rejected**` re-post (per
+// idd-review-triage.instructions.md). Mirrors the regex in
+// review-disposition-verify so the F2/F3 gate recognizes the same marker.
+const REJECTION_CONFIRMED_BY_MAINTAINER_RE =
+  /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
+export function isRejectionConfirmedDisposition(comment) {
+  return REJECTION_CONFIRMED_BY_MAINTAINER_RE.test(
+    (comment.body ?? '').trimStart(),
+  );
+}
+export function isIddDispositionComment(comment) {
+  const author = comment.author?.login ?? '';
+  return isDispositionComment(comment) && !isKnownReviewBot(author);
+}
+// #1018 non-review-notice carry-forward classifiers.
+//
+// An advisory **non-review notice** — an advisory bot reporting it did not
+// review the current HEAD (rate-limit / usage-quota exhaustion / review-limit) —
+// carries no review result and is always dispositioned `**Rejected** — {bot} did
+// not review HEAD …` per the E6 non-review-notice rule. The gate uses the two
+// tight, fail-closed predicates below to let such a disposition carry forward
+// across HEAD changes (see `summarizeDispositionEvidenceForGate`), so a Codex
+// `updatedAt` bump or a re-posted CodeRabbit rate-limit summary does not re-flag
+// `missing-disposition-evidence` for a notice the agent already rejected.
+//
+// Both intentionally **under-match**: an unrecognized notice merely keeps the
+// existing per-push re-disposition churn (safe), while a false positive could
+// carry a stale disposition onto a real review (a false merge). Only
+// machine-generated, bot-specific signals match, and the notice predicate is
+// evaluated solely on advisory-bot-authored comments at the gate, so a human
+// reviewer comment is never reclassified as a notice.
+const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
+  // CodeRabbit rate-limit notice: the machine-generated marker (distinct from
+  // the `summarize by coderabbit.ai` review marker) and its warning heading.
+  /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
+  /^[>\s]*#{1,6}\s*Review limit reached\b/im,
+];
+// Codex usage / quota exhaustion for code reviews. Token-anchored on all
+// three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for
+// code reviews", each tolerant of interposed wording drift, in the two known
+// real orderings (#1312: the two prior exact-phrase regexes broke when
+// Codex's wording interposed "have been" between "usage limits" and
+// "reached"). Requiring "for code reviews" too (not just the verb) keeps the
+// match narrow: a bare "Codex usage limits exceeded" mention with no "for
+// code reviews" nearby must not match.
+const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
+  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i;
+// #1326: the token pattern above, by itself, is a structural false positive —
+// a genuine review comment that discusses "Codex", a reach/exceed/hit verb,
+// and "for code reviews" in ordinary prose (a live risk specifically on PRs
+// that touch this detector, as #1319's own review demonstrated) matches it
+// too. Tightening the interposed-word gap cannot separate the two cases: the
+// words sit just as close together in a real sentence as in the generated
+// notice, and no gap bound keeps both known real wordings matching while
+// rejecting the false positive (verified empirically while fixing #1326).
+//
+// Instead, gate the token match on the notice's known SHAPE: a genuine
+// Codex/CodeRabbit quota notice is short and is effectively the *entire*
+// comment — nothing of substance precedes or follows it (the current wording
+// adds one recognizable generated trailer sentence). A genuine review embeds
+// the phrase mid-document, with a narrative lead-in, trailing prose, or both.
+// Three structural checks apply together, only once the token pattern above
+// already matched:
+//
+// 1. Whole-comment length ≤ CODEX_NOTICE_MAX_LENGTH — defends against a long
+//    structured review whose *last* sentence happens to coincidentally
+//    match (the longest known real wording — current wording plus its
+//    two-sentence trailer, see below — is 199 characters).
+// 2. Text before the matched span ≤ CODEX_NOTICE_MAX_PREFIX_LENGTH once
+//    trimmed — defends against a narrative lead-in preceding an otherwise
+//    bare match (known real prefixes are 0 and 9 characters).
+// 3. Text after the matched span is empty/punctuation-only, or matches the
+//    tolerant (bounded-gap, token-anchored — not exact-phrase, so a future
+//    trailer reword does not reintroduce the #1312 brittleness) generated
+//    trailer-continuation pattern below.
+//
+// This does not achieve perfect semantic disambiguation (a sufficiently
+// short human sentence with a trivial lead-in and nothing trailing is
+// inherently indistinguishable from the real notice without exact-phrase
+// matching, which the #1312 fix deliberately avoids), but it substantially
+// narrows the matching surface in the safe direction the block comment above
+// already documents: under-match is safe, over-match risks a false merge.
+// Anchored to the *entire* trimmed remainder (start `^` through end `$`,
+// not a bare substring `.test()`), so "known trailer, then more unrelated
+// prose" is still correctly rejected — a substring-only match would let
+// extra content after the trailer hide behind a recognized prefix.
+//
+// Every connector in this pattern (lead-in, inter-sentence, and trailing)
+// is bounded to punctuation/whitespace plus, where needed, one specific
+// known word — never an arbitrary-content character budget. An earlier
+// version of this fix allowed an arbitrary `[\s\S]{0,20}?` lead-in before
+// the core trailer tokens (reasoning that the real wording's ". Please "
+// connector needed *some* tolerance), but a bounded *character count* still
+// admits arbitrary *words* within that budget — a critique pass on this PR
+// found that narrative content like "We should " fits the same budget and
+// would still reach the trailer tokens. `CODEX_NOTICE_TRAILER_LEAD_IN`
+// closes that class by allowing only punctuation/whitespace and the
+// literal word "Please" (the only lead-in word in any known real wording),
+// so no other word can occupy that position regardless of length.
+//
+// The live wording observed on this very PR's own Codex review (#1326)
+// appends a SECOND administrative sentence after the one #1312 quoted
+// ("Credits must be used to enable repository wide code reviews."), so the
+// accepted closing shape is two sentences, each independently
+// token-anchored and gap-tolerant (not exact-phrase — the same #1312
+// wording-drift tolerance applies within each sentence), with the second
+// sentence optional so the shorter single-sentence wording still matches.
+// SENTENCE_2 anchors the distinctive multi-word phrases "credits must be
+// used" and "enable" (not the single generic words "credits" / "repository"
+// / "reviews" alone) — matching the same specificity SENTENCE_1 already
+// uses, so a comment that merely reuses those individual words near
+// SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
+// found and closed during this PR's own review-fix rounds).
+//
+// #1877: a THIRD, structurally distinct wording observed live on PR #1876
+// replaces the admin/credits sentence entirely with a dashboard pointer
+// ("You can see your limits in the [Codex usage dashboard](url).") — it is
+// an alternative closing sentence, not a continuation appended after
+// SENTENCE_1/SENTENCE_2, so it is a separate alternation branch
+// (SENTENCE_3) rather than a third optional suffix on the admin/credits
+// shape. SENTENCE_3 anchors the distinctive multi-word phrase "you can see
+// your limits" plus "Codex usage dashboard", with the same bounded,
+// gap-tolerant, non-exact-phrase approach as SENTENCE_1/SENTENCE_2. The
+// trailing markdown-link close `](url)` is matched structurally (bracket,
+// parens, non-`)` URL body) rather than an arbitrary-content character
+// budget, and is optional so a future plain-text rendering (no markdown
+// link) still matches.
+const CODEX_NOTICE_TRAILER_LEAD_IN =
+  '[.!,;:\\s]{0,3}(?:\\bPlease\\b[.!,;:\\s]{0,3})?';
+const CODEX_NOTICE_TRAILER_SENTENCE_1 =
+  '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
+const CODEX_NOTICE_TRAILER_SENTENCE_2 =
+  '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
+const CODEX_NOTICE_TRAILER_SENTENCE_3 =
+  '\\byou can see your limits\\b[\\s\\S]{0,60}?\\bCodex usage dashboard\\b(?:\\]\\([^)]*\\))?';
+const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
+  `^${CODEX_NOTICE_TRAILER_LEAD_IN}(?:${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?|${CODEX_NOTICE_TRAILER_SENTENCE_3})[.!,;:\\s]*$`,
+  'i',
+);
+const CODEX_NOTICE_MAX_LENGTH = 220;
+const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
+// Anchored to the *entire* trimmed remainder (not a starts-with check), so
+// trailing prose that happens to begin with a comma or period is still
+// correctly rejected.
+const CODEX_NOTICE_SUFFIX_PUNCTUATION_ONLY_RE = /^[.!,;:]*$/;
+function isCodexUsageLimitNotice(text) {
+  if (!text.trim() || text.trim().length > CODEX_NOTICE_MAX_LENGTH) {
+    return false;
+  }
+  const match = CODEX_USAGE_LIMIT_TOKEN_PATTERN.exec(text);
+  if (!match) {
+    return false;
+  }
+  const prefix = text.slice(0, match.index).trim();
+  if (prefix.length > CODEX_NOTICE_MAX_PREFIX_LENGTH) {
+    return false;
+  }
+  const remainder = text.slice(match.index + match[0].length).trim();
+  return (
+    remainder === '' ||
+    CODEX_NOTICE_SUFFIX_PUNCTUATION_ONLY_RE.test(remainder) ||
+    CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN.test(remainder)
+  );
+}
+export function isAdvisoryNonReviewNotice(body) {
+  const text = String(body ?? '');
+  if (!text) {
+    return false;
+  }
+  return (
+    ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) => pattern.test(text)) ||
+    isCodexUsageLimitNotice(text)
+  );
+}
+// A trusted IDD disposition of a non-review notice: the canonical
+// `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is not a
+// completed review` reply. Requires the `**Rejected**` prefix (via
+// `DISPOSITION_REJECTED_PREFIX_RE`, so the bounded trailing-punctuation variants
+// like `**Rejected.**` also count; a notice is always rejected, never accepted)
+// and the `did not review HEAD` phrase that names the notice, so an ordinary
+// rejection of reviewer feedback is excluded.
+export function isNonReviewNoticeDisposition(comment) {
+  const body = (comment.body ?? '').trimStart();
+  return (
+    DISPOSITION_REJECTED_PREFIX_RE.test(body) &&
+    /\bdid not review HEAD\b/i.test(body)
+  );
+}
+// #1833 diagnostic-only hint text: single-sourced so
+// `summarizeDispositionEvidenceForGate`'s `missingRegularComments[].hint`
+// names the exact phrase `isNonReviewNoticeDisposition` requires, instead of
+// forcing an agent to source-dive this file to discover it. Never consumed by
+// any routing decision -- see the `hint` field's own doc comment on
+// `DispositionEvidenceSummary`.
+export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
+  'disposition reply is missing the required non-review-notice phrase: it ' +
+  'must start with "**Rejected**" and match /\\bdid not review HEAD\\b/i -- ' +
+  'canonical form: "**Rejected** — {bot} did not review HEAD {sha} ' +
+  '({reason}); this is not a completed review"';
+// #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
+//
+// The CodeRabbit summary walkthrough is a regular comment whose body starts with
+// `CODERABBIT_SUMMARY_MARKER`. Unlike a non-review notice it IS a completed
+// review, so it is dispositioned `**Accepted**` (never `**Rejected**`). The gate
+// scores it through its general updatedAt-aware 1:1 pairing, and CodeRabbit edits
+// the summary on each re-review, so the disposition-non-review-notices helper
+// re-dispositions the CURRENT summary per HEAD rather than carrying an old
+// acceptance forward (a stale carry-forward could mask a finding folded into a
+// later summary body — the "a false positive is a false merge" hazard).
+// True when a regular comment is a CodeRabbit summary walkthrough. Detection is
+// start-anchored on the exact single-sourced marker (after trimming leading
+// whitespace) so a comment that merely quotes the marker in prose is not matched.
+export function isReviewSummaryComment(body) {
+  return String(body ?? '')
+    .trimStart()
+    .startsWith(CODERABBIT_SUMMARY_MARKER);
+}
+// A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical
+// `**Accepted** — {bot} summary walkthrough …` reply the helper posts. Requires
+// the `**Accepted**` prefix (via `DISPOSITION_ACCEPTED_PREFIX_RE`, so the bounded
+// trailing-punctuation variants like `**Accepted.**` also count; a summary is a
+// completed review, so it is accepted, never rejected) AND the
+// `summary walkthrough` phrase, so an ordinary acceptance of reviewer feedback is
+// excluded. Tightly matched to `buildSummaryDispositionBody` so a loose
+// acceptance can never be miscredited (which would under-post and strand the
+// gate).
+export function isReviewSummaryDisposition(comment) {
+  const body = (comment.body ?? '').trimStart();
+  return (
+    DISPOSITION_ACCEPTED_PREFIX_RE.test(body) &&
+    /\bsummary walkthrough\b/i.test(body)
+  );
+}
+// The stable identity token of an advisory bot, used to attribute a non-review
+// notice disposition to the bot it rejected. The `[bot]` suffix GitHub appends
+// is dropped so the token matches whether a login is stored as `coderabbitai`
+// or `coderabbitai[bot]`.
+export function advisoryBotIdentityToken(login) {
+  return String(login ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\[bot\]$/, '');
+}
+// Captures the span where a bot login structurally appears in each canonical
+// disposition template `dispositionNamesAdvisoryBot` recognizes -- between the
+// marker (tolerating the same single interior-punctuation variant as
+// `DISPOSITION_REJECTED_PREFIX_RE` / `DISPOSITION_ACCEPTED_PREFIX_RE`) and the
+// phrase that names the template. Non-greedy so a body with the phrase
+// appearing once still captures the shortest, correct span. The `^` anchor
+// applies after the caller's `trimStart()` below, so it tolerates leading
+// whitespace the same way `isNonReviewNoticeDisposition` /
+// `isReviewSummaryDisposition` already do -- not the stricter, untrimmed
+// marker-first-bytes contract `isDispositionComment` enforces -- so this
+// never matches a marker quoted mid-prose, but a leading blank line or space
+// before the marker does not defeat it either.
+const REJECTED_NOTICE_LOGIN_SPAN_RE =
+  /^\*\*Rejected[.!:]?\*\*\s+—\s+([\s\S]*?)\s+did not review HEAD\b/i;
+const ACCEPTED_SUMMARY_LOGIN_SPAN_RE =
+  /^\*\*Accepted[.!:]?\*\*\s+—\s+([\s\S]*?)\s+summary walkthrough\b/i;
+// True when a non-review-notice or summary-walkthrough disposition body names
+// the given advisory bot's GitHub login, so the gate can attribute a
+// carry-forward to exactly one bot even when several advisory bots are
+// configured. Matches only within the anchored span where a canonical
+// template places the bot login -- never a whole-body substring search --
+// so a bot whose identity token equals a word from the template's own fixed
+// text (e.g. "review", "head", or the #1482 "issuecomment" suffix) cannot
+// falsely match a disposition naming a different bot. A body naming several
+// bots in one span (a disposition that improperly covers more than one
+// notice) still matches each of them, matching the existing 1:1 consumption
+// contract at the call sites. Fail-closed: an empty token, or a disposition
+// body that does not structurally match either canonical template, names no
+// bot.
+export function dispositionNamesAdvisoryBot(
+  dispositionBody,
+  noticeAuthorLogin,
+) {
+  const token = advisoryBotIdentityToken(noticeAuthorLogin);
+  if (!token) {
+    return false;
+  }
+  const body = String(dispositionBody ?? '').trimStart();
+  const span =
+    REJECTED_NOTICE_LOGIN_SPAN_RE.exec(body)?.[1] ??
+    ACCEPTED_SUMMARY_LOGIN_SPAN_RE.exec(body)?.[1];
+  if (span === undefined) {
+    return false;
+  }
+  return span.toLowerCase().includes(token);
+}
+// #1182 Match trusted machine advisory dispositions to the advisory-bot stickies
+// they address, so a disposition posted by a trusted-marker actor who is NOT a
+// resolved IDD agent (e.g. a second trusted session) is honored without being
+// promoted into a global IDD-agent identity. Matching is strict on FOUR axes:
+//   - bot: the disposition body must name the sticky author's bot login
+//     (`dispositionNamesAdvisoryBot`);
+//   - type: a `**Rejected** — {bot} did not review HEAD …` notice disposition
+//     clears only a non-review-notice sticky, and an `**Accepted** — {bot}
+//     summary walkthrough …` disposition clears only a CodeRabbit summary
+//     sticky — the notice/summary paths are disjoint in the helper that posts
+//     them, so a notice rejection must never hide a summary that still needs its
+//     own acceptance (or vice versa);
+//   - count: consumed 1:1, so one disposition cannot clear several stickies.
+//   - recency (summary only): a CodeRabbit summary walkthrough IS a completed
+//     review that CodeRabbit edits on each re-review (bumping the sticky's
+//     `activityAt`), so a summary disposition clears a summary sticky only when
+//     the disposition is strictly NEWER than the sticky — a stale `**Accepted**`
+//     can never clear a summary edited after it (the #1122 "a false positive is
+//     a false merge" hazard). Non-review notices intentionally skip this: a
+//     notice disposition carries forward across HEAD changes while the bot still
+//     has not reviewed (the #1018 carry-forward), so it need not post-date a
+//     re-posted notice.
+// IDD-agent-authored dispositions are excluded here — they are already scored by
+// the caller's own disposition pool / watermark — which also prevents a
+// viewer-authored (agent AND trusted) disposition from being double-counted. A
+// trusted disposition matched here is bound to its advisory item and NEVER flows
+// into any generic disposition pool, so an absent or already-resolved sticky
+// leaves the disposition unused: it can never clear an unrelated human comment.
+// Returns the set of `sortedIndex` values of the stickies that are dispositioned.
+function matchTrustedAdvisoryStickyDispositions(
+  comments,
+  advisoryBotLogins,
+  trustedMarkerLogins,
+  iddAgentLogins,
+) {
+  const dispositionedStickyIndexes = new Set();
+  const consumedDispositionIndexes = new Set();
+  const trustedDispositions = comments.filter(
+    (comment) =>
+      trustedMarkerLogins.has(comment.authorLogin) &&
+      !iddAgentLogins.has(comment.authorLogin),
+  );
+  const byActivityThenIndex = (left, right) => {
+    const leftTime = Date.parse(left.activityAt);
+    const rightTime = Date.parse(right.activityAt);
+    if (leftTime !== rightTime) {
+      return leftTime - rightTime;
+    }
+    return left.sortedIndex - right.sortedIndex;
+  };
+  const kinds = [
+    {
+      isSticky: (body) => isAdvisoryNonReviewNotice(body),
+      isDisposition: (body) => isNonReviewNoticeDisposition({ body }),
+      requireNewerDisposition: false,
+    },
+    {
+      isSticky: (body) => isReviewSummaryComment(body),
+      isDisposition: (body) => isReviewSummaryDisposition({ body }),
+      requireNewerDisposition: true,
+    },
+  ];
+  for (const kind of kinds) {
+    const stickiesByBot = new Map();
+    for (const comment of comments) {
+      if (
+        !isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) ||
+        !kind.isSticky(comment.body)
+      ) {
+        continue;
+      }
+      const list = stickiesByBot.get(comment.authorLogin) ?? [];
+      list.push(comment);
+      stickiesByBot.set(comment.authorLogin, list);
+    }
+    // Sort bot logins so a disposition naming more than one configured bot is
+    // consumed deterministically (by the lexicographically-first bot only).
+    for (const botLogin of [...stickiesByBot.keys()].sort()) {
+      const stickies = [...(stickiesByBot.get(botLogin) ?? [])].sort(
+        byActivityThenIndex,
+      );
+      const candidates = trustedDispositions
+        .filter(
+          (disposition) =>
+            kind.isDisposition(disposition.body) &&
+            dispositionNamesAdvisoryBot(disposition.body, botLogin),
+        )
+        .sort(byActivityThenIndex);
+      // Greedy oldest-first pairing: match each sticky to the earliest unconsumed
+      // matching disposition (that is strictly newer, when the kind requires it),
+      // so one disposition never clears several stickies and — for summaries — a
+      // disposition only clears a sticky it post-dates.
+      for (const sticky of stickies) {
+        const match = candidates.find(
+          (disposition) =>
+            !consumedDispositionIndexes.has(disposition.sortedIndex) &&
+            (!kind.requireNewerDisposition ||
+              compareIsoTimestamps(disposition.activityAt, sticky.activityAt) >
+                0),
+        );
+        if (match) {
+          dispositionedStickyIndexes.add(sticky.sortedIndex);
+          consumedDispositionIndexes.add(match.sortedIndex);
+        }
+      }
+    }
+  }
+  return dispositionedStickyIndexes;
+}
+/**
+ * Parse a check's `completedAt` into epoch milliseconds, or `null` when it
+ * is missing, not a valid ISO 8601 timestamp, or the `0001-01-01T00:00:00Z`
+ * zero-value sentinel some GitHub API surfaces (e.g. `gh pr checks`) report
+ * for a check that has not actually completed — see `isCompletedCiTimestamp`,
+ * this file's existing convention for the same sentinel. A still-running
+ * instance's `completedAt` reads as one of these three "not completed"
+ * shapes until it finishes.
+ */
+function parseCompletedAt(value) {
+  const timestamp = String(value ?? '');
+  return isCompletedCiTimestamp(timestamp) ? Date.parse(timestamp) : null;
+}
+/**
+ * Failure-family *conclusion* states that must win a same-instant
+ * tie-break and classify as a genuine `classifyCiChecks` failure (#1688).
+ * Deliberately excludes `CANCELLED`: a cancelled run reached no real
+ * verdict at all (unlike these six, which are all concrete failure
+ * conclusions), so it keeps its own separate, lower tie-break rank in
+ * `ciStateTieRank` below and stays out of `classifyCiChecks`'s `failed`
+ * bucket — see that function and `ci-wait-state.mts`'s `FAILURE_STATES`
+ * (which is deliberately *derived from* this set plus `CANCELLED`, not
+ * independently maintained, so the two files cannot silently drift apart
+ * again the way #1504's local-only fix did).
+ *
+ * `ERROR` is StatusContext-only (a CheckRun conclusion never reports it);
+ * included here so a caller that feeds a raw, un-translated commit-status
+ * state directly into `classifyCiChecks` or `ciStateTieRank` still gets
+ * failure-family treatment, matching `normalizeStatusCheckRollupEntry`'s
+ * translation of StatusContext `error` to the literal `'FAILURE'` for the
+ * one call path that already normalizes it upstream.
+ */
+export const CI_FAILURE_CONCLUSION_STATES = new Set([
+  'FAILURE',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'STALE',
+  'ERROR',
+]);
+/**
+ * Tie-break precedence for two check-run instances that complete at the
+ * same (or an equally unusable) instant. Every `CI_FAILURE_CONCLUSION_STATES`
+ * member always wins (rank 0): a same-instant tie must never hide a real
+ * failure behind ordering happenstance (the exact regression
+ * `classifyCiChecks`'s unconditional "any FAILURE anywhere" rule existed
+ * to prevent, and not a case a rerun can plausibly land in — GitHub
+ * `completedAt` has only second resolution, and a rerun must trigger,
+ * queue, and execute before it can complete, which practically never
+ * lands in the exact same recorded second as the run it supersedes).
+ * Pre-#1688, only the literal `'FAILURE'` string won this way; `TIMED_OUT`,
+ * `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR` fell into the
+ * generic rank-1 bucket below and could lose a tie to `SUCCESS` by
+ * lexicographic happenstance (#1688's reproduction: `SUCCESS` vs
+ * `TIMED_OUT`, `'SUCCESS' < 'TIMED_OUT'`). `CANCELLED` always loses (rank
+ * 2): a cancelled run reached no real verdict, so it defers to any
+ * conclusion that did. Every other state — including pending states,
+ * which practically never reach this tie path since they have no
+ * completed timestamp to tie on — shares the middle rank (1).
+ */
+function ciStateTieRank(state) {
+  if (state === 'CANCELLED') return 2;
+  if (CI_FAILURE_CONCLUSION_STATES.has(state)) return 0;
+  return 1;
+}
+/**
+ * True when `candidate` should replace `current` as the representative
+ * instance for one check name. A still-incomplete instance (per
+ * `parseCompletedAt`) always wins over an already-completed one:
+ * completion can only happen after creation, so a live rerun can never be
+ * older than the finished run it supersedes — this mirrors GitHub's own
+ * latest-per-context semantics, under which an in-progress required check
+ * leaves the branch not-clean rather than falling back to a stale
+ * completed verdict. Once both sides have completed, the most recently
+ * completed one wins.
+ *
+ * A tie (equal completedAt, or both sides missing/unparseable) never
+ * resolves by input order — two independent runs can genuinely complete
+ * within the same recorded second. It resolves by `ciStateTieRank`
+ * instead; a residual tie within the same rank (e.g. `SUCCESS` vs.
+ * `NEUTRAL`, both rank 1) falls back to comparing the state strings
+ * themselves, which depends only on the two values being compared, never
+ * on which one the caller happened to list first — so the whole
+ * selection is fully deterministic regardless of input order.
+ */
+function isNewerCheckInstance(candidate, current) {
+  const candidateAt = parseCompletedAt(candidate.completedAt);
+  const currentAt = parseCompletedAt(current.completedAt);
+  if (candidateAt !== null && currentAt !== null && candidateAt !== currentAt) {
+    return candidateAt > currentAt;
+  }
+  if ((candidateAt !== null) !== (currentAt !== null)) {
+    // Exactly one side has a usable timestamp. The side still missing one
+    // is never older than a completed side — a live rerun cannot have
+    // started before the finished run it supersedes — so the incomplete
+    // side always wins here.
+    return candidateAt === null;
+  }
+  const candidateRank = ciStateTieRank(candidate.state);
+  const currentRank = ciStateTieRank(current.state);
+  if (candidateRank !== currentRank) {
+    return candidateRank < currentRank;
+  }
+  return candidate.state !== current.state && candidate.state < current.state;
+}
+/**
+ * Reduce a group of check-run instances that share one grouping key
+ * (typically a check name) to the single instance that represents the
+ * current truth for that key. See `isNewerCheckInstance` for the
+ * selection rule. Exported so other same-name dedup call sites (e.g.
+ * `ci-wait-state.mts`'s `buildCiWaitStateSummary`, #1478) can reuse this
+ * tie-break instead of maintaining an independent copy. `group` is
+ * always non-empty in every current caller (each group comes from
+ * bucketing a non-empty input list by key), so the seedless `reduce`
+ * below never hits its empty-array throw path.
+ */
+export function selectLatestCheckInstance(group) {
+  return group.reduce((latest, candidate) =>
+    isNewerCheckInstance(candidate, latest) ? candidate : latest,
+  );
+}
+/**
+ * Reduce a check-run list to a single representative instance per
+ * `(name, type, workflowName)` group, matching GitHub's own
+ * required-status-check semantics: only the latest run for a given
+ * producer governs, so a stale instance (e.g. a cancelled or failed run
+ * superseded by a later successful rerun) can never outvote the current,
+ * authoritative one from the *same* producer.
+ *
+ * A missing or empty `name` carries no identity to dedupe against, so
+ * each such entry gets its own singleton group instead of collapsing
+ * every unnamed check together — otherwise an unrelated unnamed failure
+ * could be discarded in favor of an unrelated unnamed success that
+ * merely happens to also lack a name.
+ *
+ * `type` (e.g. `'check-run'` vs. `'status-context'`) and `workflowName`
+ * are an optional producer-identity discriminator (#1483): two entries
+ * that share a `name` but differ on either one are never assumed to be
+ * reruns of each other (e.g. a check-run and a legacy commit-status, or
+ * two check-runs from different Actions workflows, that happen to share
+ * a display name both survive instead of one discarding the other). When
+ * `type`/`workflowName` are absent on every entry sharing a `name` (the
+ * pre-#1483 data shape, still produced by hand-built fixtures and any
+ * caller that predates the discriminator), there is no conflicting
+ * signal to split on, so the group dedupes by `name` alone exactly as
+ * #1471 established -- this keeps every pre-#1483 caller and test
+ * behavior-identical.
+ *
+ * Residual known limitation: two genuinely independent producers that
+ * share both a `name` and a `type` and both lack a `workflowName` (e.g.
+ * two different non-Actions GitHub Apps that each post a check-run
+ * directly, rather than through a workflow) remain indistinguishable
+ * here and will still be grouped together. Closing that fully needs a
+ * stronger producer identity (e.g. the owning GitHub App) than
+ * `gh`/GraphQL's `statusCheckRollup` exposes today; `ci-wait-state.mts`'s
+ * own `(checkName, workflowName)` key has the identical accepted gap.
+ */
+/**
+ * Group check-run instances by the same `(name, type, workflowName)`
+ * producer-identity key `selectLatestCheckPerName` reduces to one
+ * representative -- shared here so a caller that needs to inspect the
+ * DISCARDED siblings, not just the survivor (see
+ * {@link findDiscardedNonPassingSiblings}), can never drift out of sync
+ * with that grouping.
+ */
+function groupChecksByProducer(checks) {
+  // A Map already iterates in first-insertion order, so grouping into one
+  // is enough to preserve stable output order with no separate order array
+  // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
+  const groups = new Map();
+  let unnamedCount = 0;
+  for (const check of checks) {
+    if (!check.name) {
+      groups.set(`\0unnamed:${unnamedCount++}`, [check]);
+      continue;
+    }
+    const type = check.type ? String(check.type).trim() : '';
+    const workflowName = check.workflowName
+      ? String(check.workflowName).trim()
+      : '';
+    const key = `${String(check.name)}\0${type}\0${workflowName}`;
+    const group = groups.get(key);
+    if (group) {
+      group.push(check);
+    } else {
+      groups.set(key, [check]);
+    }
+  }
+  return groups;
+}
+function selectLatestCheckPerName(checks) {
+  return [...groupChecksByProducer(checks).values()].map((group) =>
+    selectLatestCheckInstance(group),
+  );
+}
+/** Check-run states {@link findDiscardedNonPassingSiblings} treats as
+ * "genuinely non-passing": every `CI_FAILURE_CONCLUSION_STATES` member plus
+ * `CANCELLED` (deliberately excluded from that set itself -- see its own
+ * doc comment -- but still evidence-worthy here: a discarded `CANCELLED`
+ * sibling is exactly the #1745 finding, a stale/gated instance masked by a
+ * same-name `SUCCESS`). Pending states are excluded on purpose: a discarded
+ * still-running sibling in favor of an already-completed one is ordinary,
+ * expected dedup behavior, not a discrepancy worth flagging. */
+const GENUINELY_NON_PASSING_STATES = new Set([
+  ...CI_FAILURE_CONCLUSION_STATES,
+  'CANCELLED',
+]);
+/**
+ * Detect same-producer `(name, type, workflowName)` groups whose
+ * dedup-selected "latest" instance (`selectLatestCheckInstance`) is
+ * pass-equivalent (SUCCESS/SKIPPED/NEUTRAL/NOT_APPLICABLE) while a
+ * DISCARDED sibling in that same group is genuinely non-passing (see
+ * {@link GENUINELY_NON_PASSING_STATES}) -- the live discrepancy PR #1741
+ * exhibited (#1745): `classifyCiChecks` reported `success` for a commit
+ * whose GitHub `statusCheckRollup.state` was `FAILURE`, because a
+ * `CANCELLED` bot-triggered `idd-advisory-convergence` instance existed
+ * alongside the `SUCCESS` instance this dedup selected as "latest".
+ * Confirming the exact internal GitHub selection is not possible after the
+ * fact (see #1745's evidence-durability note), so this reports the
+ * discarded-sibling FACT itself -- a same-name non-passing instance existed
+ * and was NOT counted -- rather than asserting why GitHub's own rollup
+ * disagreed. Pure and read-only: never changes which instance
+ * `selectLatestCheckPerName` selects, only reports when a discarded sibling
+ * makes that selection's "success" verdict less certain than it looks.
+ */
+function findDiscardedNonPassingSiblings(checks) {
+  const divergences = [];
+  for (const group of groupChecksByProducer(checks).values()) {
+    if (group.length < 2) continue;
+    const selected = selectLatestCheckInstance(group);
+    if (
+      !['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
+        selected.state,
+      )
+    ) {
+      continue;
+    }
+    for (const sibling of group) {
+      if (sibling === selected) continue;
+      if (!GENUINELY_NON_PASSING_STATES.has(sibling.state)) continue;
+      divergences.push({
+        name: String(selected.name ?? ''),
+        type: selected.type ? String(selected.type) : '',
+        workflowName: selected.workflowName
+          ? String(selected.workflowName)
+          : '',
+        selectedState: selected.state,
+        selectedCompletedAt: selected.completedAt ?? null,
+        discardedState: sibling.state,
+        discardedCompletedAt: sibling.completedAt ?? null,
+      });
+    }
+  }
+  return divergences;
+}
+export function classifyCiChecks(checks) {
+  const normalized = checks.map((check) => ({
+    name: check.name,
+    state: String(check.state ?? '').toUpperCase(),
+    completedAt: check.completedAt ?? null,
+    type: check.type ?? null,
+    workflowName: check.workflowName ?? null,
+  }));
+  // GitHub can report several check-run instances that share the same
+  // check `name` (a manual or automatic re-run leaves the earlier instance
+  // in the fetched list alongside the new one). Reduce to one instance per
+  // name before classifying pass/fail/pending, so a stale instance never
+  // outvotes the current one for the same name (see #1471).
+  const deduped = selectLatestCheckPerName(normalized);
+  // #1745: computed unconditionally (not just for the 'success' path) so
+  // every returned shape below carries the same field -- a discarded
+  // non-passing sibling is evidence worth surfacing even when the overall
+  // status already reads 'failed'/'pending' for an unrelated check name.
+  const discardedNonPassingInstances =
+    findDiscardedNonPassingSiblings(normalized);
+  // #1688: widened from a literal 'FAILURE' match to every
+  // CI_FAILURE_CONCLUSION_STATES member, so a TIMED_OUT/ACTION_REQUIRED/
+  // STARTUP_FAILURE/STALE/ERROR conclusion classifies as a genuine failure
+  // here too, matching ci-wait-state.mts's own bucketing for the same
+  // conclusion states instead of silently falling through to 'unknown'.
+  // CANCELLED is deliberately not included -- see CI_FAILURE_CONCLUSION_STATES.
+  const failed = deduped.filter((check) =>
+    CI_FAILURE_CONCLUSION_STATES.has(check.state),
+  );
+  if (failed.length > 0) {
+    return { status: 'failed', failed, discardedNonPassingInstances };
+  }
+  const pending = deduped.filter((check) => {
+    return (
+      check.state === 'QUEUED' ||
+      check.state === 'IN_PROGRESS' ||
+      check.state === 'WAITING'
+    );
+  });
+  if (pending.length > 0) {
+    return { status: 'pending', pending, discardedNonPassingInstances };
+  }
+  const passing = deduped.filter((check) => {
+    return ['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
+      check.state,
+    );
+  });
+  return {
+    status: passing.length === deduped.length ? 'success' : 'unknown',
+    passing,
+    unknown: deduped.filter((check) => !passing.includes(check)),
+    discardedNonPassingInstances,
+  };
+}
+/**
+ * #1686: the exact, closed set of logins recognized for the *default*
+ * Copilot primary advisory bot -- the human-facing `copilot` slash-command
+ * actor plus the two known GitHub-App review-bot login forms. Previously
+ * matched via `normalized.startsWith('copilot-pull-request-reviewer')`,
+ * which a *registrable* GitHub username lookalike (for example
+ * `copilot-pull-request-reviewer1`) could also satisfy on a public
+ * repository: any account can submit a PR review, so a lookalike login
+ * could post an empty review of the current HEAD and masquerade as the
+ * real bot's convergence signal (Clause 1 of `advisory-convergence.mts`'s
+ * verdict: `matchesHead: true, itemCount: 0`). An exact set closes that
+ * gap without narrowing the two genuine login forms GitHub actually uses.
+ */
+const EXACT_COPILOT_REVIEWER_LOGINS = new Set([
+  'copilot',
+  'copilot-pull-request-reviewer',
+  'copilot-pull-request-reviewer[bot]',
+]);
+/**
+ * Match a review/reviewer login against the configured primary advisory bot.
+ *
+ * `primaryBotLogin` defaults to Copilot so existing callers stay behavior-
+ * preserving. For the Copilot default, the login must be an exact member of
+ * {@link EXACT_COPILOT_REVIEWER_LOGINS} (#1686 -- previously a broader
+ * `copilot-pull-request-reviewer*` prefix match; see that constant's doc
+ * comment for why it was narrowed). A non-Copilot configured login is
+ * matched by exact normalized (trimmed, lower-cased) equality, since an
+ * arbitrary bot login has no analogous prefix family.
+ */
+export function isCopilotReviewerLogin(
+  login,
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  const normalized = String(login ?? '')
+    .trim()
+    .toLowerCase();
+  const configured =
+    String(primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  if (configured === DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN) {
+    return EXACT_COPILOT_REVIEWER_LOGINS.has(normalized);
+  }
+  return normalized === configured;
+}
+export function findLastCopilotReviewCommit(
+  reviews,
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  const latest = reviews
+    .filter((review) =>
+      isCopilotReviewerLogin(
+        review.user?.login ?? review.author?.login ?? '',
+        primaryBotLogin,
+      ),
+    )
+    .map((review) => ({
+      submittedAt: review.submitted_at ?? review.submittedAt ?? '',
+      commitId: review.commit_id ?? review.commitId ?? '',
+    }))
+    .sort((left, right) =>
+      compareIsoTimestamps(left.submittedAt, right.submittedAt),
+    )
+    .at(-1);
+  return latest?.commitId ?? '';
+}
+export function isCopilotPending(
+  requestedReviewers,
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  return requestedReviewers.some((reviewer) => {
+    if (typeof reviewer === 'string') {
+      return isCopilotReviewerLogin(reviewer, primaryBotLogin);
+    }
+    return isCopilotReviewerLogin(
+      reviewer?.login ?? reviewer?.user?.login ?? '',
+      primaryBotLogin,
+    );
+  });
+}
+export function computeCopilotPendingCoversHead(
+  timelineEvents,
+  prHeadSha,
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  let headIndex = -1;
+  let requestIndex = -1;
+  timelineEvents.forEach((event, index) => {
+    const eventName = String(event?.event ?? '');
+    if (eventName === 'committed') {
+      const sha = String(event?.sha ?? event?.commit_id ?? '');
+      if (sha === prHeadSha) {
+        headIndex = index;
+      }
+      return;
+    }
+    if (eventName === 'review_requested') {
+      const reviewerLogin = event?.requested_reviewer?.login ?? '';
+      if (isCopilotReviewerLogin(reviewerLogin, primaryBotLogin)) {
+        requestIndex = index;
+      }
+    }
+  });
+  return headIndex !== -1 && requestIndex !== -1 && requestIndex > headIndex;
+}
+/**
+ * True when the OPTIONAL secondary advisory bot has already been requested for
+ * the current HEAD — i.e. a `review_requested` event for `secondaryBotLogin`
+ * follows the current HEAD's `committed` event in the PR timeline. This is the
+ * once-per-HEAD guard for the non-gating secondary supplement (issue #1099),
+ * reusing the same timeline evidence as {@link computeCopilotPendingCoversHead}
+ * so no new marker is needed: when HEAD advances, the new `committed` event
+ * sits after the prior secondary request and the guard resets to `false`.
+ *
+ * The secondary is matched by exact normalized login equality (NOT the Copilot
+ * family). An empty `secondaryBotLogin` short-circuits to `false` so an
+ * unconfigured secondary never matches anything.
+ */
+export function computeSecondaryRequestedForHead(
+  timelineEvents,
+  prHeadSha,
+  secondaryBotLogin,
+) {
+  const configured = String(secondaryBotLogin ?? '')
+    .trim()
+    .toLowerCase();
+  if (configured === '') {
+    return false;
+  }
+  let headIndex = -1;
+  let requestIndex = -1;
+  timelineEvents.forEach((event, index) => {
+    const eventName = String(event?.event ?? '');
+    if (eventName === 'committed') {
+      const sha = String(event?.sha ?? event?.commit_id ?? '');
+      if (sha === prHeadSha) {
+        headIndex = index;
+      }
+      return;
+    }
+    if (eventName === 'review_requested') {
+      const reviewerLogin = String(event?.requested_reviewer?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (reviewerLogin === configured) {
+        requestIndex = index;
+      }
+    }
+  });
+  return headIndex !== -1 && requestIndex !== -1 && requestIndex > headIndex;
+}
+export function normalizeTrustedMarkerLogins(logins) {
+  return [
+    ...new Set(
+      (logins ?? [])
+        .map((login) =>
+          String(login ?? '')
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+/**
+ * Resolve the trusted marker actors for a read-only evidence helper.
+ *
+ * Precedence is strict: an explicit `--trusted-marker-logins` flag wins over
+ * the `IDD_TRUSTED_MARKER_ACTORS` env var, which wins over the
+ * `trustedMarkerActors` array declared in `.github/idd/config.json`. The flag
+ * and env var are CSV strings (or arrays); `config` is the parsed policy
+ * object. The returned `source` records which input supplied the value so the
+ * helper can emit it as auditable JSON evidence.
+ */
+export function resolveTrustedMarkerActors({
+  flagValue = '',
+  envValue = '',
+  config = null,
+} = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(flagValue),
+  );
+  if (fromFlag.length > 0) {
+    return { actors: fromFlag, source: 'flag' };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(envValue),
+  );
+  if (fromEnv.length > 0) {
+    return { actors: fromEnv, source: 'env' };
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.trustedMarkerActors)
+      ? config.trustedMarkerActors
+      : [],
+  );
+  if (fromConfig.length > 0) {
+    return { actors: fromConfig, source: 'config' };
+  }
+  return { actors: [], source: 'none' };
+}
+function trustedMarkerActorTokens(value) {
+  return Array.isArray(value) ? value : String(value ?? '').split(',');
+}
+export function unionTrustedMarkerActorSources({
+  envValue = '',
+  config = null,
+  extraActors = [],
+  extraSource = '',
+} = {}) {
+  const sources = [];
+  const actors = [];
+  const extras = normalizeTrustedMarkerLogins(extraActors);
+  if (extras.length > 0) {
+    actors.push(...extras);
+    if (extraSource) {
+      sources.push(extraSource);
+    }
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(envValue),
+  );
+  if (fromEnv.length > 0) {
+    actors.push(...fromEnv);
+    sources.push('env');
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.trustedMarkerActors)
+      ? config.trustedMarkerActors
+      : [],
+  );
+  if (fromConfig.length > 0) {
+    actors.push(...fromConfig);
+    sources.push('config');
+  }
+  return { actors: normalizeTrustedMarkerLogins(actors), sources };
+}
+export function resolveAdvisoryBotLogins({
+  flagValue = '',
+  envValue = '',
+  config = null,
+} = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(flagValue),
+  );
+  if (fromFlag.length > 0) {
+    return { logins: fromFlag, source: 'flag' };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(envValue),
+  );
+  if (fromEnv.length > 0) {
+    return { logins: fromEnv, source: 'env' };
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.advisoryBotLogins) ? config.advisoryBotLogins : [],
+  );
+  if (fromConfig.length > 0) {
+    return { logins: fromConfig, source: 'config' };
+  }
+  return { logins: [], source: 'none' };
+}
+export function deriveIddAgentLogins({
+  viewerLogin = '',
+  iddAgentLogins = [],
+  trustedMarkerLogins = [],
+  operationalComments = [],
+} = {}) {
+  const trustedLogins = new Set(
+    normalizeTrustedMarkerLogins(trustedMarkerLogins),
+  );
+  const derivedLogins = [viewerLogin, ...(iddAgentLogins ?? [])];
+  for (const comment of operationalComments ?? []) {
+    const authorLogin = String(
+      comment?.author?.login ?? comment?.user?.login ?? '',
+    )
+      .trim()
+      .toLowerCase();
+    const body = String(comment?.body ?? '');
+    const markerPrefix = operationalMarkerPrefix(body);
+    if (
+      !trustedLogins.has(authorLogin) ||
+      !markerPrefix ||
+      !IDD_AGENT_DERIVED_MARKERS.has(markerPrefix)
+    ) {
+      continue;
+    }
+    derivedLogins.push(authorLogin);
+  }
+  return normalizeTrustedMarkerLogins(derivedLogins);
+}
+export function summarizeAdvisoryWaitMarkers(
+  comments,
+  prHeadSha,
+  trustedMarkerLogins,
+) {
+  const trustedLogins = new Set(
+    normalizeTrustedMarkerLogins(trustedMarkerLogins),
+  );
+  let earliestSameHeadAt = '';
+  let trustedSameHeadMarkerCount = 0;
+  let trustedRequestMarkerCount = 0;
+  let untrustedSameHeadMarkerCount = 0;
+  let untrustedRequestMarkerCount = 0;
+  for (const comment of comments) {
+    const body = String(comment?.body ?? '').trimEnd();
+    const login = String(comment?.author?.login ?? comment?.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    const trusted = trustedLogins.has(login);
+    const isSameHeadMarker = advisoryWaitMarkerMatchesHead(body, prHeadSha);
+    const isRequestMarker = advisoryWaitRequestMarker(body);
+    if (isSameHeadMarker) {
+      if (trusted) {
+        trustedSameHeadMarkerCount += 1;
+        const createdAt = String(
+          comment?.createdAt ?? comment?.created_at ?? '',
+        );
+        if (
+          isValidIsoTimestamp(createdAt) &&
+          (!earliestSameHeadAt ||
+            compareIsoTimestamps(createdAt, earliestSameHeadAt) < 0)
+        ) {
+          earliestSameHeadAt = createdAt;
+        }
+      } else {
+        untrustedSameHeadMarkerCount += 1;
+      }
+    }
+    if (isRequestMarker) {
+      if (trusted) {
+        trustedRequestMarkerCount += 1;
+      } else {
+        untrustedRequestMarkerCount += 1;
+      }
+    }
+  }
+  return {
+    sameHeadMarkerPresent: trustedSameHeadMarkerCount > 0,
+    earliestSameHeadAt,
+    sameHeadMarkerCount: trustedSameHeadMarkerCount,
+    requestMarkerCount: trustedRequestMarkerCount,
+    trustedSameHeadMarkerCount,
+    untrustedSameHeadMarkerCount,
+    trustedRequestMarkerCount,
+    untrustedRequestMarkerCount,
+  };
+}
+export function evaluateAdvisoryWaitOutcome(input) {
+  const { requestCap, pendingWindowMinutes, settledWindowMinutes } =
+    normalizeAdvisoryWaitRuntimeOptions(input);
+  if (input.lastCopilotCommit === input.prHeadSha) {
+    return 'SATISFIED';
+  }
+  if (input.copilotPending) {
+    if (!input.sameHeadMarkerPresent) {
+      return input.copilotPendingCoversHead
+        ? 'RECOVERY_NEEDED'
+        : input.requestMarkerCount >= requestCap
+          ? 'CAP_EXHAUSTED'
+          : 'REQUEST_NEEDED';
+    }
+    return input.elapsedMinutes >= pendingWindowMinutes ? 'SATISFIED' : 'WAIT';
+  }
+  if (!input.sameHeadMarkerPresent) {
+    return input.requestMarkerCount >= requestCap
+      ? 'CAP_EXHAUSTED'
+      : 'REQUEST_NEEDED';
+  }
+  return input.elapsedMinutes >= settledWindowMinutes ? 'SATISFIED' : 'WAIT';
+}
+// F3 deliberately has a separate outcome from evaluateAdvisoryWaitOutcome:
+// once Copilot is no longer pending (review submitted or cancelled), F3
+// treats the advisory wait as SATISFIED so a settled-but-not-re-reviewed
+// HEAD can merge, even while the shared `outcome` still routes E14/F2 to
+// REQUEST_NEEDED. F3 reads f3Outcome exclusively when helper output is
+// valid; see idd-advisory-wait.instructions.md §1 (F3-specific interpretation).
+export function evaluateAdvisoryWaitF3Outcome(input) {
+  if (input.lastCopilotCommit === input.prHeadSha || !input.copilotPending) {
+    return 'SATISFIED';
+  }
+  return evaluateAdvisoryWaitOutcome(input);
+}
+export function buildAdvisoryWaitSummary(
+  {
+    prHeadSha,
+    reviews = [],
+    requestedReviewers = [],
+    timelineEvents = [],
+    comments = [],
+  },
+  options = {},
+) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  if (!/^[0-9a-f]{40}$/.test(String(prHeadSha ?? ''))) {
+    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+  }
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins(
+    options.trustedMarkerLogins ?? [],
+  );
+  const configuredTrustedActors = normalizeTrustedMarkerLogins(
+    options.configuredTrustedActors ?? [],
+  );
+  const primaryBotLogin =
+    String(options.primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  const markerSummary = summarizeAdvisoryWaitMarkers(
+    comments,
+    prHeadSha,
+    trustedMarkerLogins,
+  );
+  const elapsedMinutes = markerSummary.sameHeadMarkerPresent
+    ? minutesBetweenIso(markerSummary.earliestSameHeadAt, now)
+    : 0;
+  const lastCopilotCommit = findLastCopilotReviewCommit(
+    reviews,
+    primaryBotLogin,
+  );
+  const copilotPending = isCopilotPending(requestedReviewers, primaryBotLogin);
+  const copilotPendingCoversHead = computeCopilotPendingCoversHead(
+    timelineEvents,
+    prHeadSha,
+    primaryBotLogin,
+  );
+  const {
+    requestCap,
+    pendingWindowMinutes,
+    settledWindowMinutes,
+    pollIntervalMinutes,
+    capExhaustedRoute,
+  } = normalizeAdvisoryWaitRuntimeOptions(options);
+  const outcomeInput = {
+    lastCopilotCommit,
+    prHeadSha,
+    copilotPending,
+    copilotPendingCoversHead,
+    sameHeadMarkerPresent: markerSummary.sameHeadMarkerPresent,
+    requestMarkerCount: markerSummary.requestMarkerCount,
+    elapsedMinutes,
+    requestCap,
+    pendingWindowMinutes,
+    settledWindowMinutes,
+  };
+  const outcome = evaluateAdvisoryWaitOutcome(outcomeInput);
+  const f3Outcome = evaluateAdvisoryWaitF3Outcome(outcomeInput);
+  // Optional NON-GATING secondary advisory bot (issue #1099). Resolved AFTER
+  // `outcome` and never fed into `outcomeInput`, so it can never satisfy or
+  // alter the primary advisory-wait gate (contract a). A secondary equal to the
+  // primary is treated as unconfigured (misconfiguration guard).
+  const secondaryBotLogin = String(options.secondaryBotLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const secondaryConfigured =
+    secondaryBotLogin !== '' && secondaryBotLogin !== primaryBotLogin;
+  // Once per HEAD, read from the GitHub timeline (a `review_requested` for the
+  // secondary after the current HEAD's `committed` event) — no marker is posted
+  // for the secondary, so it never receives a primary `advisory-wait` marker
+  // and never burns the primary cap (contract b).
+  const secondaryAlreadyRequested =
+    secondaryConfigured &&
+    computeSecondaryRequestedForHead(
+      timelineEvents,
+      prHeadSha,
+      secondaryBotLogin,
+    );
+  // Request the secondary once per HEAD only when a follow-up pass is genuinely
+  // needed (the primary has not reviewed HEAD) AND the primary is
+  // cap-exhausted, or stalled/rate-limited (the wait was closed by the elapsed
+  // settle/pending window rather than by a HEAD review). REQUEST_NEEDED (primary
+  // still requestable), WAIT (still in-window), and RECOVERY_NEEDED (active
+  // recovery) deliberately do not trigger the supplement.
+  const secondaryRequestNeeded =
+    secondaryConfigured &&
+    !secondaryAlreadyRequested &&
+    lastCopilotCommit !== prHeadSha &&
+    (outcome === 'CAP_EXHAUSTED' ||
+      (outcome === 'SATISFIED' && markerSummary.sameHeadMarkerPresent));
+  return {
+    protocolVersion: '1',
+    prHeadSha,
+    lastCopilotCommit,
+    copilotPending,
+    copilotPendingCoversHead,
+    outcome,
+    f3Outcome,
+    secondaryBotLogin: secondaryConfigured ? secondaryBotLogin : '',
+    secondaryRequestNeeded,
+    now,
+    requestCap,
+    pendingWindowMinutes,
+    settledWindowMinutes,
+    pollIntervalMinutes,
+    capExhaustedRoute,
+    elapsedMinutes,
+    sameHeadMarkerPresent: markerSummary.sameHeadMarkerPresent,
+    earliestSameHeadAt: markerSummary.earliestSameHeadAt,
+    sameHeadMarkerCount: markerSummary.sameHeadMarkerCount,
+    requestMarkerCount: markerSummary.requestMarkerCount,
+    trustedMarkerSummary: {
+      viewerLogin: String(options.viewerLogin ?? '')
+        .trim()
+        .toLowerCase(),
+      configuredTrustedActors,
+      collaboratorTrustEnabled: Boolean(options.collaboratorTrustEnabled),
+      trustedMarkerLogins,
+      trustedSameHeadMarkerCount: markerSummary.trustedSameHeadMarkerCount,
+      untrustedSameHeadMarkerCount: markerSummary.untrustedSameHeadMarkerCount,
+      trustedRequestMarkerCount: markerSummary.trustedRequestMarkerCount,
+      untrustedRequestMarkerCount: markerSummary.untrustedRequestMarkerCount,
+    },
+  };
+}
+export function buildActivitySnapshotSummary(
+  { comments = [], reviews = [], threads = [], checks = [] },
+  options = {},
+) {
+  const trustedMarkerLogins = new Set(
+    (options.trustedMarkerLogins ?? [])
+      .map((login) =>
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
+  );
+  const dispositionAuthorLogins = new Set(
+    normalizeTrustedMarkerLogins(options.dispositionAuthorLogins ?? []),
+  );
+  // An advisory bot can never anchor "dispositions exist": its own
+  // **Accepted**/**Rejected**-shaped replies must not start the
+  // post-disposition window that classifies its later acks.
+  for (const login of advisoryBotLogins) {
+    dispositionAuthorLogins.delete(login);
+  }
+  const isAdvisoryBot = (login) =>
+    isConfiguredAdvisoryBotLogin(login, advisoryBotLogins);
+  const isDispositionAuthor = (login) =>
+    dispositionAuthorLogins.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  const filteredComments = comments.filter((comment) => {
+    if (!trustedMarkerLogins.has((comment.author?.login ?? '').toLowerCase())) {
+      return true;
+    }
+    return operationalMarkerPrefixByStart(comment.body ?? '') === null;
+  });
+  // Structural ack-only evidence (#858): the posting moment of the latest
+  // disposition by a configured disposition author opens the window;
+  // comments and resolved-thread replies are classified per item below.
+  // Dispositions are not SHA-bound here — the head-changed check in
+  // diffReviewSnapshot plus the unchanged disposition-evidence and
+  // unreplied-comment gates backstop that residual.
+  const dispositionCreatedAts = [
+    ...filteredComments
+      .filter(
+        (comment) =>
+          isDispositionAuthor(comment.author?.login) &&
+          isDispositionComment(comment),
+      )
+      .map((comment) => comment.createdAt),
+    ...threads.flatMap((thread) =>
+      (thread.comments?.nodes ?? [])
+        .filter(
+          (comment) =>
+            isDispositionAuthor(comment.author?.login) &&
+            isDispositionComment(comment),
+        )
+        .map((comment) => comment.createdAt),
+    ),
+  ].filter(isValidIsoTimestamp);
+  const latestDispositionAt = maxIsoTimestamp(dispositionCreatedAts) ?? null;
+  const isAckOnlyComment = (comment) => {
+    if (!latestDispositionAt) {
+      return false;
+    }
+    if (!isAdvisoryBot(comment.author?.login)) {
+      return false;
+    }
+    if (isDispositionComment(comment)) {
+      return false;
+    }
+    const activityAt = comment.updatedAt ?? comment.createdAt;
+    if (!isValidIsoTimestamp(activityAt)) {
+      return false;
+    }
+    return compareIsoTimestamps(activityAt, latestDispositionAt) > 0;
+  };
+  const ackOnlyComments = filteredComments.filter(isAckOnlyComment);
+  const ackOnlyCommentSet = new Set(ackOnlyComments);
+  // On a resolved thread whose latest reply chain contains a disposition,
+  // later advisory-bot replies are structurally ack-only; the effective
+  // thread activity is recomputed from the remaining replies. Reopened
+  // (unresolved) threads always keep their raw activity.
+  const threadEffective = threads.map((thread) => {
+    const nodes = thread.comments?.nodes ?? [];
+    const threadDispositionAt =
+      maxIsoTimestamp(
+        nodes
+          .filter(
+            (comment) =>
+              isDispositionAuthor(comment.author?.login) &&
+              isDispositionComment(comment),
+          )
+          .map((comment) => comment.createdAt)
+          .filter(isValidIsoTimestamp),
+      ) ?? null;
+    // Per-reply attribution needs the reply timeline: when a caller
+    // populates thread.updatedAt we cannot tell whether it reflects an
+    // ack or substantive activity, so fail closed and keep raw activity
+    // (production normalizers blank thread.updatedAt to opt in).
+    if (
+      !thread.isResolved ||
+      !threadDispositionAt ||
+      isValidIsoTimestamp(thread.updatedAt ?? '')
+    ) {
+      return { activityAt: threadActivityAt(thread), ackReplies: [] };
+    }
+    const ackReplies = nodes.filter((comment) => {
+      if (!isAdvisoryBot(comment.author?.login)) {
+        return false;
+      }
+      if (isDispositionComment(comment)) {
+        return false;
+      }
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        isValidIsoTimestamp(activityAt) &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+      );
+    });
+    if (ackReplies.length === 0) {
+      return { activityAt: threadActivityAt(thread), ackReplies: [] };
+    }
+    const ackReplySet = new Set(ackReplies);
+    const keptActivities = nodes
+      .filter((comment) => !ackReplySet.has(comment))
+      .flatMap((comment) => [comment.updatedAt, comment.createdAt])
+      .filter(isValidIsoTimestamp);
+    return { activityAt: maxIsoTimestamp(keptActivities), ackReplies };
+  });
+  const ackOnlyThreadReplies = threadEffective.flatMap(
+    (entry) => entry.ackReplies,
+  );
+  const commentActivities = filteredComments
+    .map((comment) => comment.updatedAt ?? comment.createdAt)
+    .filter(isValidIsoTimestamp);
+  const reviewActivities = reviews
+    .map((review) => review.updatedAt ?? review.submittedAt ?? review.createdAt)
+    .filter(isValidIsoTimestamp);
+  const threadActivities = threads
+    .map((thread) => threadActivityAt(thread))
+    .filter(isValidIsoTimestamp);
+  const latestCiCompletedAt =
+    maxIsoTimestamp(
+      checks.map((check) => check.completedAt).filter(isCompletedCiTimestamp),
+    ) ?? 'none';
+  const latestPassingCiCompletedAt =
+    maxIsoTimestamp(
+      checks
+        .filter((check) => {
+          const state = String(check.state ?? '').toUpperCase();
+          return ['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
+            state,
+          );
+        })
+        .map((check) => check.completedAt)
+        .filter(isCompletedCiTimestamp),
+    ) ?? 'none';
+  const maxActivityUpdatedAt =
+    maxIsoTimestamp([
+      ...commentActivities,
+      ...reviewActivities,
+      ...threadActivities,
+    ]) ?? 'none';
+  const effectiveCommentActivities = filteredComments
+    .filter((comment) => !ackOnlyCommentSet.has(comment))
+    .map((comment) => comment.updatedAt ?? comment.createdAt)
+    .filter(isValidIsoTimestamp);
+  const effectiveThreadActivities = threadEffective
+    .map((entry) => entry.activityAt)
+    .filter(isValidIsoTimestamp);
+  const effectiveMaxActivityUpdatedAt =
+    maxIsoTimestamp([
+      ...effectiveCommentActivities,
+      ...reviewActivities,
+      ...effectiveThreadActivities,
+    ]) ?? 'none';
+  const describeAckItem = (kind, comment, activityAt) => ({
+    kind,
+    id: String(comment.id ?? ''),
+    author: String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase(),
+    activityAt: isValidIsoTimestamp(activityAt) ? activityAt : 'none',
+    bodyPreview: String(comment.body ?? '').slice(0, 120),
+  });
+  return {
+    totalItemCount: filteredComments.length + reviews.length + threads.length,
+    maxActivityUpdatedAt,
+    latestCiCompletedAt,
+    latestPassingCiCompletedAt,
+    counts: {
+      comments: filteredComments.length,
+      reviews: reviews.length,
+      threads: threads.length,
+    },
+    ackOnly: {
+      advisoryBotLogins: [...advisoryBotLogins].sort(),
+      source: String(options.advisoryBotLoginsSource ?? 'none'),
+      dispositionsPresent: Boolean(latestDispositionAt),
+      latestDispositionAt: latestDispositionAt ?? 'none',
+      items: [
+        ...ackOnlyComments.map((comment) =>
+          describeAckItem(
+            'comment',
+            comment,
+            comment.updatedAt ?? comment.createdAt,
+          ),
+        ),
+        ...ackOnlyThreadReplies.map((comment) =>
+          describeAckItem(
+            'thread-reply',
+            comment,
+            effectiveThreadCommentActivityAt(comment),
+          ),
+        ),
+      ],
+    },
+    effective: {
+      maxActivityUpdatedAt: effectiveMaxActivityUpdatedAt,
+      totalItemCount:
+        filteredComments.length -
+        ackOnlyComments.length +
+        reviews.length +
+        threads.length,
+    },
+  };
+}
+export function resolveLatestReviewWatermark(comments, options = {}) {
+  const expectedClaimId = String(options.expectedClaimId ?? '').trim();
+  const isTrustedAuthor = options.isTrustedAuthor ?? (() => true);
+  let latest = null;
+  for (const comment of comments) {
+    if (!isTrustedAuthor(comment.author?.login ?? comment.user?.login ?? '')) {
+      continue;
+    }
+    const parsed = parseReviewWatermarkComment(
+      comment.body ?? '',
+      comment.createdAt ?? comment.created_at ?? '',
+    );
+    if (!parsed) {
+      continue;
+    }
+    if (expectedClaimId && parsed.claimId !== expectedClaimId) {
+      continue;
+    }
+    const parsedCreatedAt = normalizeComparableTimestamp(parsed.createdAt);
+    if (parsedCreatedAt === null || parsedCreatedAt === 'none') {
+      continue;
+    }
+    const latestCreatedAt = normalizeComparableTimestamp(
+      latest?.createdAt ?? 'none',
+    );
+    if (
+      latestCreatedAt === null ||
+      latestCreatedAt === 'none' ||
+      parsedCreatedAt > latestCreatedAt
+    ) {
+      latest = parsed;
+    }
+  }
+  return latest;
+}
+// Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
+// does NOT feed `computePreMergeReadinessBlockers` (no code-rollup blocker), but
+// it is NOT harmless -- the written F2 gate "Unreplied comments = 0" in
+// `idd-pre-merge.instructions.md` routes any non-IDD regular comment without a
+// later IDD reply back to review triage. So globally promoting a non-agent into
+// `iddAgentLogins` filters that actor's genuine unreplied feedback out of the F2
+// gate (fail-OPEN at the process level; its comments are excluded and its reply
+// advances the watermark), while missing a real agent over-counts. See the
+// consolidated invariants above `summarizeDispositionEvidenceForGate`
+// (#1182 / PR #1184).
+export function summarizeRegularCommentsForGate(comments, options = {}) {
+  const iddAgentLogins = new Set(
+    normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
+  );
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
+  );
+  const trustedMarkerLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const threads = Array.isArray(options.threads) ? options.threads : [];
+  const normalized = comments
+    .map((comment, inputIndex) => ({
+      id: String(comment.id ?? ''),
+      authorLogin: String(comment.author?.login ?? comment.user?.login ?? '')
+        .trim()
+        .toLowerCase(),
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      updatedAt: String(comment.updatedAt ?? comment.updated_at ?? ''),
+      inputIndex,
+    }))
+    .filter((comment) => isValidIsoTimestamp(comment.createdAt))
+    .map((comment) => ({
+      ...comment,
+      activityAt: effectiveRegularCommentActivityAt(comment),
+    }))
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.activityAt);
+      const rightTime = Date.parse(right.activityAt);
+      if (leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      return left.inputIndex - right.inputIndex;
+    })
+    .map((comment, sortedIndex) => ({ ...comment, sortedIndex }));
+  const lastIddReplyAt = normalized.reduce((latestTimestamp, comment) => {
+    if (
+      isOperationalOrDigestCommentForGate(
+        comment.body,
+        comment.authorLogin,
+        trustedMarkerLogins,
+      ) ||
+      !iddAgentLogins.has(comment.authorLogin)
+    ) {
+      return latestTimestamp;
+    }
+    if (
+      !latestTimestamp ||
+      compareIsoTimestamps(comment.createdAt, latestTimestamp) > 0
+    ) {
+      return comment.createdAt;
+    }
+    return latestTimestamp;
+  }, '');
+  const classificationComments = normalized.map((comment) => ({
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
+  }));
+  // #1182 A trusted-marker actor's machine-generated advisory disposition — and
+  // the advisory-bot sticky it names, matched by bot + type + consumed 1:1 via
+  // `matchTrustedAdvisoryStickyDispositions` — is not an unreplied comment.
+  // Recognized per item, NOT by promoting the author to a global IDD agent (which
+  // would fail the thread gate open) and NOT by advancing the `lastIddReplyAt`
+  // watermark (which would clear unrelated earlier feedback). Keyed on the two
+  // machine forms only, so a trusted human's ordinary `**Accepted**` /
+  // `**Rejected**` review disposition stays a genuine comment.
+  const isTrustedMachineDisposition = (authorLogin, body) =>
+    trustedMarkerLogins.has(authorLogin) &&
+    (isNonReviewNoticeDisposition({ body }) ||
+      isReviewSummaryDisposition({ body }));
+  const dispositionedStickyIndexes = matchTrustedAdvisoryStickyDispositions(
+    normalized,
+    advisoryBotLogins,
+    trustedMarkerLogins,
+    iddAgentLogins,
+  );
+  const items = normalized
+    .filter(
+      (comment) =>
+        !isOperationalOrDigestCommentForGate(
+          comment.body,
+          comment.authorLogin,
+          trustedMarkerLogins,
+        ),
+    )
+    .filter((comment) => !iddAgentLogins.has(comment.authorLogin))
+    .filter(
+      (comment) =>
+        !isTrustedMachineDisposition(comment.authorLogin, comment.body) &&
+        !dispositionedStickyIndexes.has(comment.sortedIndex),
+    )
+    .filter(
+      (comment) =>
+        !lastIddReplyAt ||
+        compareIsoTimestamps(lastIddReplyAt, comment.activityAt) <= 0,
+    )
+    .filter((comment) => {
+      if (!isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins)) {
+        return true;
+      }
+      return (
+        classifyRegularBotComment(
+          {
+            author: { login: comment.authorLogin },
+            body: comment.body,
+            createdAt: comment.createdAt,
+          },
+          classificationComments,
+          threads,
+          {
+            isDispositionAuthor: (login) =>
+              iddAgentLogins.has(
+                String(login ?? '')
+                  .trim()
+                  .toLowerCase(),
+              ),
+          },
+        ) === null
+      );
+    })
+    .map((comment) => ({
+      id: comment.id,
+      authorLogin: comment.authorLogin,
+      createdAt: comment.createdAt,
+      bodyPreview: buildBodyPreview(comment.body),
+    }));
+  return {
+    count: items.length,
+    items,
+  };
+}
+// Pre-merge gate invariants -- READ BEFORE MODIFYING ANY `iddAgentLogins`-KEYED
+// GATE HELPER. Three functions key disposition, reply, and thread-author
+// recognition on `iddAgentLogins`, and each reacts DIFFERENTLY when that
+// recognition is wrong:
+//   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
+//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Both
+//      recognition-error directions matter: FAILING to recognize a real agent
+//      leaves its own disposition/reply in the outstanding set -> over-block
+//      (fail-closed); GLOBALLY promoting a non-agent instead drops that actor's
+//      genuine outstanding feedback (this fn excludes `iddAgentLogins` authors
+//      from `outstandingComments`), so `blockingCount` can fall to 0 ->
+//      fail-OPEN.
+//   2. `summarizeReviewThreadsForGate` (`actionableCount`) -- MERGE-BLOCKING.
+//      Without required conversation resolution, an IDD agent's latest thread
+//      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a
+//      non-agent into `iddAgentLogins` makes that actor's genuine unresolved
+//      feedback stop blocking -> fail-OPEN. This gate keys on latest-author
+//      identity, not disposition recognition.
+//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) -- does NOT feed
+//      `computePreMergeReadinessBlockers`, but the written F2 gate "Unreplied
+//      comments = 0" (`idd-pre-merge.instructions.md`) still consumes it, so
+//      promoting a non-agent filters that actor's unreplied feedback out of
+//      that gate -> fail-OPEN at the process level (not harmless).
+// Across all three: never globally promote a non-agent into `iddAgentLogins` --
+// recognize each item by its own author.
+// Notice vs summary matching asymmetry (implemented and documented in detail on
+// `matchTrustedAdvisoryStickyDispositions`): a non-review NOTICE disposition
+// matches time-agnostically -- it carries forward across a re-posted notice
+// while the bot still has not reviewed (the #1018 carry-forward) -- while a
+// SUMMARY disposition must be STRICTLY NEWER than the sticky, so a stale
+// `**Accepted**` cannot clear a summary re-edited after it (the #1122 "a false
+// positive is a false merge" hazard).
+// Working rule: verify every advisory finding on this code with a byte-exact
+// repro before accepting it. #1182 / PR #1184 cycled through five advisory
+// rounds, each surfacing a distinct fail mode of exactly these gates.
+export function summarizeDispositionEvidenceForGate(
+  { comments = [], threads = [] },
+  options = {},
+) {
+  const iddAgentLogins = new Set(
+    normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
+  );
+  // The review-snapshot boundary (the active watermark's
+  // max-activity-updatedAt). A resolved thread whose newest external feedback
+  // predates it was settled before the snapshot and is out of E7 scope.
+  const snapshotBoundaryAt = isValidIsoTimestamp(options.snapshotBoundaryAt)
+    ? String(options.snapshotBoundaryAt)
+    : null;
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
+  );
+  const trustedMarkerLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const prAuthorLogin = String(options.prAuthorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const normalizedComments = comments
+    .map((comment, inputIndex) => ({
+      id: String(comment.id ?? ''),
+      authorLogin: String(comment.author?.login ?? comment.user?.login ?? '')
+        .trim()
+        .toLowerCase(),
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      updatedAt: String(comment.updatedAt ?? comment.updated_at ?? ''),
+      inputIndex,
+    }))
+    .filter((comment) => isValidIsoTimestamp(comment.createdAt))
+    .map((comment) => ({
+      ...comment,
+      activityAt: effectiveRegularCommentActivityAt(comment),
+    }))
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.activityAt);
+      const rightTime = Date.parse(right.activityAt);
+      if (leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      return left.inputIndex - right.inputIndex;
+    })
+    .map((comment, sortedIndex) => ({ ...comment, sortedIndex }));
+  const classificationComments = normalizedComments.map((comment) => ({
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
+  }));
+  // #1182 trusted machine-disposition recognition, scoped to this gate. A
+  // trusted-marker actor who authored one of the two machine-generated advisory
+  // disposition forms `disposition-non-review-notices` emits — `**Rejected** —
+  // {bot} did not review HEAD …` (`isNonReviewNoticeDisposition`) or
+  // `**Accepted** — {bot} summary walkthrough …` (`isReviewSummaryDisposition`)
+  // — must have that disposition honored even when the author was not resolved
+  // into `iddAgentLogins` (e.g. a second trusted session posted it). It is
+  // deliberately NOT promoted into a global IDD-agent identity: that same set is
+  // passed to `summarizeReviewThreadsForGate`, where an IDD-agent's latest
+  // thread comment is `awaiting-reviewer` rather than `actionable-blocking`, so
+  // a global promotion would let the actor's genuine unresolved review feedback
+  // stop blocking. Recognition stays HERE and covers ONLY the two machine forms
+  // — never the general `**Accepted**` / `**Rejected**` prefix — so a trusted
+  // human's ordinary review disposition is not swallowed. The disposition itself
+  // is dropped from the outstanding set (below); the advisory sticky it clears is
+  // matched by bot + type + 1:1 and bound to that item by
+  // `matchTrustedAdvisoryStickyDispositions` — never joining the generic 1:1
+  // pool, so a trusted disposition whose sticky is absent/already-resolved cannot
+  // clear an unrelated human comment.
+  const isTrustedMachineDisposition = (authorLogin, body) =>
+    trustedMarkerLogins.has(authorLogin) &&
+    (isNonReviewNoticeDisposition({ body }) ||
+      isReviewSummaryDisposition({ body }));
+  const trustedDispositionedStickyIndexes =
+    matchTrustedAdvisoryStickyDispositions(
+      normalizedComments,
+      advisoryBotLogins,
+      trustedMarkerLogins,
+      iddAgentLogins,
+    );
+  const outstandingComments = normalizedComments
+    .filter(
+      (comment) =>
+        !isOperationalOrDigestCommentForGate(
+          comment.body,
+          comment.authorLogin,
+          trustedMarkerLogins,
+        ),
+    )
+    .filter(
+      (comment) =>
+        !iddAgentLogins.has(comment.authorLogin) &&
+        !isTrustedMachineDisposition(comment.authorLogin, comment.body),
+    )
+    .filter((comment) => {
+      if (!isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins)) {
+        return true;
+      }
+      return (
+        classifyRegularBotComment(
+          {
+            author: { login: comment.authorLogin },
+            body: comment.body,
+            createdAt: comment.createdAt,
+          },
+          classificationComments,
+          threads,
+          {
+            isDispositionAuthor: (login) =>
+              iddAgentLogins.has(
+                String(login ?? '')
+                  .trim()
+                  .toLowerCase(),
+              ),
+          },
+        ) === null
+      );
+    });
+  // Only IDD-agent dispositions feed the generic 1:1 pool. Trusted machine
+  // dispositions are handled solely by `trustedDispositionedStickyIndexes`
+  // (bot + type matched), so they can never clear an unrelated regular comment.
+  const dispositionComments = normalizedComments.filter(
+    (comment) =>
+      iddAgentLogins.has(comment.authorLogin) &&
+      isDispositionComment({ body: comment.body }),
+  );
+  // #1018 non-review-notice carry-forward (fail-closed, author-scoped). A
+  // persistent advisory non-review notice already dispositioned `**Rejected** —
+  // {bot-login} did not review HEAD …` keeps that disposition across HEAD changes
+  // while the bot still has not reviewed any HEAD: a Codex `updatedAt` bump or a
+  // re-posted CodeRabbit rate-limit summary must not re-flag
+  // `missing-disposition-evidence` for a notice the agent already rejected.
+  //
+  // Each carry-forward is matched strictly WITHIN one advisory-bot identity: a
+  // notice carries forward only against a notice-disposition whose body names
+  // that same bot's GitHub login. This repository can configure several advisory
+  // bots at once (CodeRabbit + a Codex connector), so a count/order-only pairing
+  // could credit bot A's disposition to bot B's still-undispositioned notice and
+  // suppress a real blocker. An unattributable disposition (one that names no
+  // configured bot login) carries nothing forward — the original re-disposition
+  // churn, which is safe. Matched notices leave the outstanding set and the
+  // matched notice-dispositions leave the general disposition pool, so a notice
+  // disposition never also clears an unrelated regular comment and the notice's
+  // bumped activity can never strand its disposition. The guard re-checks the
+  // current notice body, so a notice the bot later replaces with a real review no
+  // longer matches and still needs a fresh disposition. Any unmatched notice or
+  // disposition falls through to the unchanged 1:1 pairing.
+  const noticeDispositions = dispositionComments.filter((comment) =>
+    isNonReviewNoticeDisposition({ body: comment.body }),
+  );
+  // #1833 diagnostic-only (see `NON_REVIEW_NOTICE_DISPOSITION_HINT` /
+  // `DispositionEvidenceSummary.missingRegularComments[].hint`): IDD-agent
+  // replies that start with `**Rejected**` -- so `isDispositionComment` and
+  // the generic 1:1 pairing both accept them as SOME disposition -- but that
+  // do not match `isNonReviewNoticeDisposition`'s stricter `did not review
+  // HEAD` phrase requirement, so they can never satisfy the notice-specific
+  // carry-forward above. Kept separate from `noticeDispositions` (its exact
+  // complement within `**Rejected**`-prefixed replies) purely to power the
+  // hint; never feeds `carriedNoticeIndexes`, `dispositionTimes`, or any
+  // other routing input.
+  //
+  // Deliberately NOT attributed per-bot: `dispositionNamesAdvisoryBot`
+  // (the carry-forward's own bot-attribution helper) can only anchor on the
+  // canonical `did not review HEAD` template's span, so a wrong-phrase
+  // reply -- missing that exact phrase by definition -- can never be
+  // attributed to one bot over another by construction. In a multi-bot
+  // scenario (e.g. CodeRabbit's notice correctly dispositioned, Codex's
+  // still missing) the hint below attaches to every still-missing notice
+  // that ANY wrong-phrase reply postdates, not just the one it may have
+  // been intended for. Advisory-only, so this is a diagnostic false
+  // positive at worst, never a routing change.
+  const wrongPhraseRejectedDispositions = dispositionComments.filter(
+    (comment) =>
+      DISPOSITION_REJECTED_PREFIX_RE.test(comment.body.trimStart()) &&
+      !isNonReviewNoticeDisposition({ body: comment.body }),
+  );
+  const outstandingNotices = outstandingComments.filter(
+    (comment) =>
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body),
+  );
+  const carriedNoticeIndexes = new Set();
+  const consumedNoticeDispositionIndexes = new Set();
+  const noticesByAuthor = new Map();
+  for (const notice of outstandingNotices) {
+    const list = noticesByAuthor.get(notice.authorLogin) ?? [];
+    list.push(notice);
+    noticesByAuthor.set(notice.authorLogin, list);
+  }
+  // Sort the bot logins so disposition consumption is deterministic when a single
+  // disposition body could name more than one configured bot (it is consumed by
+  // the lexicographically-first matching author only).
+  for (const authorLogin of [...noticesByAuthor.keys()].sort()) {
+    const notices = noticesByAuthor.get(authorLogin) ?? [];
+    const matchingDispositions = noticeDispositions.filter(
+      (disposition) =>
+        !consumedNoticeDispositionIndexes.has(disposition.sortedIndex) &&
+        dispositionNamesAdvisoryBot(disposition.body, authorLogin),
+    );
+    const carry = Math.min(notices.length, matchingDispositions.length);
+    for (let index = 0; index < carry; index += 1) {
+      carriedNoticeIndexes.add(notices[index].sortedIndex);
+      consumedNoticeDispositionIndexes.add(
+        matchingDispositions[index].sortedIndex,
+      );
+    }
+  }
+  // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
+  // disposition marker addresses at most ONE earlier regular comment, so one
+  // trailing marker cannot clear several distinct comments that each still
+  // lack a disposition.
+  // Walk the outstanding comments oldest-first and greedily consume the
+  // earliest disposition marker strictly newer than each (markers that are not
+  // newer than the current comment cannot address it or any later comment).
+  const dispositionTimes = dispositionComments
+    .filter(
+      (comment) => !consumedNoticeDispositionIndexes.has(comment.sortedIndex),
+    )
+    .map((comment) => comment.activityAt)
+    .filter(isValidIsoTimestamp)
+    .sort((left, right) => Date.parse(left) - Date.parse(right));
+  let markerCursor = 0;
+  const missing = [];
+  for (const comment of outstandingComments) {
+    if (
+      carriedNoticeIndexes.has(comment.sortedIndex) ||
+      trustedDispositionedStickyIndexes.has(comment.sortedIndex)
+    ) {
+      continue;
+    }
+    while (
+      markerCursor < dispositionTimes.length &&
+      compareIsoTimestamps(
+        dispositionTimes[markerCursor],
+        comment.activityAt,
+      ) <= 0
+    ) {
+      markerCursor += 1;
+    }
+    if (markerCursor < dispositionTimes.length) {
+      markerCursor += 1;
+    } else {
+      missing.push(comment);
+    }
+  }
+  const missingRegularComments = missing.map((comment) => {
+    // #1833: only hint when this missing item is itself a recognized
+    // advisory non-review notice AND a wrong-phrase `**Rejected**` attempt
+    // exists that postdates the notice's original `createdAt` -- so the hint
+    // targets the specific comment a human/agent plausibly already tried
+    // (and mis-phrased) rather than every unrelated missing item whenever any
+    // wrong-phrase reply exists anywhere. Deliberately compares against
+    // `createdAt`, not the notice's (possibly bumped) `activityAt`: the
+    // motivating scenario is a wrong-phrase reply posted right after the
+    // notice first appeared, followed by a re-triggered bot bumping
+    // `updatedAt` past that reply -- which is exactly what strands the item
+    // in `missing` in the first place (see the `activityAt`-based general 1:1
+    // pairing above), so requiring the attempt to postdate the bumped
+    // `activityAt` would always be false in the one case this hint exists
+    // for.
+    const isNoticeComment =
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body);
+    const hasWrongPhraseAttempt =
+      isNoticeComment &&
+      wrongPhraseRejectedDispositions.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
+    return {
+      id: comment.id || `comment-${comment.sortedIndex + 1}`,
+      authorLogin: comment.authorLogin || 'unknown',
+      createdAt: comment.createdAt,
+      bodyPreview: buildBodyPreview(comment.body),
+      ...(hasWrongPhraseAttempt
+        ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
+        : {}),
+    };
+  });
+  // #978 advisory-only diagnostic: a blocking resolved thread is
+  // "ack-only-post-disposition" when a thread-local IDD disposition exists and
+  // EVERY external comment newer than BOTH the snapshot boundary (so it re-blocks
+  // the gate) AND the disposition is an advisory-bot, non-disposition courtesy
+  // ack. Reuses the review-currency carve-out's recognition shape (advisory-bot
+  // predicate driven by `advisoryBotLogins`, no hard-coded logins;
+  // post-disposition ack). Fails closed (false) without a snapshot boundary,
+  // without a thread-local disposition, or for unresolved threads, and never
+  // changes the gate route.
+  //
+  // #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
+  // same pass (it needs the identical `threadDispositionAt` /
+  // `postDispositionBlockingFeedback` groundwork, so folding it into one
+  // function avoids recomputing that twice). `inPlaceEditOnly` additionally
+  // requires every qualifying comment to be an in-place edit of content that
+  // already existed at-or-before the disposition (its own `createdAt` is not
+  // newer than the disposition, and its `updatedAt` is strictly newer than
+  // its own `createdAt`) rather than a brand-new post-disposition comment --
+  // the #1313 report's exact scenario (a bot editing its own
+  // already-dispositioned finding in place, e.g. to append a cosmetic
+  // "addressed" badge). Deliberately advisory-only, like its sibling:
+  // GitHub's API exposes no revision diff for an edited comment, so this
+  // helper cannot tell a cosmetic append from a substantive change to the
+  // finding -- an agent that wants to act on this signal must still read the
+  // comment's current body before treating the block as safe to override.
+  const classifyThreadAckOnlyPostDisposition = (thread) => {
+    const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
+    if (!thread.isResolved || !snapshotBoundaryAt) {
+      return none;
+    }
+    const nodes = thread.comments?.nodes ?? [];
+    // Recognize the same dispositions `hasFreshDisposition` accepts on a
+    // resolved thread (the gate that already decided this thread blocks): a
+    // `**Accepted**`/`**Rejected**` marker OR the terminal
+    // `**Rejection confirmed by maintainer**` marker, anchored by effective
+    // activity (`updatedAt`-preferring) so an edited disposition is dated
+    // consistently. The thread is already known resolved here.
+    const threadDispositionAt = maxIsoTimestamp(
+      nodes
+        .filter(
+          (comment) =>
+            iddAgentLogins.has(
+              String(comment.author?.login ?? '')
+                .trim()
+                .toLowerCase(),
+            ) &&
+            (isDispositionComment({ body: String(comment.body ?? '') }) ||
+              isRejectionConfirmedDisposition({
+                body: String(comment.body ?? ''),
+              })),
+        )
+        .map((comment) => effectiveThreadCommentActivityAt(comment))
+        .filter(isValidIsoTimestamp),
+    );
+    if (!threadDispositionAt) {
+      return none;
+    }
+    // The blocking activity is external feedback newer than BOTH the snapshot
+    // boundary (so it actually re-blocks the gate) AND the thread disposition
+    // (so already-dispositioned feedback predating the ack does not disqualify
+    // the signal). When the disposition lands after the boundary, the
+    // post-disposition bound is what isolates the genuine ack.
+    const postDispositionBlockingFeedback = nodes.filter((comment) => {
+      const authorLogin = String(comment.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (
+        !authorLogin ||
+        iddAgentLogins.has(authorLogin) ||
+        authorLogin === prAuthorLogin
+      ) {
+        return false;
+      }
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        isValidIsoTimestamp(activityAt) &&
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0 &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+      );
+    });
+    if (postDispositionBlockingFeedback.length === 0) {
+      return none;
+    }
+    // Each remaining item must be a pure advisory-bot courtesy ack: an
+    // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
+    // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
+    const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
+      (comment) =>
+        isConfiguredAdvisoryBotLogin(
+          comment.author?.login,
+          advisoryBotLogins,
+        ) &&
+        !isDispositionComment({ body: String(comment.body ?? '') }) &&
+        !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
+    );
+    if (!ackOnlyPostDisposition) {
+      return none;
+    }
+    const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
+      const createdAt = String(comment.createdAt ?? '');
+      const updatedAt = String(comment.updatedAt ?? '');
+      return (
+        isValidIsoTimestamp(createdAt) &&
+        compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
+        isValidIsoTimestamp(updatedAt) &&
+        compareIsoTimestamps(updatedAt, createdAt) > 0
+      );
+    });
+    return { ackOnlyPostDisposition, inPlaceEditOnly };
+  };
+  const missingThreads = (threads ?? [])
+    .map((thread, index) => {
+      const commentsInThread = thread.comments?.nodes ?? [];
+      const hasExternalFeedback = commentsInThread.some((comment) => {
+        const authorLogin = String(comment.author?.login ?? '')
+          .trim()
+          .toLowerCase();
+        return (
+          authorLogin &&
+          !iddAgentLogins.has(authorLogin) &&
+          authorLogin !== prAuthorLogin
+        );
+      });
+      if (!hasExternalFeedback) {
+        return null;
+      }
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        return {
+          id: String(thread.id ?? '') || `thread-${index + 1}`,
+          isResolved: Boolean(thread.isResolved),
+          reason: 'incomplete-thread-comments',
+          ackOnlyPostDisposition: false,
+          inPlaceEditOnly: false,
+        };
+      }
+      if (
+        hasFreshDisposition(thread, {
+          isDispositionAuthor: (login) =>
+            iddAgentLogins.has(
+              String(login ?? '')
+                .trim()
+                .toLowerCase(),
+            ),
+        })
+      ) {
+        return null;
+      }
+      // E1 only snapshots UNRESOLVED non-awaiting threads, and E7 only requires
+      // dispositions for snapshot items. A thread that is already resolved and
+      // whose newest external feedback predates the review-snapshot boundary was
+      // settled out-of-band (or resolved by the reviewer) and must not block; a
+      // resolved thread with external feedback newer than the boundary (e.g.
+      // freshly reopened) still requires a disposition.
+      if (thread.isResolved && snapshotBoundaryAt) {
+        const newestFeedbackAt = maxIsoTimestamp(
+          commentsInThread
+            .filter((comment) => {
+              const authorLogin = String(comment.author?.login ?? '')
+                .trim()
+                .toLowerCase();
+              return (
+                authorLogin &&
+                !iddAgentLogins.has(authorLogin) &&
+                authorLogin !== prAuthorLogin
+              );
+            })
+            .map((comment) => effectiveThreadCommentActivityAt(comment))
+            .filter(isValidIsoTimestamp),
+        );
+        if (
+          !newestFeedbackAt ||
+          compareIsoTimestamps(newestFeedbackAt, snapshotBoundaryAt) <= 0
+        ) {
+          return null;
+        }
+      }
+      const classification = classifyThreadAckOnlyPostDisposition(thread);
+      return {
+        id: String(thread.id ?? '') || `thread-${index + 1}`,
+        isResolved: Boolean(thread.isResolved),
+        reason: thread.isResolved
+          ? 'missing-fresh-disposition'
+          : 'unresolved-without-fresh-disposition',
+        ackOnlyPostDisposition: classification.ackOnlyPostDisposition,
+        inPlaceEditOnly: classification.inPlaceEditOnly,
+      };
+    })
+    .filter(Boolean);
+  const blockingCount = missingRegularComments.length + missingThreads.length;
+  // #978: the sole blocking cause is post-disposition advisory-bot ack-only
+  // activity. True only when something blocks AND every blocking item is an
+  // ack-only-post-disposition resolved thread (no missing regular comments, no
+  // non-ack thread). The guard implies missingThreads is non-empty, so `.every`
+  // is never vacuously true.
+  const soleCauseAckOnlyPostDisposition =
+    blockingCount > 0 &&
+    missingRegularComments.length === 0 &&
+    missingThreads.every((entry) => entry.ackOnlyPostDisposition === true);
+  // #1313: narrower sibling -- true only when every blocking item is ALSO an
+  // in-place edit of pre-existing content (see `inPlaceEditOnly` above). A
+  // strict subset of `soleCauseAckOnlyPostDisposition`.
+  const soleCauseInPlaceEditOnly =
+    blockingCount > 0 &&
+    missingRegularComments.length === 0 &&
+    missingThreads.every((entry) => entry.inPlaceEditOnly === true);
+  return {
+    route: blockingCount > 0 ? 'return-to-e1' : 'proceed',
+    reason: blockingCount > 0 ? 'missing-disposition-evidence' : 'complete',
+    blockingCount,
+    missingRegularCommentCount: missingRegularComments.length,
+    missingThreadCount: missingThreads.length,
+    soleCauseAckOnlyPostDisposition,
+    soleCauseInPlaceEditOnly,
+    missingRegularComments,
+    missingThreads,
+  };
+}
+export function summarizeBranchReviewRequirements(
+  branchRules = [],
+  branchProtection = {},
+) {
+  const requiredCheckNames = new Set();
+  // #1689: the subset of requiredCheckNames whose ruleset/classic-protection
+  // entry is source-pinned (see `summarizeRequiredCheckMetadata`'s
+  // `pinnedNames`) -- lets `summarizeRequiredChecks` name the specific
+  // pinned check(s) in a blocker detail instead of a generic message.
+  const requiredCheckSourcePinnedNames = new Set();
+  const requiredReviewerLogins = new Set();
+  const requiredReviewerTeams = new Set();
+  const requiredReviewerRequirements = [];
+  const classicBypassPullRequestUserLogins = new Set();
+  const classicBypassPullRequestTeamSlugs = new Set();
+  const classicBypassPullRequestAppSlugs = new Set();
+  let requiredApprovingReviewCount = 0;
+  let requireCodeOwnerReview = false;
+  let classicRequireCodeOwnerReview = false;
+  let requiresConversationResolution = false;
+  let requiredCheckSourcePinned = false;
+  // #1689: true when at least one pinned source cannot be attributed to a
+  // resolved check name (a `workflows` rule, or a pinned entry with no
+  // `context`/`name`/`check`) -- independent of whether OTHER, named-and-
+  // pinned entries also exist. `trustSourcePinnedRequiredChecks` must never
+  // bypass the downgrade while this is true, even when
+  // `requiredCheckSourcePinnedNames` is non-empty from a separate entry.
+  let requiredCheckSourcePinnedUnresolved = false;
+  for (const rule of branchRules) {
+    if (rule?.type === 'pull_request') {
+      const parameters = rule.parameters ?? {};
+      requiredApprovingReviewCount = Math.max(
+        requiredApprovingReviewCount,
+        Number(parameters.required_approving_review_count ?? 0) || 0,
+      );
+      requireCodeOwnerReview =
+        requireCodeOwnerReview || Boolean(parameters.require_code_owner_review);
+      requiresConversationResolution =
+        requiresConversationResolution ||
+        Boolean(parameters.required_review_thread_resolution);
+      for (const reviewer of parameters.required_reviewers ?? []) {
+        const requirement = extractRequiredReviewerRequirement(reviewer);
+        if (!requirement.identity) {
+          continue;
+        }
+        requiredReviewerRequirements.push(requirement);
+        if (requirement.identity.includes('/')) {
+          requiredReviewerTeams.add(requirement.identity);
+        } else {
+          requiredReviewerLogins.add(requirement.identity);
+        }
+      }
+      continue;
+    }
+    if (rule?.type === 'required_status_checks') {
+      const checkMetadata = summarizeRequiredCheckMetadata(
+        rule.parameters ?? {},
+      );
+      requiredCheckSourcePinned =
+        requiredCheckSourcePinned || checkMetadata.sourcePinned;
+      requiredCheckSourcePinnedUnresolved =
+        requiredCheckSourcePinnedUnresolved || checkMetadata.unresolvedPinned;
+      for (const name of checkMetadata.names) {
+        requiredCheckNames.add(name);
+      }
+      for (const name of checkMetadata.pinnedNames) {
+        requiredCheckSourcePinnedNames.add(name);
+      }
+      continue;
+    }
+    if (rule?.type === 'workflows') {
+      requiredCheckSourcePinned = true;
+      requiredCheckSourcePinnedUnresolved = true;
+    }
+  }
+  const protectionReviews =
+    branchProtection.required_pull_request_reviews ?? {};
+  classicRequireCodeOwnerReview =
+    Boolean(protectionReviews.require_code_owner_reviews) ||
+    Boolean(protectionReviews.require_code_owner_review);
+  for (const user of protectionReviews.bypass_pull_request_allowances?.users ??
+    []) {
+    const login = typeof user === 'string' ? user : user?.login;
+    for (const normalizedLogin of normalizeTrustedMarkerLogins([login])) {
+      classicBypassPullRequestUserLogins.add(normalizedLogin);
+    }
+  }
+  for (const team of protectionReviews.bypass_pull_request_allowances?.teams ??
+    []) {
+    const slug = typeof team === 'string' ? team : team?.slug;
+    for (const normalizedSlug of normalizeTrustedMarkerLogins([slug])) {
+      classicBypassPullRequestTeamSlugs.add(normalizedSlug);
+    }
+  }
+  for (const app of protectionReviews.bypass_pull_request_allowances?.apps ??
+    []) {
+    const slug = typeof app === 'string' ? app : (app?.slug ?? app?.app_slug);
+    for (const normalizedSlug of normalizeTrustedMarkerLogins([slug])) {
+      classicBypassPullRequestAppSlugs.add(normalizedSlug);
+    }
+  }
+  requiredApprovingReviewCount = Math.max(
+    requiredApprovingReviewCount,
+    Number(protectionReviews.required_approving_review_count ?? 0) || 0,
+  );
+  requireCodeOwnerReview =
+    requireCodeOwnerReview || classicRequireCodeOwnerReview;
+  requiresConversationResolution =
+    requiresConversationResolution ||
+    Boolean(branchProtection.required_conversation_resolution?.enabled);
+  const protectionCheckMetadata = summarizeRequiredCheckMetadata(
+    branchProtection.required_status_checks ?? {},
+  );
+  requiredCheckSourcePinned =
+    requiredCheckSourcePinned || protectionCheckMetadata.sourcePinned;
+  requiredCheckSourcePinnedUnresolved =
+    requiredCheckSourcePinnedUnresolved ||
+    protectionCheckMetadata.unresolvedPinned;
+  for (const name of protectionCheckMetadata.names) {
+    requiredCheckNames.add(name);
+  }
+  for (const name of protectionCheckMetadata.pinnedNames) {
+    requiredCheckSourcePinnedNames.add(name);
+  }
+  return {
+    requiredApprovingReviewCount,
+    requireCodeOwnerReview,
+    classicRequireCodeOwnerReview,
+    classicBypassPullRequestUserLogins: [
+      ...classicBypassPullRequestUserLogins,
+    ].sort(),
+    classicBypassPullRequestTeamSlugs: [
+      ...classicBypassPullRequestTeamSlugs,
+    ].sort(),
+    classicBypassPullRequestAppSlugs: [
+      ...classicBypassPullRequestAppSlugs,
+    ].sort(),
+    requiresConversationResolution,
+    requiredCheckSourcePinned,
+    requiredCheckSourcePinnedNames: [...requiredCheckSourcePinnedNames].sort(),
+    requiredCheckSourcePinnedUnresolved,
+    requiredReviewerLogins: [...requiredReviewerLogins].sort(),
+    requiredReviewerTeams: [...requiredReviewerTeams].sort(),
+    requiredReviewerRequirements,
+    requiredCheckNames: [...requiredCheckNames].sort(),
+  };
+}
+/**
+ * #1513: resolve whether the base branch's protection or ruleset requires
+ * an up-to-date head before merge, and pair that with the PR's live
+ * `mergeStateStatus` / `mergeable`. Neither `pre-merge-readiness.mts` nor
+ * `idd-merge-execute.mts` previously read this at all -- a live `BEHIND`
+ * PR could report `ready: true` right up to the uncaught `gh pr merge`
+ * rejection (the field incident this issue documents).
+ *
+ * Resolution order mirrors `summarizeRequiredChecks`'s existing
+ * ruleset-then-classic precedence: a ruleset's `required_status_checks`
+ * rule carries `strict_required_status_checks_policy` (confirmed
+ * empirically against this repository's own `main`: classic protection
+ * returns a genuine 404 "Branch not protected", while
+ * `rules/branches/main` returns this field as `true`); classic
+ * protection's equivalent field is `required_status_checks.strict`. When
+ * neither source resolves `true` AND the branch-protection/ruleset reads
+ * were unreadable (a masked 403-as-404, see `protectionReadsUnreadable`
+ * in `pre-merge-readiness.mts`), fail closed per
+ * `idd-overview-core.instructions.md`'s fail-closed default: assume the
+ * requirement is present rather than silently reporting "no requirement."
+ * Only a genuinely readable "no rule found" resolves to `none`.
+ *
+ * Strict `=== true` checks throughout (not `Boolean(...)` coercion) per
+ * the write-side mutation-helper critique lens
+ * (`idd-overview-appendix.instructions.md`): a non-boolean or missing
+ * value must never be silently coerced into "requirement satisfied."
+ */
+export function summarizeBranchCurrency(
+  branchRules = [],
+  branchProtection = {},
+  options = {},
+) {
+  // #1513 (Copilot/Codex review on PR #1538): GitHub's ruleset docs state
+  // `strict_required_status_checks_policy` "will not take effect unless at
+  // least one status check is enabled" -- confirmed against
+  // https://docs.github.com/en/rest/repos/rules. Treating the flag alone as
+  // authoritative would false-positive block a BEHIND PR under an
+  // empty-required-check ruleset that GitHub itself would allow to merge, so
+  // also require a non-empty required-check list (reusing the same
+  // extraction `summarizeRequiredChecks` already uses for check names).
+  // Classic branch protection's `required_status_checks.strict` carries no
+  // equivalent documented caveat, so it is left unconditional.
+  const rulesetRequires = (branchRules ?? []).some(
+    (rule) =>
+      rule?.type === 'required_status_checks' &&
+      rule.parameters?.strict_required_status_checks_policy === true &&
+      summarizeRequiredCheckMetadata(rule.parameters ?? {}).names.length > 0,
+  );
+  const classicRequires =
+    branchProtection.required_status_checks?.strict === true;
+  let requiresUpToDateHead;
+  let requiresUpToDateHeadSource;
+  if (rulesetRequires) {
+    requiresUpToDateHead = true;
+    requiresUpToDateHeadSource = 'ruleset';
+  } else if (classicRequires) {
+    requiresUpToDateHead = true;
+    requiresUpToDateHeadSource = 'classic-protection';
+  } else if (options.protectionReadsUnreadable === true) {
+    requiresUpToDateHead = true;
+    requiresUpToDateHeadSource = 'unreadable-fail-closed';
+  } else {
+    requiresUpToDateHead = false;
+    requiresUpToDateHeadSource = 'none';
+  }
+  return {
+    mergeStateStatus: String(options.mergeStateStatus ?? '').toUpperCase(),
+    mergeable: String(options.mergeable ?? '').toUpperCase(),
+    requiresUpToDateHead,
+    requiresUpToDateHeadSource,
+  };
+}
+export function summarizeRequiredChecks(
+  checks = [],
+  branchRules = [],
+  branchProtection = {},
+  {
+    waivers = null,
+    waivableSelectors = null,
+    protectionReadsUnreadable = false,
+    trustSourcePinnedRequiredChecks = false,
+  } = {},
+) {
+  const branchReviewRequirements = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  );
+  const requiredCheckNames = branchReviewRequirements.requiredCheckNames;
+  const requiredCheckNameSet = new Set(requiredCheckNames);
+  const validWaivers = waivers?.valid ?? [];
+  const SUCCESS_STATES = new Set([
+    'SUCCESS',
+    'SKIPPED',
+    'NEUTRAL',
+    'NOT_APPLICABLE',
+  ]);
+  const normalizedChecks = checks.map((check) => {
+    const name = String(check.name ?? '');
+    const state = String(check.state ?? '').toUpperCase();
+    const coveredByWaiver =
+      !SUCCESS_STATES.has(state) &&
+      validWaivers.some((w) =>
+        matchCheckSelectorLocal(name, w.checkSelector),
+      ) &&
+      // The check must also sit on the policy's waivable surface. A
+      // null/undefined list keeps the legacy behavior with no gate; an empty
+      // configured list covers nothing.
+      (!Array.isArray(waivableSelectors) ||
+        isCheckNameConfiguredWaivable(name, waivableSelectors));
+    return {
+      name,
+      state,
+      completedAt: String(check.completedAt ?? ''),
+      coveredByWaiver,
+      // Producer-identity discriminator (#1483); see `CheckLike` and
+      // `selectLatestCheckPerName` for how it disambiguates a same-name
+      // rerun from a genuinely independent, differently-sourced check.
+      type: check.type ? String(check.type) : '',
+      workflowName: check.workflowName ? String(check.workflowName).trim() : '',
+    };
+  });
+  const matchedRequiredChecks = normalizedChecks.filter((check) =>
+    requiredCheckNameSet.has(check.name),
+  );
+  const presentNames = new Set(
+    matchedRequiredChecks.map((check) => check.name),
+  );
+  const missingRequiredCheckNames = requiredCheckNames.filter(
+    (name) => !presentNames.has(name),
+  );
+  let status = 'unknown';
+  // #1745: discarded non-passing same-name siblings among the REQUIRED
+  // checks, e.g. a CANCELLED idd-advisory-convergence instance sitting
+  // alongside the SUCCESS instance selectLatestCheckPerName picked as
+  // "latest" -- surfaced regardless of the final `status` below so a
+  // 'success' verdict here is never silently opaque about a discarded
+  // non-passing sibling GitHub's own statusCheckRollup may have weighed
+  // differently (the live PR #1741 divergence this field exists to make
+  // visible; see classifyCiChecks's own findDiscardedNonPassingSiblings
+  // doc comment for the full rationale). Empty (never omitted) when no
+  // required checks are configured.
+  let discardedNonPassingRequiredChecks = [];
+  // #1689: the pinned required-check names that caused the downgrade below
+  // (empty unless that downgrade actually fired). Lets a caller's blocker
+  // detail name the source-pinned cause explicitly instead of a generic
+  // "CI is not all-passing" message -- see `computePreMergeReadinessBlockers`.
+  let sourcePinnedRequiredCheckNames = [];
+  // #1689: true when the downgrade below fired at least partly because of a
+  // pinned source that could not be attributed to any check name (a
+  // ruleset `workflows` rule, or a pinned entry with no `context`/`name`/
+  // `check`) -- distinct from `sourcePinnedRequiredCheckNames` being empty,
+  // which alone would be ambiguous between "no pinning" and "pinning
+  // exists but is unnamed." Lets a blocker detail name the cause even when
+  // no specific check name can be cited.
+  let sourcePinnedUnresolved = false;
+  if (requiredCheckNames.length > 0) {
+    const effectiveChecks = matchedRequiredChecks.map((c) =>
+      c.coveredByWaiver ? { ...c, state: 'SKIPPED' } : c,
+    );
+    const ciClassification = classifyCiChecks(effectiveChecks);
+    status =
+      missingRequiredCheckNames.length > 0
+        ? 'missing'
+        : ciClassification.status;
+    // #1689: the `trustSourcePinnedRequiredChecks` opt-in only widens the
+    // named/resolved case -- an unresolved pinned source (no check name to
+    // correlate with a live run at all) always still forces the downgrade,
+    // even when a SEPARATE, named-and-pinned entry also exists and the
+    // operator has opted in for that one.
+    if (
+      status === 'success' &&
+      branchReviewRequirements.requiredCheckSourcePinned &&
+      (!trustSourcePinnedRequiredChecks ||
+        branchReviewRequirements.requiredCheckSourcePinnedUnresolved)
+    ) {
+      status = 'unknown';
+      sourcePinnedRequiredCheckNames = [
+        ...branchReviewRequirements.requiredCheckSourcePinnedNames,
+      ];
+      sourcePinnedUnresolved =
+        branchReviewRequirements.requiredCheckSourcePinnedUnresolved;
+    }
+    // #1753: computed from the RAW matchedRequiredChecks -- deliberately
+    // NOT ciClassification.discardedNonPassingInstances above, which is
+    // derived from the waiver-adjusted effectiveChecks. A valid waiver
+    // rewrites a waived non-passing instance's `state` to 'SKIPPED' (pass-
+    // equivalent, outside GENUINELY_NON_PASSING_STATES), so computing this
+    // evidence field from effectiveChecks would let a waived CANCELLED
+    // sibling silently drop out of this field the moment it is waived --
+    // exactly the divergence-masking scenario #1745 exists to surface, and
+    // exactly the check this repo's own `idd-advisory-convergence` waivable
+    // policy can trigger. `status` above intentionally keeps using the
+    // waiver-adjusted effectiveChecks -- a valid waiver legitimately makes
+    // a check pass for merge-gate purposes; only this evidence-only
+    // computation needs the pre-waiver truth.
+    discardedNonPassingRequiredChecks = findDiscardedNonPassingSiblings(
+      matchedRequiredChecks,
+    );
+  }
+  return {
+    status,
+    noRequiredChecksConfigured:
+      !protectionReadsUnreadable &&
+      requiredCheckNames.length === 0 &&
+      !branchReviewRequirements.requiredCheckSourcePinned,
+    // #1377: surfaced separately from `noRequiredChecksConfigured` so a hold
+    // message can name the unreadable-read cause specifically instead of a
+    // generic "CI is not all-passing".
+    protectionReadsUnreadable,
+    presentRunConclusion: resolvePresentRunConclusion(normalizedChecks),
+    requiredCheckCount: requiredCheckNames.length,
+    generatedRequiredCheckCount: matchedRequiredChecks.length,
+    requiredChecksGenerated:
+      requiredCheckNames.length > 0 && missingRequiredCheckNames.length === 0,
+    requiredChecksPassing:
+      requiredCheckNames.length > 0 && status === 'success',
+    requiredCheckNames,
+    missingRequiredCheckNames,
+    // #1745: see the field's own inline comment above -- reported
+    // unconditionally (empty array, never omitted) so a consumer never has
+    // to special-case "field absent" vs. "field empty".
+    discardedNonPassingRequiredChecks,
+    // #1689: see the field's own inline comment above -- reported
+    // unconditionally (empty array, never omitted), populated only when the
+    // source-pinned downgrade actually fired for this call.
+    sourcePinnedRequiredCheckNames,
+    // #1689: see the field's own inline comment above -- `false` unless the
+    // downgrade fired AND at least one pinned source was unnamed.
+    sourcePinnedUnresolved,
+    checks: normalizedChecks.map((check) => ({
+      name: check.name,
+      state: check.state,
+      completedAt: isValidIsoTimestamp(check.completedAt)
+        ? check.completedAt
+        : '',
+      required: requiredCheckNameSet.has(check.name),
+      ...(check.coveredByWaiver ? { coveredByWaiver: true } : {}),
+    })),
+  };
+}
+// Conclusion over *all* present check runs (waiver-covered runs count as
+// skipped), used for the F2 fallback when no required checks are configured:
+// an unprotected branch must not satisfy CI vacuously, so the gate inspects the
+// real run conclusions instead.
+function resolvePresentRunConclusion(normalizedChecks) {
+  if (normalizedChecks.length === 0) {
+    return 'none';
+  }
+  const effective = normalizedChecks.map((check) =>
+    check.coveredByWaiver ? { ...check, state: 'SKIPPED' } : check,
+  );
+  const { status } = classifyCiChecks(effective);
+  if (status === 'success') {
+    return 'all-passing';
+  }
+  if (status === 'pending') {
+    return 'pending';
+  }
+  return 'some-failing';
+}
+export function resolveCodeownersForFiles(codeownersText, changedFiles = []) {
+  const rules = parseCodeownersRules(codeownersText);
+  return collectCodeownersForFiles(rules, changedFiles);
+}
+export function selectCodeownersText(payloads = []) {
+  for (const payload of payloads) {
+    if (
+      !payload ||
+      typeof payload !== 'object' ||
+      !Object.hasOwn(payload, 'content')
+    ) {
+      continue;
+    }
+    const content = String(payload.content ?? '').replace(/\n/g, '');
+    return Buffer.from(content, 'base64').toString('utf8');
+  }
+  return '';
+}
+function collectCodeownersForFiles(rules, changedFiles = []) {
+  const codeownerUsers = new Set();
+  const codeownerTeams = new Set();
+  const codeownerEmails = new Set();
+  const unmatchedFiles = [];
+  for (const filePath of changedFiles) {
+    const normalizedPath = String(filePath ?? '').replace(/^\/+/, '');
+    if (!normalizedPath) {
+      continue;
+    }
+    const owners = findCodeownersForPath(rules, normalizedPath);
+    if (!owners) {
+      unmatchedFiles.push(normalizedPath);
+      continue;
+    }
+    if (!hasCodeownerOwners(owners)) {
+      continue;
+    }
+    for (const owner of owners.users) {
+      codeownerUsers.add(owner);
+    }
+    for (const owner of owners.teams) {
+      codeownerTeams.add(owner);
+    }
+    for (const owner of owners.emails) {
+      codeownerEmails.add(owner);
+    }
+  }
+  return {
+    ruleCount: rules.length,
+    changedFileCount: changedFiles.length,
+    unmatchedFiles,
+    codeownerUserLogins: [...codeownerUsers].sort(),
+    codeownerTeamSlugs: [...codeownerTeams].sort(),
+    codeownerEmailAddresses: [...codeownerEmails].sort(),
+  };
+}
+export function summarizeReviewerStates(
+  reviews = [],
+  {
+    reviewDecision = '',
+    branchRules = [],
+    branchRulesets = [],
+    branchProtection = {},
+    branchRulesetsUnreadable = false,
+    codeownersText = '',
+    changedFiles = [],
+    eligibleCodeownerUserLogins = null,
+    eligibleCodeownerUserLoginsUnreadable = false,
+    reviewsUnreadable = false,
+    advisoryBotLogins = [],
+    prAuthorLogin = '',
+    viewerLogin = '',
+    viewerTeamSlugs = [],
+    viewerAppSlug = '',
+  } = {},
+) {
+  const branchReviewRequirements = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  );
+  const requiredReviewerLogins = new Set(
+    branchReviewRequirements.requiredReviewerLogins,
+  );
+  const advisoryBotLoginSet = new Set(
+    normalizeTrustedMarkerLogins(advisoryBotLogins),
+  );
+  const codeownerRules = parseCodeownersRules(codeownersText);
+  const codeowners = collectCodeownersForFiles(codeownerRules, changedFiles);
+  const codeownerUsers = new Set(codeowners.codeownerUserLogins);
+  const eligibleCodeownerUsers =
+    eligibleCodeownerUserLogins === null
+      ? codeownerUsers
+      : new Set(
+          normalizeTrustedMarkerLogins(eligibleCodeownerUserLogins).filter(
+            (login) => codeownerUsers.has(login),
+          ),
+        );
+  const normalizedReviewDecision = String(reviewDecision ?? '');
+  const latestByAuthor = [...indexLatestGatingReviewsByAuthor(reviews).values()]
+    .map((review) => {
+      const login = String(review.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      const isAdvisoryBot = isGateAdvisoryBotLogin(login, advisoryBotLoginSet);
+      const isCodeowner = eligibleCodeownerUsers.has(login);
+      const isRequiredReviewer = requiredReviewerLogins.has(login);
+      return {
+        login,
+        state: String(review.state ?? ''),
+        submittedAt: String(review.submittedAt ?? review.submitted_at ?? ''),
+        isHuman: !isAdvisoryBot,
+        isAdvisoryBot,
+        isCodeowner,
+        isRequiredReviewer,
+      };
+    })
+    .sort((left, right) => left.login.localeCompare(right.login));
+  const blockingChangesRequestedLogins = latestByAuthor
+    .filter((review) => {
+      return review.state === 'CHANGES_REQUESTED' && !review.isAdvisoryBot;
+    })
+    .map((review) => review.login);
+  const humanApprovedCount = latestByAuthor.filter((review) => {
+    return review.isHuman && review.state === 'APPROVED';
+  }).length;
+  // #1818: also require `isHuman` here, mirroring `humanApprovedCount` above.
+  // Without it, any advisory bot (default-recognized or configured) that is
+  // also listed as a CODEOWNER for the changed files would satisfy the
+  // codeowner-approval gate on its own review -- the same fail-open shape
+  // `humanApprovedCount` already guarded against. This intentionally
+  // diverges from GitHub's own CODEOWNERS gate (which would count a bot
+  // codeowner's approval); the stricter, fail-closed reading is deliberate,
+  // not a gap to "fix" back.
+  const codeownerApproved = latestByAuthor.some((review) => {
+    return review.isCodeowner && review.isHuman && review.state === 'APPROVED';
+  });
+  const hasExplicitCodeownerMatches = changedFiles.some((filePath) => {
+    const normalizedPath = String(filePath ?? '').replace(/^\/+/, '');
+    if (!normalizedPath) {
+      return false;
+    }
+    const owners = findCodeownersForPath(codeownerRules, normalizedPath);
+    return !!owners && hasCodeownerOwners(owners);
+  });
+  const latestByLogin = new Map(
+    latestByAuthor.map((review) => [review.login, review]),
+  );
+  const requiredReviewerApprovalsSatisfied =
+    branchReviewRequirements.requiredReviewerRequirements.every(
+      (requirement) => {
+        if (
+          requirement.filePatterns.length > 0 &&
+          !changedFiles.some((filePath) => {
+            return requirement.filePatterns.some((pattern) =>
+              matchesCodeownersPattern(pattern, filePath),
+            );
+          })
+        ) {
+          return true;
+        }
+        if ((requirement.minimumApprovals ?? 0) <= 0) {
+          return true;
+        }
+        // #1837: deliberately NOT gated by `reviewsUnreadable` (unlike the
+        // `codeownerApprovalSatisfied`/`requiredApprovalsSatisfied` bypasses
+        // fixed below). A team-identity requirement (`requirement.identity`
+        // contains `/`, checked immediately below) can never be resolved to
+        // a reviewing login from `reviews` data -- this code has no team
+        // membership lookup at all -- so GitHub's own aggregate decision is
+        // the only signal available for it regardless of whether the caller
+        // fetched full review data. See "required reviewer rule objects
+        // stay blocking until GitHub marks approval satisfied" in
+        // tests/pre-merge-readiness.test.mts, which locks this in.
+        if (normalizedReviewDecision === 'APPROVED') {
+          return true;
+        }
+        if (requirement.identity.includes('/')) {
+          return false;
+        }
+        return latestByLogin.get(requirement.identity)?.state === 'APPROVED';
+      },
+    );
+  // #1837: `normalizedReviewDecision === 'APPROVED'` alone used to be an
+  // unconditional bypass here, letting GitHub's own aggregate `reviewDecision`
+  // (which can resolve APPROVED from a bot-only review -- GitHub shipped
+  // bot-review-state support 2026-08-01, see #1818's background) satisfy this
+  // gate even when the classified data this function already computed
+  // (`codeownerApproved`) shows the approval came only from a bot. When the
+  // caller genuinely could not fetch/classify individual reviews
+  // (`reviewsUnreadable`), GitHub's aggregate is still the only available
+  // signal and stays a bypass. When review data IS available (the normal
+  // `collectPreMergeReadiness` path, which fails closed by throwing rather
+  // than ever reaching this function with partial data), the classified
+  // `codeownerApproved` check must also agree -- GitHub's `APPROVED` decision
+  // no longer overrides it on its own.
+  const codeownerSelfApproval = summarizeCodeownerSelfApproval({
+    requireCodeOwnerReview: branchReviewRequirements.requireCodeOwnerReview,
+    codeownerApprovalSatisfied:
+      !branchReviewRequirements.requireCodeOwnerReview ||
+      !hasExplicitCodeownerMatches ||
+      codeownerApproved ||
+      (reviewsUnreadable && normalizedReviewDecision === 'APPROVED'),
+    hasExplicitCodeownerMatches,
+    codeownerUserLogins: codeowners.codeownerUserLogins,
+    eligibleCodeownerUserLogins:
+      eligibleCodeownerUserLogins === null
+        ? null
+        : [...eligibleCodeownerUsers].sort(),
+    eligibleCodeownerUserLoginsUnreadable,
+    codeownerTeamSlugs: codeowners.codeownerTeamSlugs,
+    codeownerEmailAddresses: codeowners.codeownerEmailAddresses,
+    prAuthorLogin,
+    viewerLogin,
+    viewerTeamSlugs,
+    viewerAppSlug,
+    branchRules,
+    branchRulesets,
+    branchRulesetsUnreadable,
+    classicRequireCodeOwnerReview:
+      branchReviewRequirements.classicRequireCodeOwnerReview,
+    classicBypassPullRequestUserLogins:
+      branchReviewRequirements.classicBypassPullRequestUserLogins,
+    classicBypassPullRequestTeamSlugs:
+      branchReviewRequirements.classicBypassPullRequestTeamSlugs,
+    classicBypassPullRequestAppSlugs:
+      branchReviewRequirements.classicBypassPullRequestAppSlugs,
+  });
+  return {
+    reviewDecision: normalizedReviewDecision,
+    requiredApprovingReviewCount:
+      branchReviewRequirements.requiredApprovingReviewCount,
+    requireCodeOwnerReview: branchReviewRequirements.requireCodeOwnerReview,
+    requiresConversationResolution:
+      branchReviewRequirements.requiresConversationResolution,
+    requiredReviewerLogins: branchReviewRequirements.requiredReviewerLogins,
+    requiredReviewerTeams: branchReviewRequirements.requiredReviewerTeams,
+    codeownerUserLogins: codeowners.codeownerUserLogins,
+    codeownerTeamSlugs: codeowners.codeownerTeamSlugs,
+    unmatchedCodeownerFiles: codeowners.unmatchedFiles,
+    latestByAuthor,
+    humanApprovedCount,
+    // #1837: see the comment above `codeownerSelfApproval` for the shared
+    // rationale. `reviewsUnreadable` keeps the pre-fix blanket-trust bypass
+    // (first disjunct) only when review data genuinely could not be
+    // classified. Otherwise (the normal, classifiable path -- the second
+    // disjunct), an `APPROVED` aggregate is treated the same as an empty
+    // one: it still must be corroborated by the classified
+    // `humanApprovedCount` reaching the required threshold (or the
+    // threshold being `0`, i.e. no approvals required at all -- nothing is
+    // missing, so this stays a pass by design, not a gap).
+    requiredApprovalsSatisfied:
+      requiredReviewerApprovalsSatisfied &&
+      ((reviewsUnreadable && normalizedReviewDecision === 'APPROVED') ||
+        (!reviewsUnreadable &&
+          (normalizedReviewDecision === 'APPROVED' ||
+            !normalizedReviewDecision) &&
+          (branchReviewRequirements.requiredApprovingReviewCount === 0 ||
+            humanApprovedCount >=
+              branchReviewRequirements.requiredApprovingReviewCount))),
+    codeownerApprovalSatisfied:
+      !branchReviewRequirements.requireCodeOwnerReview ||
+      !hasExplicitCodeownerMatches ||
+      codeownerApproved ||
+      (reviewsUnreadable && normalizedReviewDecision === 'APPROVED'),
+    codeownerSelfApproval,
+    humanChangesRequestedCount: blockingChangesRequestedLogins.length,
+    blockingChangesRequestedLogins,
+  };
+}
+function summarizeCodeownerSelfApproval({
+  requireCodeOwnerReview,
+  codeownerApprovalSatisfied,
+  hasExplicitCodeownerMatches,
+  codeownerUserLogins = [],
+  eligibleCodeownerUserLogins = null,
+  eligibleCodeownerUserLoginsUnreadable = false,
+  codeownerTeamSlugs = [],
+  codeownerEmailAddresses = [],
+  prAuthorLogin = '',
+  viewerLogin = '',
+  viewerTeamSlugs = [],
+  viewerAppSlug = '',
+  branchRules = [],
+  branchRulesets = [],
+  branchRulesetsUnreadable = false,
+  classicRequireCodeOwnerReview = false,
+  classicBypassPullRequestUserLogins = [],
+  classicBypassPullRequestTeamSlugs = [],
+  classicBypassPullRequestAppSlugs = [],
+}) {
+  const normalizedAuthor = String(prAuthorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const normalizedViewer = String(viewerLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const normalizedViewerAppSlug = String(viewerAppSlug ?? '')
+    .trim()
+    .toLowerCase();
+  const normalizedViewerTeamSlugs =
+    normalizeTrustedMarkerLogins(viewerTeamSlugs);
+  const directCodeownerUserLogins =
+    normalizeTrustedMarkerLogins(codeownerUserLogins);
+  const eligibleDirectCodeownerUserLogins =
+    eligibleCodeownerUserLogins === null
+      ? directCodeownerUserLogins
+      : normalizeTrustedMarkerLogins(eligibleCodeownerUserLogins).filter(
+          (login) => directCodeownerUserLogins.includes(login),
+        );
+  const normalizedCodeownerTeamSlugs =
+    normalizeTrustedMarkerLogins(codeownerTeamSlugs);
+  const normalizedCodeownerEmailAddresses = normalizeTrustedMarkerLogins(
+    codeownerEmailAddresses,
+  );
+  const classicBypassDetected = Boolean(
+    Boolean(classicRequireCodeOwnerReview) &&
+      ((normalizedViewer &&
+        normalizeTrustedMarkerLogins(
+          classicBypassPullRequestUserLogins,
+        ).includes(normalizedViewer)) ||
+        normalizedViewerTeamSlugs.some((slug) => {
+          return normalizeTrustedMarkerLogins(
+            classicBypassPullRequestTeamSlugs,
+          ).includes(slug);
+        }) ||
+        (normalizedViewerAppSlug &&
+          normalizeTrustedMarkerLogins(
+            classicBypassPullRequestAppSlugs,
+          ).includes(normalizedViewerAppSlug))),
+  );
+  const bypass = summarizeRulesetPullRequestBypass(
+    branchRulesets,
+    branchRules,
+    branchRulesetsUnreadable,
+  );
+  const rulesetGateSatisfiedByBypass =
+    bypass.relevantRulesetCount === 0 || bypass.detected;
+  const classicGateSatisfiedByBypass =
+    !classicRequireCodeOwnerReview || classicBypassDetected;
+  const applicableBypassDetected =
+    (bypass.detected || classicBypassDetected) &&
+    rulesetGateSatisfiedByBypass &&
+    classicGateSatisfiedByBypass;
+  const applicableBypassMode = applicableBypassDetected
+    ? bypass.detected
+      ? bypass.mode
+      : 'pull_request'
+    : 'none';
+  // Hoisted above `base` (moved up from its original position further down,
+  // right before the `deadlock` branch that also consumes it) so the #1521
+  // `prAuthorIsSoleEligibleCodeowner` field below can reuse this exact
+  // expression instead of recomputing an equivalent one. Pure and
+  // side-effect-free, so hoisting it earlier changes nothing about the
+  // later branches that also read it.
+  const allDirectUsersAreAuthor =
+    eligibleDirectCodeownerUserLogins.length > 0 &&
+    eligibleDirectCodeownerUserLogins.every(
+      (login) => login === normalizedAuthor,
+    );
+  // #1521: additive topology fact, computed independently of `status` /
+  // `applicableBypassDetected` below and exposed on every branch (not just
+  // the `deadlock` one). This is the ONLY safe discriminator an F3 caller
+  // may use to gate an automatic `--admin` retry: `status: 'clear'` alone
+  // (whether via `applicableBypassDetected` or `hasNonAuthorDirectUser`
+  // further down) does NOT prove the PR author is the sole codeowner --
+  // `applicableBypassDetected` fires whenever a bypass actor is configured
+  // for the viewer, regardless of whether a genuinely distinct non-author
+  // codeowner's review is separately outstanding. Deliberately NOT folded
+  // into `status`/`reason` themselves (that general gate intentionally
+  // keeps its existing pass/fail shape for every adopter repo -- see the
+  // #1521 review discussion); a caller that needs the narrow self-deadlock
+  // fact must check this field explicitly alongside `status`/`reason`.
+  //
+  // Requires `!eligibleCodeownerUserLoginsUnreadable` (Codex review, #1521):
+  // `eligibleDirectCodeownerUserLogins` can be silently NARROWED by a
+  // transient permission-lookup failure for some OTHER direct codeowner
+  // (see `resolveEligibleCodeownerUserLogins` in pre-merge-readiness.mts),
+  // which would make the author look like the sole eligible codeowner even
+  // though a real co-owner's eligibility simply could not be confirmed.
+  // Fail closed rather than trust a possibly-incomplete narrowed set.
+  const prAuthorIsSoleEligibleCodeowner =
+    Boolean(normalizedAuthor) &&
+    normalizedCodeownerTeamSlugs.length === 0 &&
+    normalizedCodeownerEmailAddresses.length === 0 &&
+    !eligibleCodeownerUserLoginsUnreadable &&
+    allDirectUsersAreAuthor;
+  const base = {
+    status: 'not_applicable',
+    reason: 'codeowner-review-not-required',
+    prAuthorLogin: normalizedAuthor,
+    directCodeownerUserLogins,
+    codeownerTeamSlugs: normalizedCodeownerTeamSlugs,
+    requireCodeOwnerReview: Boolean(requireCodeOwnerReview),
+    codeownerApprovalSatisfied: Boolean(codeownerApprovalSatisfied),
+    bypassDetected: applicableBypassDetected,
+    bypassMode: applicableBypassMode,
+    currentUserCanBypass: bypass.currentUserCanBypass,
+    // #1380: true when a codeowner-requiring ruleset's *detail* read was
+    // masked-404 unreadable, so `bypass.detected` could not rule out an
+    // actual configured bypass. Diagnostic only -- never flips a `status`
+    // to `clear` on its own -- but downgrades a would-be certain `deadlock`
+    // below to the already-documented `possible_deadlock`.
+    rulesetBypassUnreadable: bypass.unreadable,
+    prAuthorIsSoleEligibleCodeowner,
+    // #1521: true when at least one direct-user codeowner's
+    // collaborator-permission lookup was unreadable (see
+    // `prAuthorIsSoleEligibleCodeowner` above). Diagnostic only, mirroring
+    // `rulesetBypassUnreadable`'s shape -- never flips `status` on its own.
+    codeownerEligibilityUnreadable: Boolean(
+      eligibleCodeownerUserLoginsUnreadable,
+    ),
+  };
+  if (!requireCodeOwnerReview) {
+    return base;
+  }
+  if (!hasExplicitCodeownerMatches) {
+    return {
+      ...base,
+      reason: 'no-explicit-codeowner-match',
+    };
+  }
+  if (codeownerApprovalSatisfied) {
+    return {
+      ...base,
+      reason: 'codeowner-approval-satisfied',
+    };
+  }
+  if (applicableBypassDetected) {
+    return {
+      ...base,
+      status: 'clear',
+      reason:
+        applicableBypassMode === 'pull_request'
+          ? 'pull-request-bypass-available'
+          : 'ruleset-bypass-available',
+    };
+  }
+  if (!normalizedAuthor) {
+    return {
+      ...base,
+      status: 'possible_deadlock',
+      reason: 'pr-author-unknown',
+    };
+  }
+  // `allDirectUsersAreAuthor` is computed above (hoisted next to
+  // `prAuthorIsSoleEligibleCodeowner` in `base`); reused here unchanged.
+  const hasNonAuthorDirectUser = eligibleDirectCodeownerUserLogins.some(
+    (login) => login !== normalizedAuthor,
+  );
+  if (hasNonAuthorDirectUser) {
+    return {
+      ...base,
+      status: 'clear',
+      reason: 'non-author-codeowner-available',
+    };
+  }
+  if (normalizedCodeownerTeamSlugs.length > 0) {
+    return {
+      ...base,
+      status: 'possible_deadlock',
+      reason: 'team-codeowner-ambiguous',
+    };
+  }
+  if (normalizedCodeownerEmailAddresses.length > 0) {
+    return {
+      ...base,
+      status: 'possible_deadlock',
+      reason: 'email-codeowner-ambiguous',
+    };
+  }
+  if (allDirectUsersAreAuthor) {
+    // #1380: a masked-404 on a relevant ruleset's detail read means
+    // `bypass.detected` could not rule out an actual configured bypass for
+    // this PR author -- asserting a *certain* `deadlock` here would be an
+    // unjustified false-certainty diagnostic. Downgrade to the
+    // already-documented `possible_deadlock` (idd-pre-merge.instructions.md:
+    // "could not prove ... applicable pull-request bypass, so fail closed")
+    // instead of inventing a new status value.
+    if (bypass.unreadable) {
+      return {
+        ...base,
+        status: 'possible_deadlock',
+        reason: 'ruleset-bypass-unreadable',
+      };
+    }
+    return {
+      ...base,
+      status: 'deadlock',
+      reason:
+        eligibleCodeownerUserLogins === null
+          ? 'pr-author-is-only-direct-codeowner'
+          : 'pr-author-is-only-eligible-direct-codeowner',
+    };
+  }
+  return {
+    ...base,
+    status: 'possible_deadlock',
+    reason: 'no-reviewable-codeowner-identity',
+  };
+}
+function summarizeRulesetPullRequestBypass(
+  branchRulesets = [],
+  branchRules = [],
+  branchRulesetsUnreadable = false,
+) {
+  const codeownerRulesetIds = new Set(
+    (branchRules ?? [])
+      .filter((rule) => {
+        return (
+          rule?.type === 'pull_request' &&
+          Boolean(rule?.parameters?.require_code_owner_review)
+        );
+      })
+      .map((rule) => Number.parseInt(String(rule?.ruleset_id ?? ''), 10))
+      .filter(Number.isInteger),
+  );
+  const expectedRulesetCount = codeownerRulesetIds.size;
+  const relevantRulesets = (branchRulesets ?? []).filter((ruleset) => {
+    const rulesetId = Number.parseInt(
+      String(ruleset?.id ?? ruleset?.ruleset_id ?? ''),
+      10,
+    );
+    return codeownerRulesetIds.has(rulesetId);
+  });
+  const values = relevantRulesets
+    .map((ruleset) => String(ruleset?.current_user_can_bypass ?? '').trim())
+    .map((value) => {
+      return ['always', 'exempt', 'never', 'pull_requests_only'].includes(value)
+        ? value
+        : 'unknown';
+    })
+    .filter(Boolean);
+  let currentUserCanBypass = 'unknown';
+  if (values.length > 1 && new Set(values).size > 1) {
+    currentUserCanBypass = 'mixed';
+  } else if (values.includes('exempt')) {
+    currentUserCanBypass = 'exempt';
+  } else if (values.includes('pull_requests_only')) {
+    currentUserCanBypass = 'pull_requests_only';
+  } else if (values.includes('always')) {
+    currentUserCanBypass = 'always';
+  } else if (values.includes('never')) {
+    currentUserCanBypass = 'never';
+  }
+  const bypassValues = new Set(['always', 'exempt', 'pull_requests_only']);
+  const detected =
+    expectedRulesetCount > 0 &&
+    relevantRulesets.length === expectedRulesetCount &&
+    values.length === relevantRulesets.length &&
+    values.every((value) => bypassValues.has(value));
+  let mode = 'none';
+  if (detected) {
+    if (new Set(values).size > 1) {
+      mode = 'mixed';
+    } else if (values.includes('pull_requests_only')) {
+      mode = 'pull_request';
+    } else if (values.includes('always')) {
+      mode = 'always';
+    } else if (values.includes('exempt')) {
+      mode = 'exempt';
+    }
+  }
+  // #1380: only report `unreadable` when a *relevant* (codeowner-requiring)
+  // ruleset is actually missing from `relevantRulesets` -- not merely
+  // whenever `detected` is `false`, since a fully-read ruleset can
+  // legitimately report a real, non-bypass value (e.g. `never`) that also
+  // makes `detected` false. That is genuine data, not a masked-404 gap, and
+  // must not be relabeled as "could not determine". A masked-404 on a
+  // relevant ruleset's detail read only ever *prevents* `detected` from
+  // becoming `true` (the count check above requires every expected
+  // ruleset's detail to be present), so this can never cause a false
+  // `detected: true`.
+  const unreadable =
+    branchRulesetsUnreadable &&
+    expectedRulesetCount > 0 &&
+    relevantRulesets.length < expectedRulesetCount;
+  return {
+    detected,
+    mode,
+    currentUserCanBypass,
+    relevantRulesetCount: expectedRulesetCount,
+    unreadable,
+  };
+}
+export function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
+  const sourceType = String(
+    rule?.ruleset_source_type ?? rule?.source_type ?? '',
+  )
+    .trim()
+    .toLowerCase();
+  if (sourceType === 'organization') {
+    const source = String(rule?.ruleset_source ?? rule?.source ?? owner).trim();
+    const org = source.split('/')[0] || owner;
+    return `orgs/${encodeURIComponent(org)}/rulesets/${rulesetId}`;
+  }
+  if (sourceType === 'enterprise') {
+    const source = String(rule?.ruleset_source ?? rule?.source ?? '').trim();
+    const enterprise = source.split('/')[0];
+    if (enterprise) {
+      return `enterprises/${encodeURIComponent(enterprise)}/rulesets/${rulesetId}`;
+    }
+  }
+  return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/rulesets/${rulesetId}`;
+}
+/**
+ * Resolve a PR's first-commit time as an ISO string -- the minimum across all
+ * commits of each commit's committer date, falling back to author date. A
+ * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
+ * minimum defensively rather than relying on order. Returns `null` when no
+ * commit carries a parseable date, which makes the Part B gate below fail
+ * closed (an `issue-only` handoff against a PR-backed claim stays rejected).
+ *
+ * Shared by every `prFirstCommitAt` resolver (`pre-merge-readiness.mts`,
+ * `advisory-convergence.mts`, `live-status-digest.mts`) so the Part B
+ * allowance's date computation has one implementation, not three.
+ */
+export function resolvePrFirstCommitAt(commits) {
+  let earliestMs = null;
+  let earliestIso = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
+}
+/**
+ * Build the `isForcedHandoffEnabled` gate shared by every claim-revalidation
+ * path (resume routing, the merge-gate, and the write-side helpers).
+ *
+ * Semantics:
+ *
+ * - forced-handoff mode disabled → never honor;
+ * - no open linked PR backs the claim (`expectedLinkedPrReferences` empty) →
+ *   honor an `issue-only` (or any) handoff as before;
+ * - an open linked PR backs the claim:
+ *   - `issue-plus-pr` handoff → require `linkedPr` to match one of the
+ *     expected PRs (unchanged behavior);
+ *   - `issue-only` handoff → accept it IFF a `prFirstCommitAt` is supplied
+ *     AND the handoff's `createdAt` is a valid ISO timestamp strictly before
+ *     it (the handoff predates the PR, so the successor created the PR after
+ *     taking over the issue). Any other `issue-only` handoff is rejected.
+ *
+ * The `prFirstCommitAt` parameter is the Part B extension (#1058). Callers
+ * that do not pass it keep the original behavior byte-identical: an
+ * `issue-only` handoff against a PR-backed claim is rejected.
+ */
+export function buildForcedHandoffEnableGate(options) {
+  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
+  const prFirstCommitAt =
+    typeof options.prFirstCommitAt === 'string' ? options.prFirstCommitAt : '';
+  return (forcedHandoff) => {
+    if (!forcedHandoffEnabled) {
+      return false;
+    }
+    if (expectedLinkedPrReferences.size === 0) {
+      return true;
+    }
+    if (forcedHandoff.contextScope === 'issue-plus-pr') {
+      return expectedLinkedPrReferences.has(
+        normalizeLinkedPrReference(forcedHandoff.linkedPr),
+      );
+    }
+    // issue-only handoff against a PR-backed claim: accept only when it
+    // predates the PR's first commit (a robust ISO compare; either side
+    // unparseable → fail closed = reject).
+    return isStrictlyBeforeIso(forcedHandoff.createdAt, prFirstCommitAt);
+  };
+}
+/**
+ * Resolve the active claim for a write-side merge-gate revalidation, honoring
+ * an operator-approved forced handoff while failing closed on
+ * unauthorized/forged markers exactly as the Resume routing path does.
+ *
+ * This is the centralized, pure (no I/O) helper used by the write-side
+ * helpers (disposition-non-review-notices, resolve-review-thread) so they no
+ * longer ignore forced handoffs. It builds the same forced-handoff enable
+ * gate as `summarizeClaimValidation` / `buildForcedHandoffEnabledGate`
+ * (extended with the Part B time rule) and delegates the rest of the
+ * fail-closed enforcement to `applyClaimEvent` rule 7.
+ *
+ * - `forcedHandoffEnabled` defaults to `false` (forced handoffs ignored).
+ * - `expectedLinkedPrs` of `null`/empty marks an issue-scoped revalidation:
+ *   an `issue-only` handoff is accepted (issue takeover). A non-empty set
+ *   marks a PR-backed claim and applies the `issue-plus-pr` / `prFirstCommitAt`
+ *   rules.
+ * - `isAuthorizedForcedHandoff` defaults to an allowlist of ∅ ⇒ always false
+ *   (every handoff is treated as unauthorized) when not supplied, so callers
+ *   that forget to wire it fail closed.
+ * - `requireAuthorMatchesForcedBy` defaults to `true` (the strict
+ *   self-signed-hijack block used by Resume routing).
+ * - `staleAgeMs` (#1310) is an optional config-aware claim-staleness window,
+ *   in milliseconds (a parsed `claimTiming.staleAge`). When omitted, invalid
+ *   (non-numeric/non-finite), or non-positive, staleness falls back to the
+ *   hardcoded 24h `isStaleAt` default unchanged — so callers that do not
+ *   pass it keep today's exact behavior. See `isStaleByAge`.
+ */
+export function resolveActiveClaimForWriteGate(events, options) {
+  const expectedLinkedPrReferences = new Set(
+    (options.expectedLinkedPrs ?? [])
+      .map((value) => normalizeLinkedPrReference(value))
+      .filter(Boolean),
+  );
+  const isForcedHandoffEnabled = buildForcedHandoffEnableGate({
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    expectedLinkedPrReferences,
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+  });
+  return resolveActiveClaim(events, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    isForcedHandoffEnabled,
+    isAuthorizedForcedHandoff:
+      typeof options.isAuthorizedForcedHandoff === 'function'
+        ? options.isAuthorizedForcedHandoff
+        : () => false,
+    requireAuthorMatchesForcedBy: options.requireAuthorMatchesForcedBy ?? true,
+    isStale: resolveStalePredicate(options.staleAgeMs),
+  });
+}
+export function summarizeClaimValidation(claimEvents = [], options = {}) {
+  const trustedMarkerLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const authorizedForcedHandoffLogins = new Set(
+    normalizeTrustedMarkerLogins(options.authorizedForcedHandoffLogins ?? []),
+  );
+  const expectedLinkedPrReferences = new Set(
+    (options.expectedLinkedPrs ?? [])
+      .map((value) => normalizeLinkedPrReference(value))
+      .filter(Boolean),
+  );
+  const expectedClaimId = String(options.expectedClaimId ?? '').trim();
+  const expectedAgentId = String(options.expectedAgentId ?? '').trim();
+  const trustedAuthorPredicate =
+    typeof options.isTrustedAuthor === 'function'
+      ? options.isTrustedAuthor
+      : (login) =>
+          trustedMarkerLogins.has(
+            String(login ?? '')
+              .trim()
+              .toLowerCase(),
+          );
+  // Merge-side write-gate forced-handoff strictness — intentionally the
+  // lenient half of the strict-resume vs. lenient-relay-merge split (see
+  // docs/idd-design-rationale.md, "Claim resolution"). This call leaves
+  // `requireAuthorMatchesForcedBy` at its lenient default (off) so a
+  // maintainer-authorized handoff relayed by a separate automation actor is
+  // still honored — authorization rests on `isAuthorizedForcedHandoff` alone —
+  // and it passes `prFirstCommitAt` so the Part-B allowance (#1058, an
+  // issue-only handoff predating the PR) applies. resume-claim-routing.mts
+  // deliberately does the opposite (`requireAuthorMatchesForcedBy: true`, no
+  // `prFirstCommitAt`) because a takeover decision must block the same-identity
+  // self-signed hijack. The two callers can therefore return different verdicts
+  // for the same corrected-handoff state (resume `already_owned` vs. merge
+  // `claimLost`) by design; both still funnel through the single
+  // resolveActiveClaim resolver.
+  const activeClaim = resolveActiveClaim(claimEvents, {
+    isTrustedAuthor: trustedAuthorPredicate,
+    isForcedHandoffEnabled:
+      typeof options.isForcedHandoffEnabled === 'function'
+        ? options.isForcedHandoffEnabled
+        : buildForcedHandoffEnableGate({
+            forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+            expectedLinkedPrReferences,
+            prFirstCommitAt: options.prFirstCommitAt ?? null,
+          }),
+    isAuthorizedForcedHandoff:
+      typeof options.isAuthorizedForcedHandoff === 'function'
+        ? options.isAuthorizedForcedHandoff
+        : (forcedBy) => {
+            if (authorizedForcedHandoffLogins.size === 0) {
+              return false;
+            }
+            return authorizedForcedHandoffLogins.has(
+              String(forcedBy ?? '')
+                .trim()
+                .toLowerCase(),
+            );
+          },
+    isStale: resolveStalePredicate(options.staleAgeMs),
+  });
+  const expectedNonce = String(options.expectedNonce ?? '').trim();
+  let reason = 'match';
+  if (!activeClaim) {
+    reason = 'missing-active-claim';
+  } else if (expectedClaimId && activeClaim.claimId !== expectedClaimId) {
+    reason = 'claim-id-mismatch';
+  } else if (expectedAgentId && activeClaim.agentId !== expectedAgentId) {
+    reason = 'agent-id-mismatch';
+  } else if (expectedClaimId && expectedNonce) {
+    // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
+    // check (resume-claim-routing.mts) -- only meaningful once claim-id and
+    // agent-id already match, since claim-id alone cannot distinguish a
+    // second, independent activation of the same id. Computed lazily, here,
+    // so every pre-#1528 caller that never passes expectedNonce (the
+    // default) pays no parsing/sorting cost for it. Trust-filter first
+    // (findActivationNonceWinner does no author checks of its own), matching
+    // how the resume-side caller pre-filters before calling the same shared
+    // primitive.
+    const activationNonceWinner = findActivationNonceWinner(
+      claimEvents.filter((event) =>
+        trustedAuthorPredicate(event.author?.login ?? event.user?.login ?? ''),
+      ),
+      activeClaim.claimId,
+    );
+    if (
+      activationNonceWinner !== null &&
+      activationNonceWinner !== expectedNonce
+    ) {
+      reason = 'activation-nonce-mismatch';
+    }
+  }
+  return {
+    expectedClaimId,
+    expectedAgentId,
+    activeClaimPresent: Boolean(activeClaim),
+    activeClaim: {
+      agentId: activeClaim?.agentId ?? '',
+      claimId: activeClaim?.claimId ?? '',
+      supersedes: activeClaim?.supersedes ?? '',
+      branch: activeClaim?.branch ?? '',
+      createdAt: activeClaim?.createdAt ?? '',
+    },
+    matchesExpectedClaim: reason === 'match',
+    claimLost: reason !== 'match',
+    reason,
+  };
+}
+function preMergeAsRecord(value) {
+  return value && typeof value === 'object' ? value : {};
+}
+function isPreMergeCiAllPassing(ci) {
+  // #1377: an unreadable protection/ruleset read means the required-check
+  // set this report computed may be incomplete -- a masked 404 can hide
+  // additional required checks the readable source(s) never surfaced. Block
+  // unconditionally here, before either shortcut below, so a passing
+  // subset of (possibly incomplete) required checks can never mark the
+  // report ready.
+  if (ci.protectionReadsUnreadable === true) {
+    return false;
+  }
+  if (ci.requiredChecksPassing === true || ci.status === 'success') {
+    return true;
+  }
+  return (
+    ci.noRequiredChecksConfigured === true &&
+    String(ci.presentRunConclusion ?? '') === 'all-passing'
+  );
+}
+function isPreMergeReviewSatisfied(reviewerStates) {
+  if (reviewerStates.requiredApprovalsSatisfied !== true) {
+    return false;
+  }
+  if (reviewerStates.codeownerApprovalSatisfied === true) {
+    return true;
+  }
+  const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
+  return String(selfApproval.status ?? '') === 'clear';
+}
+/**
+ * Roll up the F2/F3 merge gates from a pre-merge-readiness report into the
+ * ordered blocker list. This is the single source of the merge-gate AND:
+ * `buildPreMergeReadinessSummary` embeds `{ ready, blockers }` computed from it,
+ * and `idd-merge-execute.evaluateMergeGates` delegates to it, so no caller
+ * re-implements the conjunction. The rollup is **strict** — it reads
+ * `dispositionEvidence.route === 'proceed'` directly and does NOT apply the
+ * `soleCauseAckOnlyPostDisposition` override (a separate flag the F2 checklist
+ * layers on top), so the fully-autonomous F3 executor keeps its fail-closed
+ * behavior. A gate whose evidence is missing or garbled fails closed (recorded
+ * as a blocker) rather than passing vacuously.
+ */
+export function computePreMergeReadinessBlockers(report) {
+  const blockers = [];
+  // Fail closed on a missing/invalid head: `prHeadSha` binds
+  // `--match-head-commit`, so a non-40-hex value must never yield a "ready"
+  // verdict with an unsafe merge binding.
+  const prHeadSha = String(report.prHeadSha ?? '');
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    blockers.push({
+      gate: 'head-sha',
+      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
+    });
+  }
+  const reviewCurrency = preMergeAsRecord(report.reviewCurrency);
+  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
+  if (comparisonRoute !== 'proceed') {
+    blockers.push({
+      gate: 'review-currency',
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(reviewCurrency.comparisonReason ?? 'unknown')}`,
+    });
+  }
+  const threads = preMergeAsRecord(report.threads);
+  const actionableCount = Number(threads.actionableCount ?? -1);
+  if (actionableCount !== 0) {
+    blockers.push({
+      gate: 'unresolved-threads',
+      detail: `actionableCount is ${actionableCount} (expected 0)`,
+    });
+  }
+  const advisoryWait = preMergeAsRecord(report.advisoryWait);
+  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
+  if (f3Outcome !== 'SATISFIED') {
+    blockers.push({
+      gate: 'advisory-wait',
+      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
+    });
+  }
+  // #1570: a settled-but-unreviewed Copilot request (`f3Outcome:
+  // "SATISFIED"` once `copilotPending` goes `false`, per
+  // `evaluateAdvisoryWaitF3Outcome`'s deliberate settled-path shortcut) must
+  // NOT merge unattended when the terminal `#1572` recovery contract has
+  // separately proven Copilot unavailable on this HEAD -- `f3Outcome` itself
+  // is intentionally left untouched (see `buildPreMergeReadinessSummary`'s
+  // module notes) so this is a DEDICATED, additive blocker rather than a
+  // change to the `advisory-wait` gate above. Only fires when the caller
+  // supplied `copilotUnavailable: true` (computed from
+  // `buildCopilotRecoverySummary`); omitted/false never fires, so a caller
+  // that has not wired this evidence sees unchanged behavior. A valid
+  // maintainer waiver for the `idd-advisory-convergence` selector (the same
+  // evidence the CI gate consumes, see advisory-convergence.mts) clears it.
+  if (
+    advisoryWait.copilotUnavailable === true &&
+    advisoryWait.copilotUnavailableWaived !== true
+  ) {
+    blockers.push({
+      gate: 'copilot-terminal-unavailable',
+      detail:
+        'Copilot is terminally unavailable on current HEAD (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver for selector ' +
+        `"${DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR}"`,
+    });
+  }
+  const ci = preMergeAsRecord(report.ci);
+  if (!isPreMergeCiAllPassing(ci)) {
+    // #1689: name the source-pinned cause explicitly when a required check
+    // is otherwise green but its ruleset entry carries an
+    // `app_id`/`integration_id` this helper cannot verify -- see
+    // `summarizeRequiredChecks`'s `sourcePinnedRequiredCheckNames` doc
+    // comment. Checked before the masked-403-as-404 detail below since the
+    // two causes are mutually exclusive (the source-pinned downgrade only
+    // fires on a genuinely readable required-check set).
+    const sourcePinnedNames = Array.isArray(ci.sourcePinnedRequiredCheckNames)
+      ? ci.sourcePinnedRequiredCheckNames.map((name) => String(name ?? ''))
+      : [];
+    // #1689: a pinned source that could not be attributed to any check name
+    // (a ruleset `workflows` rule, or a pinned entry with no `context`/
+    // `name`/`check`) -- see `sourcePinnedRequiredCheckNames`'s doc comment.
+    // Checked so the detail still names the source-pinned cause even when
+    // `sourcePinnedNames` above is empty (or only partially covers the
+    // pinning, in the mixed case), and so the opt-in caveat only appears
+    // when it is actually relevant (an unresolvable source is never
+    // covered by `trustSourcePinnedRequiredChecks`).
+    const sourcePinnedUnresolved = ci.sourcePinnedUnresolved === true;
+    let sourcePinnedDetail = '';
+    if (sourcePinnedNames.length > 0 && sourcePinnedUnresolved) {
+      sourcePinnedDetail = `required ${sourcePinnedNames.length > 1 ? 'checks' : 'check'} ${sourcePinnedNames.join(', ')}, plus an unresolvable source-pinned required-check requirement (e.g. a ruleset \`workflows\` rule), are source-pinned; producer verification unavailable (set ciGate.trustSourcePinnedRequiredChecks to opt in for the named check(s); the unresolvable source is never covered by this opt-in)`;
+    } else if (sourcePinnedNames.length > 0) {
+      sourcePinnedDetail = `required ${sourcePinnedNames.length > 1 ? 'checks' : 'check'} ${sourcePinnedNames.join(', ')} ${sourcePinnedNames.length > 1 ? 'are' : 'is'} source-pinned; producer verification unavailable (set ciGate.trustSourcePinnedRequiredChecks to opt in once the pinned integration is verified)`;
+    } else if (sourcePinnedUnresolved) {
+      sourcePinnedDetail =
+        'an unresolvable source-pinned required-check requirement is in force (e.g. a ruleset `workflows` rule); producer verification unavailable, and this cause is never covered by the ciGate.trustSourcePinnedRequiredChecks opt-in';
+    }
+    // #1377: name the masked-403-as-404 cause explicitly when that is why the
+    // gate is not all-passing, matching idd-ci.instructions.md's wording,
+    // instead of the generic status/noRequiredChecksConfigured detail below.
+    const detail =
+      ci.protectionReadsUnreadable === true
+        ? 'cannot determine required checks: protection/ruleset unreadable'
+        : sourcePinnedDetail ||
+          `CI is not all-passing (status="${String(ci.status ?? '')}", noRequiredChecksConfigured=${Boolean(ci.noRequiredChecksConfigured)}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`;
+    blockers.push({ gate: 'ci', detail });
+  }
+  const reviewerStates = preMergeAsRecord(report.reviewerStates);
+  if (!isPreMergeReviewSatisfied(reviewerStates)) {
+    const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
+    // #1380: name the masked-403-as-404 ruleset-detail cause explicitly when
+    // that is *why* the required-reviews gate is unmet, mirroring the CI
+    // gate's `protectionReadsUnreadable`-specific detail above, instead of
+    // the generic status detail below. Gate on the specific `reason` (set
+    // only by the one branch in `summarizeCodeownerSelfApproval` that
+    // actually resolved to this cause), not the bare
+    // `rulesetBypassUnreadable` boolean: that flag is present on every
+    // returned branch (it lives on `base`), so an unrelated resolution --
+    // e.g. `possible_deadlock`/`team-codeowner-ambiguous` -- could also
+    // carry `rulesetBypassUnreadable: true` (the same fetch that flagged
+    // the ruleset unreadable) while the real blocking cause is the
+    // ambiguous team, not the unreadable ruleset. Naming the wrong cause
+    // would misdirect an operator's remediation.
+    const detail =
+      selfApproval.reason === 'ruleset-bypass-unreadable'
+        ? 'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable'
+        : `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`;
+    blockers.push({ gate: 'required-reviews', detail });
+  }
+  const claim = preMergeAsRecord(report.claim);
+  if (claim.matchesExpectedClaim !== true) {
+    blockers.push({
+      gate: 'claim-ownership',
+      detail: `claim ownership does not match (reason="${String(claim.reason ?? 'unknown')}")`,
+    });
+  }
+  const dispositionEvidence = preMergeAsRecord(report.dispositionEvidence);
+  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
+  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
+  // blockingCount so a missing/garbled count is treated as a blocker.
+  const dispositionRoute = String(dispositionEvidence.route ?? '');
+  const dispositionBlockingCount = Number(
+    dispositionEvidence.blockingCount ?? -1,
+  );
+  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
+    blockers.push({
+      gate: 'disposition-evidence',
+      detail: `dispositionEvidence.route is "${dispositionRoute || 'missing'}" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
+    });
+  }
+  // #1513: fail closed on a missing/garbled `requiresUpToDateHead` -- only
+  // an explicit `false` counts as "not required" (matching every gate
+  // above's fail-closed promise); an absent/non-boolean value defaults to
+  // "required." Scoped to the literal `BEHIND` value only: `UNKNOWN`/null
+  // is the async-still-computing state that `idd-pre-merge.instructions.md`
+  // F1 and `idd-review-triage.instructions.md`'s E-phase branch-sync check
+  // already re-poll as transient, not terminal -- out of this gate's scope.
+  // Every other non-BEHIND `gh pr merge` rejection is caught by
+  // `idd-merge-execute.mts`'s `deps.mergePr` try/catch instead.
+  const branchCurrency = preMergeAsRecord(report.branchCurrency);
+  const requiresUpToDateHead = branchCurrency.requiresUpToDateHead !== false;
+  const mergeStateStatus = String(
+    branchCurrency.mergeStateStatus ?? '',
+  ).toUpperCase();
+  if (requiresUpToDateHead && mergeStateStatus === 'BEHIND') {
+    blockers.push({
+      gate: 'branch-currency',
+      detail: `mergeStateStatus is "BEHIND" and the base branch requires an up-to-date head before merge (requiresUpToDateHeadSource="${String(branchCurrency.requiresUpToDateHeadSource ?? 'unknown')}")`,
+    });
+  }
+  return blockers;
+}
+export function buildPreMergeReadinessSummary(
+  {
+    prHeadSha,
+    comments = [],
+    reviews = [],
+    threads = [],
+    checks = [],
+    branchRules = [],
+    branchRulesets = [],
+    branchProtection = {},
+    protectionReadsUnreadable = false,
+    branchRulesetsUnreadable = false,
+    requestedReviewers = [],
+    timelineEvents = [],
+    claimEvents = [],
+    changedFiles = [],
+    codeownersText = '',
+    eligibleCodeownerUserLogins = null,
+    eligibleCodeownerUserLoginsUnreadable = false,
+    reviewsUnreadable = false,
+    reviewDecision = '',
+    mergeStateStatus = '',
+    mergeable = '',
+  },
+  options = {},
+) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  if (!/^[0-9a-f]{40}$/.test(String(prHeadSha ?? ''))) {
+    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+  }
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins(
+    options.trustedMarkerLogins ?? [],
+  );
+  const iddAgentLogins = normalizeTrustedMarkerLogins(
+    options.iddAgentLogins ?? [],
+  );
+  const advisoryBotLogins = normalizeTrustedMarkerLogins(
+    options.advisoryBotLogins ?? [],
+  );
+  const prAuthorLogin = String(options.prAuthorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const branchReviewRequirements = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  );
+  const branchCurrency = summarizeBranchCurrency(
+    branchRules,
+    branchProtection,
+    {
+      mergeStateStatus,
+      mergeable,
+      protectionReadsUnreadable,
+    },
+  );
+  const liveSnapshot = buildActivitySnapshotSummary(
+    {
+      comments,
+      reviews,
+      threads,
+      checks,
+    },
+    {
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource: options.advisoryBotLoginsSource,
+      dispositionAuthorLogins: iddAgentLogins,
+    },
+  );
+  const watermark = resolveLatestReviewWatermark(comments, {
+    expectedClaimId: options.expectedClaimId,
+    isTrustedAuthor: (login) =>
+      trustedMarkerLogins.includes(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+  });
+  const reviewCurrency = watermark
+    ? diffReviewSnapshot(
+        {
+          headSha: watermark.headSha,
+          maxActivityUpdatedAt: watermark.maxActivityUpdatedAt,
+          totalItemCount: watermark.totalItemCount,
+          latestPassingCiCompletedAt: watermark.latestCiCompletedAt,
+        },
+        {
+          headSha: prHeadSha,
+          ...liveSnapshot,
+        },
+      )
+    : { route: 'return-to-e1', reason: 'missing-watermark' };
+  const threadSummary = summarizeReviewThreadsForGate(threads, {
+    iddAgentLogins,
+    prAuthorLogin,
+    requiresConversationResolution:
+      branchReviewRequirements.requiresConversationResolution,
+  });
+  const unrepliedComments = summarizeRegularCommentsForGate(comments, {
+    iddAgentLogins,
+    advisoryBotLogins,
+    trustedMarkerLogins,
+    threads,
+  });
+  // #1818: `options.primaryBotLogin` (the configured advisory-wait primary
+  // bot, e.g. a non-default Copilot form or a wholly different bot) must be
+  // treated as an advisory bot by `summarizeReviewerStates`'s review-approval
+  // counting specifically -- `isKnownReviewBot` only recognizes the literal
+  // default bot identities, and a repo that configures a custom
+  // `primaryBotLogin` without separately adding it to `advisoryBotLogins`
+  // would otherwise have that bot's `APPROVED`/`CHANGES_REQUESTED` review
+  // counted as a human's. Union it into a call-site-local set instead of
+  // widening the shared `advisoryBotLogins` above, which also feeds
+  // `buildActivitySnapshotSummary` and `summarizeRegularCommentsForGate`
+  // (unrelated classification needs that must not change as a side effect).
+  //
+  // Normalize + default `options.primaryBotLogin` the same way
+  // `buildAdvisoryWaitSummary` does a few lines below (`primaryBotLogin`
+  // local const there) -- an omitted/blank option must still resolve to the
+  // Copilot default, not silently drop out of the union. Without this, a
+  // caller that relies on defaulting (any caller other than this file's own
+  // `collectPreMergeReadiness`, which always resolves a non-empty value)
+  // would leave the bare `copilot` login unclassified here even though
+  // `isCopilotReviewerLogin` elsewhere already treats it as a genuine
+  // Copilot form (Copilot review, PR #1826).
+  const resolvedPrimaryBotLogin =
+    String(options.primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  const reviewerStateAdvisoryBotLogins = normalizeTrustedMarkerLogins([
+    ...advisoryBotLogins,
+    resolvedPrimaryBotLogin,
+  ]);
+  const reviewerStates = summarizeReviewerStates(reviews, {
+    reviewDecision,
+    branchRules,
+    branchRulesets,
+    branchProtection,
+    branchRulesetsUnreadable,
+    codeownersText,
+    changedFiles,
+    eligibleCodeownerUserLogins,
+    eligibleCodeownerUserLoginsUnreadable,
+    reviewsUnreadable,
+    advisoryBotLogins: reviewerStateAdvisoryBotLogins,
+    prAuthorLogin,
+    viewerLogin: options.viewerLogin,
+    viewerTeamSlugs: options.viewerTeamSlugs,
+    viewerAppSlug: options.viewerAppSlug,
+  });
+  const advisoryWaitOptions = normalizeAdvisoryWaitRuntimeOptions(options);
+  const advisoryWait = buildAdvisoryWaitSummary(
+    {
+      prHeadSha,
+      reviews,
+      requestedReviewers,
+      timelineEvents,
+      comments,
+    },
+    {
+      now,
+      ...advisoryWaitOptions,
+      viewerLogin: options.viewerLogin,
+      configuredTrustedActors: options.configuredTrustedActors,
+      collaboratorTrustEnabled: options.collaboratorTrustEnabled,
+      trustedMarkerLogins,
+      primaryBotLogin: options.primaryBotLogin,
+    },
+  );
+  const claim = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins,
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+    authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
+    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+    isForcedHandoffEnabled: options.isForcedHandoffEnabled,
+    expectedClaimId: options.expectedClaimId,
+    expectedAgentId: options.expectedAgentId,
+    expectedNonce: options.expectedNonce,
+    staleAgeMs: options.staleAgeMs,
+  });
+  const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
+  const waiverEvidence = summarizeExternalCheckWaivers(comments, {
+    prHeadSha,
+    activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
+    trustedMarkerLogins,
+    now,
+    waivableSelectors: waivableCheckSelectors,
+    maxValidity: options.externalCheckWaiverMaxValidity ?? '',
+  });
+  const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
+    waivers: waiverEvidence,
+    waivableSelectors: waivableCheckSelectors,
+    protectionReadsUnreadable,
+    trustSourcePinnedRequiredChecks:
+      options.trustSourcePinnedRequiredChecks === true,
+  });
+  // #1570: reuse the SAME waiver evidence above (already validated for
+  // selector/HEAD/claim/authority/expiry) to decide whether the caller-
+  // supplied terminal-unavailability verdict is also validly waived, filtered
+  // to the `idd-advisory-convergence` selector -- the identical selector
+  // advisory-convergence.mts's own terminal-waiver path consumes, so a single
+  // maintainer-posted waiver marker satisfies whichever gate (the CI
+  // required-check, or this direct F2/F3 evidence collector) is currently
+  // asking.
+  const copilotUnavailable = options.copilotUnavailable === true;
+  const copilotUnavailableWaived =
+    copilotUnavailable &&
+    waiverEvidence.valid.some(
+      (entry) =>
+        entry.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    );
+  const dispositionEvidence = options.includeDispositionEvidence
+    ? summarizeDispositionEvidenceForGate(
+        { comments, threads },
+        {
+          iddAgentLogins,
+          advisoryBotLogins,
+          trustedMarkerLogins,
+          prAuthorLogin,
+          snapshotBoundaryAt: watermark?.maxActivityUpdatedAt ?? null,
+        },
+      )
+    : null;
+  const summary = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    prHeadSha,
+    now,
+    reviewCurrency: {
+      watermarkPresent: Boolean(watermark),
+      watermark: {
+        agentId: watermark?.agentId ?? '',
+        claimId: watermark?.claimId ?? '',
+        headSha: watermark?.headSha ?? '',
+        maxActivityUpdatedAt: watermark?.maxActivityUpdatedAt ?? 'none',
+        totalItemCount: watermark?.totalItemCount ?? 0,
+        latestCiCompletedAt: watermark?.latestCiCompletedAt ?? 'none',
+        createdAt: watermark?.createdAt ?? 'none',
+      },
+      live: {
+        totalItemCount: liveSnapshot.totalItemCount,
+        maxActivityUpdatedAt: liveSnapshot.maxActivityUpdatedAt,
+        latestCiCompletedAt: liveSnapshot.latestCiCompletedAt,
+        latestPassingCiCompletedAt: liveSnapshot.latestPassingCiCompletedAt,
+        counts: liveSnapshot.counts,
+        ackOnly: liveSnapshot.ackOnly,
+        effective: liveSnapshot.effective,
+      },
+      comparisonRoute: reviewCurrency.route,
+      comparisonReason: reviewCurrency.reason,
+    },
+    threads: {
+      unresolvedCount: threads.filter((thread) => !thread.isResolved).length,
+      actionableCount: threadSummary.actionableCount,
+      awaitingReviewerCount: threadSummary.awaitingReviewerCount,
+      amdBlockingCount: threadSummary.amdBlockingCount,
+      conversationResolveAgentCount:
+        threadSummary.conversationResolveAgentCount,
+      conversationResolveAuthorCount:
+        threadSummary.conversationResolveAuthorCount,
+      classifications: threadSummary.classifications,
+    },
+    unrepliedComments,
+    reviewerStates,
+    advisoryWait: {
+      outcome: advisoryWait.outcome,
+      f3Outcome: advisoryWait.f3Outcome,
+      lastCopilotCommit: advisoryWait.lastCopilotCommit,
+      copilotPending: advisoryWait.copilotPending,
+      copilotPendingCoversHead: advisoryWait.copilotPendingCoversHead,
+      sameHeadMarkerPresent: advisoryWait.sameHeadMarkerPresent,
+      earliestSameHeadAt: advisoryWait.earliestSameHeadAt,
+      sameHeadMarkerCount: advisoryWait.sameHeadMarkerCount,
+      requestMarkerCount: advisoryWait.requestMarkerCount,
+      requestCap: advisoryWait.requestCap,
+      pendingWindowMinutes: advisoryWait.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWait.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWait.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWait.capExhaustedRoute,
+      elapsedMinutes: advisoryWait.elapsedMinutes,
+      copilotUnavailable,
+      copilotUnavailableWaived,
+    },
+    ci,
+    claim,
+    waiverEvidence,
+    branchCurrency,
+  };
+  if (dispositionEvidence) {
+    summary.dispositionEvidence = dispositionEvidence;
+  }
+  // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`
+  // instead of hand-ANDing ~8 nested gates (a dropped clause would fail open).
+  // Strict by construction (see `computePreMergeReadinessBlockers`): the F2
+  // checklist applies the ack-only override on top of this, not inside it.
+  const blockers = computePreMergeReadinessBlockers(summary);
+  summary.ready = blockers.length === 0;
+  summary.blockers = blockers;
+  return summary;
+}
+function normalizeLiveStatusDigestFields(fields) {
+  const normalized = {
+    phase: normalizeDigestField(fields.phase, 'Phase'),
+    claim: normalizeDigestField(fields.claim, 'Claim'),
+    branch: normalizeDigestField(fields.branch, 'Branch'),
+    lastChecked: normalizeDigestField(fields.lastChecked, 'Last checked'),
+    openBlockers: normalizeDigestField(fields.openBlockers, 'Open blockers'),
+    nextAction: normalizeDigestField(fields.nextAction, 'Next action'),
+    authoritativeBy: normalizeDigestField(
+      fields.authoritativeBy,
+      'Authoritative by',
+    ),
+  };
+  if (!isValidIsoTimestamp(normalized.lastChecked)) {
+    throw new Error('Last checked must be an ISO 8601 UTC timestamp');
+  }
+  return normalized;
+}
+function normalizeDigestField(value, label) {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+function escapeMarkdownTableCell(value) {
+  return String(value)
+    .replaceAll('\\', '\\\\')
+    .replaceAll('|', '\\|')
+    .replace(/\r?\n/g, '<br>');
+}
+function firstLine(value) {
+  return String(value)
+    .replace(/^\uFEFF/, '')
+    .split(/\r?\n/, 1)[0]
+    .trimEnd();
+}
+function sameDigestBody(currentBody, nextBody) {
+  return currentBody.trimEnd() === nextBody.trimEnd();
+}
+/**
+ * The distributed default claim-staleness window (`claimTiming.staleAge`
+ * `PT24H`), in milliseconds. Exported so config-aware callers can compare
+ * a parsed `claimTiming.staleAge` against "no override configured" and so
+ * {@link isStaleByAge} can fast-path to {@link isStaleAt} when the two
+ * agree.
+ */
+export const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+export function isStaleAt(activeCreatedAt, nextCreatedAt) {
+  return (
+    new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >=
+    DEFAULT_STALE_AGE_MS
+  );
+}
+/**
+ * Config-aware claim-staleness primitive: true when `nextCreatedAt` is at
+ * least `staleAgeMs` after `activeCreatedAt`. This is the single shared
+ * primitive promoted out of the staleness-window comparison that was
+ * independently duplicated across the resume and discover paths (each of
+ * which already reads `claimTiming.staleAge` from policy correctly) so a
+ * write-gate caller can reuse the exact same algorithm instead of adding
+ * yet another copy. Delegates to {@link isStaleAt} when `staleAgeMs` equals
+ * {@link DEFAULT_STALE_AGE_MS}, so behavior stays byte-identical for
+ * repositories on the default. Fails closed to `false` (not stale) when
+ * either timestamp is unparseable.
+ */
+export function isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
+  if (staleAgeMs === DEFAULT_STALE_AGE_MS) {
+    return isStaleAt(activeCreatedAt, nextCreatedAt);
+  }
+  const start = Date.parse(activeCreatedAt ?? '');
+  const end = Date.parse(nextCreatedAt ?? '');
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return false;
+  }
+  return end - start >= staleAgeMs;
+}
+/**
+ * Resolve the `isStale` predicate for the write-gate resolvers below from an
+ * optional caller-supplied `staleAgeMs` (a parsed `claimTiming.staleAge` in
+ * milliseconds). A valid positive finite value routes through the
+ * config-aware {@link isStaleByAge}; an omitted, non-numeric, non-finite, or
+ * non-positive value falls back to {@link isStaleAt} unchanged, so callers
+ * that do not pass `staleAgeMs` keep today's exact 24h behavior.
+ */
+function resolveStalePredicate(staleAgeMs) {
+  if (
+    typeof staleAgeMs !== 'number' ||
+    !Number.isFinite(staleAgeMs) ||
+    staleAgeMs <= 0
+  ) {
+    return isStaleAt;
+  }
+  return (activeCreatedAt, nextCreatedAt) =>
+    isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs);
+}
+function compareClaimIds(left, right) {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
+}
+function createdAtToTime(createdAt) {
+  const time = new Date(createdAt ?? '').getTime();
+  return Number.isFinite(time) ? time : null;
+}
+function createdAtToSecond(createdAt) {
+  const time = createdAtToTime(createdAt);
+  if (time === null) {
+    return null;
+  }
+  return Math.floor(time / 1000);
+}
+/**
+ * Robust ISO timestamp comparison: returns true only when both `left` and
+ * `right` parse to valid instants and `left` is strictly before `right`. If
+ * either side is missing or unparseable, returns false (fail closed). Used by
+ * the forced-handoff enable gate to decide whether an `issue-only` handoff
+ * predates a PR's first commit.
+ */
+function isStrictlyBeforeIso(left, right) {
+  const leftTime = createdAtToTime(left);
+  const rightTime = createdAtToTime(right);
+  if (leftTime === null || rightTime === null) {
+    return false;
+  }
+  return leftTime < rightTime;
+}
+export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
+  const options = normalizeClaimResolutionOptions(isTrustedAuthor);
+  const orderedEvents = events
+    .map((event, index) => {
+      const claim = parseClaimComment(event.body ?? '', event.createdAt ?? '');
+      return {
+        event,
+        index,
+        claimId: claim?.claimId ?? null,
+        time: createdAtToTime(event.createdAt),
+        second: createdAtToSecond(event.createdAt),
+      };
+    })
+    .sort((left, right) => {
+      if (
+        left.second !== null &&
+        right.second !== null &&
+        left.second !== right.second
+      ) {
+        return left.second - right.second;
+      }
+      if (left.second !== null && right.second === null) {
+        return -1;
+      }
+      if (left.second === null && right.second !== null) {
+        return 1;
+      }
+      if (
+        left.second !== null &&
+        right.second !== null &&
+        left.claimId &&
+        right.claimId &&
+        left.claimId !== right.claimId
+      ) {
+        return compareClaimIds(left.claimId, right.claimId);
+      }
+      if (
+        left.time !== null &&
+        right.time !== null &&
+        left.time !== right.time
+      ) {
+        return left.time - right.time;
+      }
+      return left.index - right.index;
+    })
+    .map(({ event }) => event);
+  let active = null;
+  for (const event of orderedEvents) {
+    active = applyClaimEvent(active, event, options);
+  }
+  return active;
+}
+export function applyClaimEvent(activeClaim, event, options = {}) {
+  const normalizedOptions = normalizeClaimResolutionOptions(options);
+  const authorLogin = event.author?.login ?? '';
+  if (!normalizedOptions.isTrustedAuthor(authorLogin)) {
+    return activeClaim;
+  }
+  const claim = parseClaimComment(event.body ?? '', event.createdAt ?? '');
+  if (claim) {
+    if (!activeClaim) {
+      return claim.supersedes === 'none' ? claim : null;
+    }
+    if (
+      claim.agentId === activeClaim.agentId &&
+      claim.claimId === activeClaim.claimId
+    ) {
+      // Enforce the heartbeat branch invariant (idd-claim.instructions.md
+      // rule 3.5): a heartbeat candidate whose {branch} does not exactly
+      // match the active claim's {branch} is anomalous and must not
+      // refresh the stale clock. Without this guard, a spurious heartbeat
+      // could extend the stale clock indefinitely and block the 24h
+      // stale-takeover recovery path that audit-pr-cleanup depends on.
+      if (claim.branch !== activeClaim.branch) {
+        normalizedOptions.onAnomalousHeartbeat({
+          agentId: claim.agentId,
+          claimId: claim.claimId,
+          activeBranch: activeClaim.branch,
+          heartbeatBranch: claim.branch,
+          createdAt: event.createdAt,
+        });
+        return activeClaim;
+      }
+      return {
+        ...activeClaim,
+        createdAt: event.createdAt ?? activeClaim.createdAt,
+      };
+    }
+    if (
+      claim.supersedes === activeClaim.claimId &&
+      normalizedOptions.isStale(activeClaim.createdAt, event.createdAt ?? '')
+    ) {
+      return claim;
+    }
+    return activeClaim;
+  }
+  const release = parseReleaseComment(event.body ?? '');
+  if (
+    release &&
+    activeClaim &&
+    release.agentId === activeClaim.agentId &&
+    release.claimId === activeClaim.claimId
+  ) {
+    return null;
+  }
+  const forcedHandoff = parseForcedHandoffComment(
+    event.body ?? '',
+    event.createdAt ?? '',
+  );
+  if (
+    forcedHandoff &&
+    activeClaim &&
+    forcedHandoff.oldAgentId === activeClaim.agentId &&
+    forcedHandoff.oldClaimId === activeClaim.claimId &&
+    forcedHandoff.branch === activeClaim.branch
+  ) {
+    if (!normalizedOptions.isForcedHandoffEnabled(forcedHandoff, event)) {
+      normalizedOptions.onIgnoredForcedHandoff({
+        reason: 'mode-disabled',
+        forcedHandoff,
+        event,
+      });
+      return activeClaim;
+    }
+    // Optional: bind the asserted forcedBy identity to the comment
+    // author so a trusted-marker actor cannot self-attest a handoff by
+    // naming an unrelated maintainer in the payload. This is the
+    // strict mode used by the Resume routing path (idd-claim.instructions.md
+    // rule 7). The default is off because production forced-handoff
+    // markers can be posted on behalf of a maintainer by a separate
+    // automation account; callers that want the strict binding (e.g.
+    // resume-claim-routing.mjs) opt in via `requireAuthorMatchesForcedBy`.
+    if (normalizedOptions.requireAuthorMatchesForcedBy) {
+      const authorLoginLower = String(authorLogin).trim().toLowerCase();
+      const forcedByLower = String(forcedHandoff.forcedBy ?? '')
+        .trim()
+        .toLowerCase();
+      if (!authorLoginLower || authorLoginLower !== forcedByLower) {
+        normalizedOptions.onIgnoredForcedHandoff({
+          reason: 'author-forced-by-mismatch',
+          forcedHandoff,
+          event,
+        });
+        return activeClaim;
+      }
+    }
+    if (
+      !normalizedOptions.isAuthorizedForcedHandoff(
+        forcedHandoff.forcedBy,
+        forcedHandoff,
+        event,
+      )
+    ) {
+      normalizedOptions.onIgnoredForcedHandoff({
+        reason: 'forced-by-unauthorized',
+        forcedHandoff,
+        event,
+      });
+      return activeClaim;
+    }
+    return {
+      agentId: forcedHandoff.newAgentId,
+      claimId: forcedHandoff.newClaimId,
+      supersedes: forcedHandoff.oldClaimId,
+      branch: forcedHandoff.branch,
+      createdAt: forcedHandoff.createdAt ?? activeClaim.createdAt,
+    };
+  }
+  return activeClaim;
+}
+function normalizeClaimResolutionOptions(optionsOrPredicate) {
+  if (typeof optionsOrPredicate === 'function') {
+    return {
+      isTrustedAuthor: optionsOrPredicate,
+      isForcedHandoffEnabled: () => false,
+      isAuthorizedForcedHandoff: () => false,
+      isStale: isStaleAt,
+      requireAuthorMatchesForcedBy: false,
+      onAnomalousHeartbeat: () => {},
+      onIgnoredForcedHandoff: () => {},
+    };
+  }
+  const options = optionsOrPredicate ?? {};
+  return {
+    isTrustedAuthor:
+      typeof options.isTrustedAuthor === 'function'
+        ? options.isTrustedAuthor
+        : () => true,
+    isForcedHandoffEnabled:
+      typeof options.isForcedHandoffEnabled === 'function'
+        ? options.isForcedHandoffEnabled
+        : () => false,
+    isAuthorizedForcedHandoff:
+      typeof options.isAuthorizedForcedHandoff === 'function'
+        ? options.isAuthorizedForcedHandoff
+        : () => false,
+    isStale:
+      typeof options.isStale === 'function' ? options.isStale : isStaleAt,
+    requireAuthorMatchesForcedBy: Boolean(options.requireAuthorMatchesForcedBy),
+    onAnomalousHeartbeat:
+      typeof options.onAnomalousHeartbeat === 'function'
+        ? options.onAnomalousHeartbeat
+        : () => {},
+    onIgnoredForcedHandoff:
+      typeof options.onIgnoredForcedHandoff === 'function'
+        ? options.onIgnoredForcedHandoff
+        : () => {},
+  };
+}
+export function normalizeLinkedPrReference(value) {
+  const token = String(value ?? '').trim();
+  if (!token) {
+    return '';
+  }
+  if (/^#?[1-9]\d*$/.test(token)) {
+    return token.replace(/^#/, '');
+  }
+  try {
+    const parsed = new URL(token);
+    const protocol = parsed.protocol.toLowerCase();
+    const hostname = parsed.hostname.toLowerCase();
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      return token.toLowerCase();
+    }
+    if (hostname !== 'github.com' && hostname !== 'www.github.com') {
+      return token.toLowerCase();
+    }
+    const pathMatch = parsed.pathname.match(
+      /^\/[^/]+\/[^/]+\/pull\/([1-9]\d*)\/?$/i,
+    );
+    if (pathMatch) {
+      return pathMatch[1];
+    }
+  } catch {
+    // Not a URL-form linked-pr reference.
+  }
+  return token.toLowerCase();
+}
+export function classifyResumeRoutingCase(input, options = {}) {
+  const staleHours = Number.isFinite(options.staleHours)
+    ? options.staleHours
+    : 24;
+  const stallMinutes = Number.isFinite(options.stallMinutes)
+    ? options.stallMinutes
+    : 30;
+  const pendingCiStates = new Set(
+    options.pendingCiStates ?? ['queued', 'in_progress', 'waiting', 'pending'],
+  );
+  const terminalSafeCiStates = new Set(
+    options.terminalSafeCiStates ?? ['success', 'none'],
+  );
+  if (input.displacedByForcedHandoff) {
+    return {
+      route: 'claim-lost-stop',
+      reason: 'session was displaced by trusted forced-handoff evidence',
+    };
+  }
+  if (!input.hasActiveClaim) {
+    return {
+      route: 'unclaimed-reclaim-required',
+      reason: 'resume requires a fresh claim before continuation',
+    };
+  }
+  if (input.claimOwnedBySession) {
+    if (input.rebaseInProgress || input.worktreeDirty) {
+      return {
+        route: 'crash-recovery',
+        reason: 'owned claim with interrupted local state',
+      };
+    }
+    return {
+      route: 'ordinary-continuation',
+      reason: 'owned claim with clean local state',
+    };
+  }
+  if (input.hasUsableForcedHandoffEvidence) {
+    return {
+      route: 'forced-handoff-recovery',
+      reason:
+        'trusted forced-handoff evidence takes precedence over stalled-session takeover',
+    };
+  }
+  if (!Number.isFinite(input.claimAgeHours)) {
+    return {
+      route: 'hold-for-evidence',
+      reason: 'claim age is missing for a non-owned claim',
+    };
+  }
+  if (!Number.isFinite(input.latestActivityAgeMinutes)) {
+    return {
+      route: 'hold-for-evidence',
+      reason: 'activity age is missing for a non-owned active claim',
+    };
+  }
+  const ciState = String(input.ciState ?? 'none').toLowerCase();
+  if (pendingCiStates.has(ciState)) {
+    return {
+      route: 'hold-for-evidence',
+      reason: 'CI is still pending for the active non-owned claim',
+    };
+  }
+  if (!terminalSafeCiStates.has(ciState)) {
+    return {
+      route: 'hold-for-evidence',
+      reason: 'CI is not in a terminal-safe state for stalled-claim recovery',
+    };
+  }
+  if (input.claimAgeHours < staleHours) {
+    if (input.latestActivityAgeMinutes >= stallMinutes) {
+      return {
+        route: 'hold-for-evidence',
+        reason: `non-owned claim is fresh and idle for >= ${stallMinutes}m, but still non-inheritable`,
+      };
+    }
+    return {
+      route: 'hold-for-evidence',
+      reason: 'non-owned claim remains non-inheritable until stale',
+    };
+  }
+  if (input.latestActivityAgeMinutes < stallMinutes) {
+    return {
+      route: 'hold-for-evidence',
+      reason: `non-owned claim is stale but quiet-window evidence is < ${stallMinutes}m`,
+    };
+  }
+  return {
+    route: 'stale-claim-takeover',
+    reason: `non-owned claim is stale at >= ${staleHours}h with quiet-window evidence >= ${stallMinutes}m`,
+  };
+}
+function hasExplicitDispositionAfter(targetComment, comments, options = {}) {
+  // Default accepts any non-bot human; an IDD-scoped predicate (when supplied)
+  // restricts the disposition author so a reviewer-authored marker does not
+  // count as a completed IDD disposition.
+  const isDispositionAuthor =
+    typeof options.isDispositionAuthor === 'function'
+      ? options.isDispositionAuthor
+      : (login) => !isKnownReviewBot(login);
+  const targetTime = Date.parse(targetComment.createdAt ?? '');
+  // The disposition must attribute itself to this sticky's advisory bot. Accept
+  // either the product word (`CodeRabbit`) or the bot **login**
+  // (`coderabbitai[bot]`) — the canonical disposition-non-review-notices output
+  // names the login, which `\bCodeRabbit\b` misses (no word boundary before the
+  // trailing `ai`). Naming the login reuses the same `advisoryBotIdentityToken`
+  // attribution the rest of the gate relies on. Fail-closed: an unattributable
+  // disposition still matches nothing.
+  const targetBotLogin = String(targetComment.author?.login ?? '');
+  return comments.some((comment) => {
+    const author = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!isDispositionAuthor(author) || !isDispositionComment(comment)) {
+      return false;
+    }
+    if (
+      !/\bCodeRabbit\b/i.test(comment.body ?? '') &&
+      !dispositionNamesAdvisoryBot(comment.body ?? '', targetBotLogin)
+    ) {
+      return false;
+    }
+    const dispositionTime = Date.parse(comment.createdAt ?? '');
+    return (
+      Number.isFinite(targetTime) &&
+      Number.isFinite(dispositionTime) &&
+      dispositionTime > targetTime
+    );
+  });
+}
+function normalizeGatingReviewTimestamp(review, state) {
+  const submittedAt = String(review.submittedAt ?? review.submitted_at ?? '');
+  if (isValidIsoTimestamp(submittedAt)) {
+    return submittedAt;
+  }
+  if (
+    state !== 'APPROVED' &&
+    state !== 'CHANGES_REQUESTED' &&
+    state !== 'DISMISSED'
+  ) {
+    return null;
+  }
+  const updatedAt = String(review.updatedAt ?? review.updated_at ?? '');
+  if (isValidIsoTimestamp(updatedAt)) {
+    return updatedAt;
+  }
+  return null;
+}
+function maxIsoTimestamp(values) {
+  let latest = null;
+  for (const value of values) {
+    const normalized = String(value);
+    if (!isValidIsoTimestamp(normalized)) {
+      continue;
+    }
+    if (!latest || compareIsoTimestamps(normalized, latest) > 0) {
+      latest = normalized;
+    }
+  }
+  return latest;
+}
+function summarizeRequiredCheckMetadata(parameters) {
+  const names = new Set();
+  // #1689: the SPECIFIC subset of `names` whose rule entry is itself
+  // source-pinned -- distinct from the aggregate `sourcePinned` flag below,
+  // which only says "at least one pinned entry exists somewhere in this
+  // parameters object." `summarizeRequiredChecks` needs the actual pinned
+  // names to name the source-pinned cause in a blocker detail instead of a
+  // generic "CI is not all-passing" message.
+  const pinnedNames = new Set();
+  let sourcePinned = false;
+  // #1689: true when at least one pinned entry could NOT be attributed to a
+  // resolved name (no `context`/`name`/`check` at all) -- distinct from
+  // `pinnedNames` being merely empty, which could also mean "no pinned
+  // entry exists." A caller must fail closed on this regardless of the
+  // `trustSourcePinnedRequiredChecks` opt-in: there is nothing to verify or
+  // trust when there is no check name to correlate with a live run.
+  let unresolvedPinned = false;
+  const rawChecks = [
+    ...(parameters.required_status_checks ?? []),
+    ...(parameters.required_checks ?? []),
+    ...(parameters.checks ?? []),
+    ...(parameters.contexts ?? []),
+  ];
+  for (const rawCheck of rawChecks) {
+    if (typeof rawCheck === 'string') {
+      if (rawCheck.trim()) {
+        names.add(rawCheck.trim());
+      }
+      continue;
+    }
+    const isPinned =
+      isSourcePinnedRequirementId(rawCheck?.app_id) ||
+      isSourcePinnedRequirementId(rawCheck?.integration_id) ||
+      Boolean(rawCheck?.source);
+    if (isPinned) {
+      sourcePinned = true;
+    }
+    let resolvedName = '';
+    for (const candidate of [
+      rawCheck?.context,
+      rawCheck?.name,
+      rawCheck?.check,
+      rawCheck?.integration_id ? rawCheck?.name : '',
+    ]) {
+      const normalized = String(candidate ?? '').trim();
+      if (normalized) {
+        resolvedName = normalized;
+        break;
+      }
+    }
+    if (resolvedName) {
+      names.add(resolvedName);
+      if (isPinned) {
+        pinnedNames.add(resolvedName);
+      }
+    } else if (isPinned) {
+      unresolvedPinned = true;
+    }
+  }
+  return {
+    names: [...names].sort(),
+    sourcePinned,
+    pinnedNames: [...pinnedNames].sort(),
+    unresolvedPinned,
+  };
+}
+function extractRequiredReviewerRequirement(reviewer) {
+  const record = typeof reviewer === 'string' ? undefined : reviewer;
+  const reviewerRef = record?.reviewer ?? {};
+  const reviewerType = String(reviewerRef.type ?? record?.type ?? '')
+    .trim()
+    .toLowerCase();
+  const reviewerId = String(reviewerRef.id ?? record?.id ?? '').trim();
+  let candidate =
+    typeof reviewer === 'string'
+      ? reviewer
+      : (record?.login ??
+        reviewerRef.login ??
+        record?.slug ??
+        record?.team ??
+        reviewerRef.slug ??
+        reviewerRef.team ??
+        reviewerRef.name ??
+        '');
+  if (!candidate && reviewerType && reviewerId) {
+    candidate = `${reviewerType}/${reviewerId}`;
+  }
+  return {
+    identity: String(candidate ?? '')
+      .trim()
+      .replace(/^@/, '')
+      .toLowerCase(),
+    minimumApprovals:
+      Number(record?.minimum_approvals ?? record?.min_approvals ?? 1) || 0,
+    filePatterns: (record?.file_patterns ?? record?.filePatterns ?? [])
+      .map((pattern) => String(pattern ?? '').trim())
+      .filter(Boolean),
+  };
+}
+function parseCodeownersRules(codeownersText) {
+  return String(codeownersText ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !line.startsWith('#'))
+    .map((line) => {
+      const tokens = tokenizeCodeownersLine(line);
+      const pattern = tokens.shift() ?? '';
+      const ownerTokens = [];
+      for (const token of tokens) {
+        if (token.startsWith('#')) {
+          break;
+        }
+        ownerTokens.push(token);
+      }
+      const users = ownerTokens
+        .filter((token) => /^@[^/\s#]+$/.test(token))
+        .map((token) => token.slice(1).toLowerCase());
+      const teams = ownerTokens
+        .filter((token) => /^@[^/\s#]+\/[^/\s#]+$/.test(token))
+        .map((token) => token.slice(1).toLowerCase());
+      const emails = ownerTokens
+        .filter((token) => /^[^@\s#][^\s#]*@[^\s#]+$/.test(token))
+        .map((token) => token.toLowerCase());
+      if (!pattern) {
+        return null;
+      }
+      return { pattern, users, teams, emails };
+    })
+    .filter(Boolean);
+}
+function findCodeownersForPath(rules, path) {
+  let latest = null;
+  for (const rule of rules) {
+    if (matchesCodeownersPattern(rule.pattern, path)) {
+      latest = rule;
+    }
+  }
+  return latest;
+}
+function matchesCodeownersPattern(pattern, path) {
+  const normalizedPattern = String(pattern ?? '').trim();
+  const normalizedPath = String(path ?? '')
+    .replace(/^\/+/, '')
+    .replace(/\\/g, '/');
+  if (!normalizedPattern || !normalizedPath) {
+    return false;
+  }
+  let body = normalizedPattern;
+  const anchored = body.startsWith('/');
+  if (anchored) {
+    body = body.slice(1);
+  }
+  const rawBody = body;
+  const trailingSlashPattern = rawBody.endsWith('/');
+  const lastSegment = rawBody.split('/').at(-1) ?? '';
+  const anyDepthFromRoot = rawBody.startsWith('**/');
+  const directoryLikePattern =
+    !trailingSlashPattern &&
+    !lastSegment.includes('*') &&
+    !lastSegment.includes('?');
+  if (trailingSlashPattern) {
+    body = `${body}**`;
+  }
+  if (anyDepthFromRoot) {
+    body = body.slice(3);
+  }
+  const slashAnchored =
+    anchored ||
+    (rawBody.includes('/') && !anyDepthFromRoot && !trailingSlashPattern);
+  let source = anyDepthFromRoot || !slashAnchored ? '^(?:|.*\\/)' : '^';
+  for (let index = 0; index < body.length; index += 1) {
+    const triplet = body.slice(index, index + 3);
+    const pair = body.slice(index, index + 2);
+    if (triplet === '**/') {
+      source += '(?:[^/]+/)*';
+      index += 2;
+      continue;
+    }
+    if (pair === '**') {
+      source += '.*';
+      index += 1;
+      continue;
+    }
+    const character = body[index];
+    if (character === '*') {
+      source += '[^/]*';
+      continue;
+    }
+    if (character === '?') {
+      source += '[^/]';
+      continue;
+    }
+    source += escapeRegExp(character);
+  }
+  if (directoryLikePattern) {
+    source += '(?:/.*)?';
+  }
+  source += '$';
+  return new RegExp(source).test(normalizedPath);
+}
+export function effectiveRegularCommentActivityAt(comment) {
+  const updatedAt = String(comment.updatedAt ?? '');
+  if (
+    isValidIsoTimestamp(updatedAt) &&
+    compareIsoTimestamps(updatedAt, comment.createdAt) > 0
+  ) {
+    return updatedAt;
+  }
+  return comment.createdAt;
+}
+function isSourcePinnedRequirementId(value) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0;
+}
+function tokenizeCodeownersLine(line) {
+  const tokens = [];
+  let current = '';
+  let escaped = false;
+  for (const character of String(line ?? '')) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === ' ' || character === '\t') {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += character;
+  }
+  if (escaped) {
+    current += '\\';
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+function hasCodeownerOwners(rule) {
+  return (
+    (rule?.users?.length ?? 0) > 0 ||
+    (rule?.teams?.length ?? 0) > 0 ||
+    (rule?.emails?.length ?? 0) > 0
+  );
+}
+// True when a PR-author login belongs to a gate-relevant advisory bot — a known
+// review bot (CodeRabbit/Codex/Copilot defaults) or a configured
+// `advisoryBotLogins` entry. The GitHub `[bot]` suffix is normalized
+// symmetrically via `advisoryBotIdentityToken` on both the incoming login and
+// each configured entry, so a custom bot matches whether the config or the
+// author login stores the suffixed (`my-bot[bot]`) or suffixless (`my-bot`)
+// form. Fail-closed on an empty token.
+export function isGateAdvisoryBotLogin(login, advisoryBotLogins) {
+  const token = advisoryBotIdentityToken(login);
+  if (!token) {
+    return false;
+  }
+  return (
+    isKnownReviewBot(token) ||
+    isConfiguredAdvisoryBotLogin(login, advisoryBotLogins)
+  );
+}
+// True when a login matches a **configured** `advisoryBotLogins` entry, with the
+// GitHub `[bot]` suffix normalized symmetrically via `advisoryBotIdentityToken`
+// on both the incoming login and each configured entry — so a custom bot matches
+// whether either side stores the suffixed (`my-bot[bot]`) or suffixless
+// (`my-bot`) form. Unlike `isGateAdvisoryBotLogin`, this does **not** also match
+// `isKnownReviewBot`: the advisory courtesy-ack carve-outs must recognize only
+// configured advisory bots, so a Copilot/known-review-bot ack is never
+// reclassified as a configured-advisory-bot ack. Fail-closed on an empty token.
+export function isConfiguredAdvisoryBotLogin(login, advisoryBotLogins) {
+  const token = advisoryBotIdentityToken(login);
+  if (!token) {
+    return false;
+  }
+  for (const configured of advisoryBotLogins) {
+    if (advisoryBotIdentityToken(configured) === token) {
+      return true;
+    }
+  }
+  return false;
+}
+function _isOperationalOrDigestComment(body) {
+  return (
+    operationalMarkerPrefix(body) !== null ||
+    firstLine(body) === LIVE_STATUS_DIGEST_MARKER
+  );
+}
+function isOperationalOrDigestCommentForGate(
+  body,
+  authorLogin,
+  trustedMarkerLogins,
+) {
+  const marker = operationalMarkerPrefix(body);
+  if (marker === '<!-- forced-handoff:') {
+    return trustedMarkerLogins.has(
+      String(authorLogin ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  }
+  return marker !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;
+}
+function buildBodyPreview(body) {
+  return firstLine(String(body ?? '')).slice(0, 120);
+}
+function advisoryWaitMarkerMatchesHead(body, prHeadSha) {
+  return (
+    new RegExp(`^advisory-wait: [^ ]+ ${escapeRegExp(prHeadSha)}(?: |$)`).test(
+      body,
+    ) ||
+    new RegExp(
+      `^advisory-wait-recovery: [^ ]+ ${escapeRegExp(prHeadSha)}(?: |$)`,
+    ).test(body) ||
+    new RegExp(
+      `^<!-- advisory-wait: [^ ]+ ${escapeRegExp(prHeadSha)} [^ ]+ -->$`,
+    ).test(body)
+  );
+}
+function advisoryWaitRequestMarker(body) {
+  return /^advisory-wait:/.test(body) || /^<!-- advisory-wait:/.test(body);
+}
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+function minutesBetweenIso(start, end) {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return 0;
+  }
+  return Math.floor((endMs - startMs) / 60000);
+}
+export function compareIsoTimestamps(left, right) {
+  const leftComparable = normalizeComparableTimestamp(left);
+  const rightComparable = normalizeComparableTimestamp(right);
+  if (
+    typeof leftComparable === 'number' &&
+    typeof rightComparable === 'number'
+  ) {
+    if (leftComparable !== rightComparable) {
+      return leftComparable - rightComparable;
+    }
+    return String(left ?? '').localeCompare(String(right ?? ''));
+  }
+  if (typeof leftComparable === 'number') {
+    return 1;
+  }
+  if (typeof rightComparable === 'number') {
+    return -1;
+  }
+  return String(left ?? '').localeCompare(String(right ?? ''));
+}
+function threadActivityAt(thread) {
+  if (isValidIsoTimestamp(thread.updatedAt ?? '')) {
+    return thread.updatedAt;
+  }
+  const commentTimes = (thread.comments?.nodes ?? [])
+    .flatMap((comment) => [comment.updatedAt, comment.createdAt])
+    .filter(isValidIsoTimestamp);
+  return maxIsoTimestamp(commentTimes);
+}
+function effectiveThreadCommentActivityAt(comment) {
+  const updatedAt = String(comment?.updatedAt ?? '');
+  if (isValidIsoTimestamp(updatedAt)) {
+    return updatedAt;
+  }
+  const createdAt = String(comment?.createdAt ?? '');
+  if (isValidIsoTimestamp(createdAt)) {
+    return createdAt;
+  }
+  return '';
+}
+function hasCompletedBotThreadDispositions(
+  threads,
+  loginPredicate,
+  options = {},
+) {
+  const botThreads = threads.filter((thread) => {
+    return (thread.comments?.nodes ?? []).some((comment) => {
+      return (
+        loginPredicate(comment.author?.login ?? '') &&
+        !isDispositionComment(comment)
+      );
+    });
+  });
+  return (
+    botThreads.length > 0 &&
+    botThreads.every((thread) => {
+      return (
+        thread.isResolved &&
+        !thread.comments?.pageInfo?.hasNextPage &&
+        hasFreshDisposition(thread, {
+          isDispositionAuthor: options.isDispositionAuthor,
+        })
+      );
+    })
+  );
+}
+function hasUnresolvedKnownBotThreads(threads) {
+  return threads.some((thread) => {
+    if (thread.isResolved) {
+      return false;
+    }
+    if (thread.comments?.pageInfo?.hasNextPage) {
+      return true;
+    }
+    return (thread.comments?.nodes ?? []).some((comment) => {
+      return isKnownReviewBot(comment.author?.login ?? '');
+    });
+  });
+}
+function isCompletedCiTimestamp(value) {
+  const timestamp = String(value ?? '');
+  return timestamp !== '0001-01-01T00:00:00Z' && isValidIsoTimestamp(timestamp);
+}
+function normalizeComparableTimestamp(value) {
+  const normalized = String(value ?? 'none');
+  if (normalized === 'none') {
+    return 'none';
+  }
+  if (!isValidIsoTimestamp(normalized)) {
+    return null;
+  }
+  return Date.parse(normalized);
+}

--- a/scripts/readline-prompt.mjs
+++ b/scripts/readline-prompt.mjs
@@ -1,0 +1,28 @@
+// idd-generated-from: src/scripts/readline-prompt.mts
+//
+// The scripts/readline-prompt.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared interactive stdin/stdout prompt, extracted from identical
+// hand-rolled copies in force-handoff.mts and external-check-waiver.mts
+// (see #1448). `node:readline/promises`'s `question` already resolves a
+// `Promise<string>`, so no manual `new Promise` wrapping is needed here.
+//
+// Consumed by:
+//
+// - scripts/force-handoff.mjs
+// - scripts/external-check-waiver.mjs
+import { createInterface } from 'node:readline/promises';
+/**
+ * Create an interactive stdin/stdout prompt. The returned function asks
+ * `question` and resolves with the operator's answer; `.close` releases the
+ * underlying readline interface, matching the interface every caller of the
+ * former hand-rolled `makeReadlinePrompt` already expects.
+ */
+export function makeReadlinePrompt() {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (question) => rl.question(question);
+  ask.close = () => rl.close();
+  return ask;
+}

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -1,0 +1,2038 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/rerun-advisory-convergence.mts
+//
+// The scripts/rerun-advisory-convergence.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only rerun-plan helper for stuck `idd-advisory-convergence` rollups
+// (#1431). Automates the manual recovery documented in
+// `idd-ci.instructions.md` §Rerun mechanics (#1381, extended by #1424): a
+// PR HEAD can accumulate several `idd-advisory-convergence` check-run
+// instances (the check fires on pull_request + pull_request_review +
+// pull_request_review_comment, and `cancel-in-progress` cancels most of
+// them), and the required-check rollup can stay pinned to a stale
+// non-passing instance even after the real verdict converges. This helper
+// fetches every check-run instance for the current HEAD via the commit
+// check-runs API (not the recent-runs list, which can page the target run
+// out of view -- see the module-level `fetchCheckRunsForRef` doc comment),
+// classifies each instance, and prints the exact sequential `gh run rerun`
+// recovery plan. It never calls `gh run rerun` (or any other mutating
+// command) itself; a mutating `--apply` mode is a deliberate follow-up
+// (out of scope here).
+//
+// Classification (six states -- the issue's three named buckets, `pass` /
+// `rerun-eligible` / `bot-gated-skip`, are a subset here; `pending`,
+// `unresolved`, and `awaiting-fresh-review` are additional fail-safe
+// states so a live run is never force-classified into either "skip
+// forever" or "safe to rerun", an unresolvable run identity is reported
+// instead of silently guessed or dropped, and a failure whose own
+// advisory-convergence verdict is "review does not cover HEAD" is never
+// recommended for a rerun that cannot change that outcome -- #1775):
+//   - `pass`: conclusion is success/neutral/skipped -- no action needed.
+//   - `pending`: still queued/in_progress (no conclusion yet) -- reported,
+//     excluded from the plan (rerunning a live run cancels it, not helps).
+//   - `bot-gated-skip`: conclusion is `action_required` -- rerunning
+//     without a non-bot trigger or maintainer approval re-enters
+//     `action_required` per #1424, so this needs a non-bot trigger or
+//     maintainer approval, never a rerun. Whether the underlying workflow
+//     run's actor/triggering_actor is a bot (`type === "Bot"` is the
+//     primary signal; a configured advisory-bot login is a defensive
+//     fallback) is reported in the reason text when it applies, but no
+//     longer gates BY ITSELF (narrowed by #1745): #1424 only established
+//     that an `action_required`-conclusion Copilot-triggered run is gated
+//     by GitHub, never that every bot-triggered instance regardless of its
+//     own conclusion is unsafe to rerun. A direct experiment on PR #1741
+//     confirmed a `CANCELLED`-conclusion bot-triggered instance reran and
+//     completed normally, never re-entering `action_required` -- the prior,
+//     over-broad `|| botTriggered` condition withheld exactly that working
+//     recovery action from the plan.
+//   - `unresolved`: the run id could not be parsed from the check-run's
+//     URL, or the per-run lookup itself failed -- reported for manual
+//     inspection, never silently dropped and never placed in the plan
+//     (fail-closed: an instance this helper cannot positively verify as
+//     safe is never recommended for rerun).
+//   - `awaiting-fresh-review`: the instance's own advisory-convergence
+//     JSON verdict (from the workflow job log) reports that the latest
+//     Copilot review does not cover the current HEAD. No number of
+//     `gh run rerun` invocations changes that outcome -- only a fresh
+//     review does -- so this is never placed in the plan and never
+//     spends the rerun-once budget (#1775, observed on PR #1772).
+//     #1806: this historical verdict is a snapshot of the workflow job
+//     log at the time THAT run executed, and the log is immutable -- so
+//     an instance that failed BEFORE a fresh review landed keeps
+//     reporting uncovered-HEAD forever, even once live coverage is
+//     satisfied (observed on PR #1854: the failed run's own log still
+//     said "does not cover current HEAD" after Copilot had already
+//     reviewed the real current HEAD with no new comments). When a LIVE
+//     check (reusing `advisory-convergence.mts`'s own Clause 1 evidence
+//     via `review-clause.mts`) confirms the current HEAD IS now covered,
+//     this classification recovers to `rerun-eligible` instead of
+//     staying stuck -- see `RerunPlanOptions.headCoverageSatisfied` and
+//     `classifyInstance`'s uncovered-HEAD step. Live coverage that is
+//     unreadable, not yet established, or simply not checked (no
+//     historical uncovered-HEAD reason to recover) leaves this hold
+//     exactly as it was before #1806 -- fail-closed, never an invented
+//     rerun.
+//   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
+//     ordered rerun plan (bot-triggered or not, unless gated per above).
+//
+// Reuse map (no duplicated identity/config logic):
+//   - `resolveAdvisoryPrimaryBotLogin`, `isCopilotReviewerLogin`,
+//     `resolveAdvisoryBotLogins`, `advisoryBotIdentityToken` -- the same
+//     bot-identity configuration and matching (including the `[bot]`-suffix
+//     normalization) every advisory-wait/-convergence helper already uses.
+//   - `normalizeCiWaitPolicy` -- the same ciWait.rerunPolicy resolution
+//     `idd-ci.instructions.md` §Rerun mechanics makes this helper's own
+//     recovery recommendations subject to.
+//   - `resolveCiRerunDecision` -- the same rerun-once-budget decision
+//     (policy string AND per-run rerun-attempt count) CI-wait itself
+//     applies, reused per instance here (via each instance's own
+//     `runAttempt`) rather than re-derived, so this helper can never
+//     recommend a rerun CI-wait's own budget would already refuse
+//     (ci-wait-policy.mts).
+//   - `deriveGhHttpStatus` -- discriminates a confirmed 404 (genuinely no
+//     remote config) from any other unreadable state, so a cross-repo
+//     config fetch fails closed instead of guessing (gh-http-status.mts).
+//   - `ghText` -- shared `gh` execution (gh-exec.mts). The CLI-entry-point
+//     guard below uses Node's own native `import.meta.main`, which
+//     replaced this repo's hand-rolled `isCliExecution` helper (removed
+//     from gh-exec.mts by an unrelated `main`-sync merge).
+//   - `parsePaginatedGhNdjson` -- shared NDJSON pagination parser
+//     (protocol-helpers.mts), reused directly here rather than through
+//     `ghApiJson`'s `paginate` mode: that mode hardcodes `--jq '.[]'` for a
+//     bare top-level array, but the commit check-runs endpoint's shape is
+//     `{ total_count, check_runs: [...] }`, so this file's own
+//     `fetchCheckRunsForRef` passes `--jq '.check_runs[]'` instead.
+//   - `resolveLatestCopilotReviewClause`, `fetchReviewsAndHeadCommit`
+//     (review-clause.mts, #1806) -- the SAME latest-review Clause 1
+//     evidence `advisory-convergence.mts`'s own `converged` verdict is
+//     built on, reused here for the live-coverage recovery signal
+//     (`RerunPlanOptions.headCoverageSatisfied`) instead of a second,
+//     independent GraphQL path that could drift out of sync with the
+//     real gate's own notion of "covers current HEAD". Deliberately
+//     imported from the small `review-clause.mts` module rather than
+//     `advisory-convergence.mts` directly, keeping this read-only
+//     helper's dependency surface off that file's full claim/waiver/
+//     disposition machinery (see `review-clause.mts`'s own doc comment).
+//
+// This helper never mutates GitHub state: it only reads check-run/run data
+// and prints a diagnosis plus a plan of commands for a human (or a future
+// --apply follow-up) to execute.
+import { parseArgs as nodeParseArgs } from 'node:util';
+import {
+  DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  resolveAdvisoryPrimaryBotLogin,
+} from './advisory-wait-policy.mjs';
+import {
+  normalizeCiWaitPolicy,
+  resolveCiRerunDecision,
+} from './ci-wait-policy.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { isValidIsoTimestamp } from './marker-helpers.mjs';
+import {
+  advisoryBotIdentityToken,
+  isCopilotReviewerLogin,
+  parsePaginatedGhNdjson,
+  resolveAdvisoryBotLogins,
+} from './protocol-helpers.mjs';
+// #1806: reuses `advisory-convergence.mts`'s own latest-review Clause 1
+// evidence (whether the latest trusted primary-bot review's commit
+// matches the PR's current HEAD) to recover a check-run instance whose
+// OWN historical job-log verdict is stale, instead of a second ad-hoc
+// GraphQL path. Imported from `review-clause.mts` (not
+// `advisory-convergence.mts` directly) -- see that module's own doc
+// comment and this file's module-header "Reuse map" above for why this
+// helper's dependency surface deliberately stays off the full
+// `advisory-convergence.mts` claim/waiver/disposition machinery.
+import {
+  fetchReviewsAndHeadCommit,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mjs';
+import { loadJson, validateConfigSection } from './validate-schemas.mjs';
+/** The check name this helper diagnoses. Matches
+ * `ADVISORY_CONVERGENCE_CHECK_SELECTOR` in advisory-convergence.mts;
+ * duplicated as a literal here (not imported) to keep this read-only
+ * helper's dependency surface limited to what it actually needs --
+ * advisory-convergence.mts pulls in the full claim/waiver/disposition
+ * machinery this helper has no use for. */
+export const RERUN_PLAN_CHECK_NAME = 'idd-advisory-convergence';
+/** Same schema `readCiWaitPolicy` (ci-wait-policy.mts) and
+ * `readAdvisoryPrimaryBotLogin` (advisory-wait-policy.mts) already
+ * validate their own local-disk config reads against, reused here for
+ * {@link sanitizeRemoteConfig} so a fetched-but-schema-invalid section
+ * fails closed the same way theirs already does (#1434 review, Codex
+ * P2). */
+const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+/** Check-run `conclusion` values treated as pass-equivalent, matching
+ * `idd-ci.instructions.md`'s normalized required-check states. */
+const PASS_CONCLUSIONS = new Set(['success', 'neutral', 'skipped']);
+/** Check-run `status` values meaning "has not concluded yet". Only
+ * consulted when `conclusion` is absent -- a completed run always reports
+ * a conclusion, so this set is only reached pre-completion. */
+const PENDING_STATUSES = new Set([
+  'queued',
+  'in_progress',
+  'requested',
+  'waiting',
+  'pending',
+]);
+/** Workflow-run trigger events this helper trusts to reliably refresh the
+ * PR's required-check rollup on rerun, matching the events
+ * `idd-advisory-convergence` itself subscribes to (its own header comment,
+ * mirrored in `idd-ci.instructions.md` §Rerun mechanics): `pull_request`,
+ * `pull_request_review`, `pull_request_review_comment`. A run triggered by
+ * any other event -- most notably `workflow_dispatch` -- has no
+ * `pull_request` context of its own and is documented as NOT reliably
+ * associated with the PR's HEAD SHA, so rerunning it would not dependably
+ * clear a stuck rollup even though the run itself is otherwise a plain,
+ * non-bot failure. */
+const PULL_REQUEST_FAMILY_EVENTS = new Set([
+  'pull_request',
+  'pull_request_review',
+  'pull_request_review_comment',
+]);
+/**
+ * Stable phrase shared with `advisory-convergence.mts` Clause 1's reason
+ * text (`latest <bot> review (commit <sha>) does not cover current HEAD
+ * <head>`). Matching on this substring (not the whole templated string)
+ * keeps the classifier independent of the configured primary bot login
+ * and of either SHA, while still sourcing the decision from the
+ * workflow's own verdict rather than re-deriving coverage (#1775).
+ */
+export const UNCOVERED_HEAD_REASON_MARKER = 'does not cover current HEAD';
+const PLAN_CAVEAT =
+  'Rerun the rerun-eligible instances ONE AT A TIME, in the order listed below, waiting for each `gh run rerun` to finish before starting the next -- rerunning several concurrently makes them cancel each other via the shared concurrency group.';
+// Deliberately does NOT open with "No rerun-eligible instance exists": since
+// #1745, recoveryRefreshPlan can be populated alongside a non-empty `plan`
+// (a bot-triggered rerun-eligible instance, e.g. a CANCELLED sibling, does
+// not itself supply the non-bot trigger a separately bot-gated instance
+// still needs), so that claim is not always true. `plan`'s own emptiness or
+// non-emptiness is already visible in the JSON document; this text sticks to
+// the technical gating condition, which holds regardless (#1752).
+const RECOVERY_REFRESH_CAVEAT =
+  'At least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
+/**
+ * Compute the deterministic rerun-plan verdict from already-fetched and
+ * already-enriched check-run instances. Pure (no I/O), so it is directly
+ * unit-testable with fixtures -- mirrors
+ * `computeAdvisoryConvergenceVerdict` (advisory-convergence.mts).
+ */
+export function computeRerunPlan(input, options) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  // Lowercased before validating, so a mixed-/upper-case 40-hex SHA is
+  // accepted (normalized), matching advisory-convergence.mts's own rule.
+  const prHeadSha = String(input.prHeadSha ?? '').toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character hexadecimal commit SHA');
+  }
+  const checkName =
+    String(input.checkName ?? '').trim() || RERUN_PLAN_CHECK_NAME;
+  const owner = String(input.owner ?? '').trim();
+  const repo = String(input.repo ?? '').trim();
+  const primaryBotLogin =
+    String(options.primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  const advisoryBotLogins = normalizeLoginList(options.advisoryBotLogins ?? []);
+  const classifyOptions = {
+    primaryBotLogin,
+    advisoryBotLogins,
+    // #1806: `undefined` normalizes to `null` here so `classifyInstance`'s
+    // uncovered-HEAD step can use a single `=== true` check to fail closed
+    // on every non-`true` value (`false`, `null`, and omitted alike).
+    headCoverageSatisfied: options.headCoverageSatisfied ?? null,
+  };
+  const instances = (input.instances ?? []).map((instance) =>
+    classifyInstance(instance, classifyOptions),
+  );
+  // idd-ci.instructions.md §Rerun mechanics makes the advisory-convergence
+  // recovery explicitly subject to the resolved ciWait.rerunPolicy: a
+  // `"hold"` policy means a repository has deliberately opted out of
+  // automatic reruns (withholds every instance), and even under the
+  // default `"rerun-once"` policy, an instance whose own `runAttempt`
+  // shows a rerun already happened has already used its one-rerun budget
+  // (withholds only that instance). Both flow through the SAME
+  // {@link resolveCiRerunDecision} (ci-wait-policy.mts) CI-wait itself
+  // applies, reused per instance here rather than re-derived, so this
+  // helper's recovery recommendations can never drift out of sync with
+  // the budget CI-wait already enforces. `runAttempt` counts every rerun
+  // of the underlying workflow run regardless of trigger (a manual UI
+  // rerun, another session's `gh run rerun`, or this helper's own
+  // previously-followed plan) -- treating any prior attempt as already
+  // having consumed the budget is intentional: a rollup still stuck after
+  // one rerun warrants a human look, not another automated rerun (#1434
+  // review, Codex P1).
+  const rerunPolicy =
+    String(options.rerunPolicy ?? '').trim() === 'hold' ? 'hold' : 'rerun-once';
+  const eligibleInstances = instances.filter(
+    (instance) => instance.classification === 'rerun-eligible',
+  );
+  const eligibleDecisions = new Map(
+    eligibleInstances.map((instance) => [
+      instance.checkRunId,
+      resolveInstanceRerunDecision(instance, rerunPolicy),
+    ]),
+  );
+  const reRunningEligibleInstances = eligibleInstances.filter(
+    (instance) =>
+      eligibleDecisions.get(instance.checkRunId)?.action === 'rerun',
+  );
+  const plan = buildOrderedPlan(reRunningEligibleInstances, owner, repo);
+  const recoveryRefreshCandidates = selectRecoveryRefreshCandidates(
+    instances,
+    classifyOptions,
+  );
+  // Two independent conditions gate recoveryRefreshPlan, both preserved
+  // from the reasoning that produced them:
+  //
+  // 1. `!anyEligibleHeld` (CodeRabbit review, #1434): a genuine
+  //    rerun-eligible instance whose OWN budget is exhausted/unconfirmed
+  //    must never silently fall through to recovery-refresh, which would
+  //    recommend rerunning a DIFFERENT, already-passing instance instead --
+  //    circumventing the "one rerun, then a human reviews it" boundary the
+  //    budget hold exists to enforce.
+  // 2. `everyReRunningEligibleIsBotTriggered` (#1745 Codex review, this
+  //    PR): pre-#1745, EVERY bot-triggered non-pass instance was
+  //    `bot-gated-skip`, so `eligibleInstances.length === 0` alone
+  //    correctly meant "bot-gated-only, nothing else to trigger a fresh
+  //    evaluation" -- the scenario recoveryRefreshPlan's own doc comment
+  //    describes. #1745 narrowed `bot-gated-skip` to a genuine
+  //    `action_required` conclusion only, so a bot-triggered `CANCELLED`
+  //    sibling can now be BOTH independently `rerun-eligible` (goes into
+  //    `plan`) AND coexist with a still-genuinely-gated `action_required`
+  //    instance that ALSO needs the passing-instance refresh -- rerunning
+  //    the bot-triggered eligible instance does not itself supply the
+  //    "fresh NON-BOT-triggered evaluation" the refresh mechanism exists
+  //    to force (a rerun preserves its original run's triggering actor),
+  //    so it must not suppress recoveryRefreshPlan the way a genuinely
+  //    NON-bot rerun-eligible instance legitimately does (that instance's
+  //    own rerun already IS the needed non-bot trigger). Vacuously `true`
+  //    when there is nothing in `plan` to begin with, preserving the
+  //    original bot-gated-only case unchanged.
+  //
+  // #1806 interaction (intentional): a live-coverage-recovered instance
+  // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
+  // see `classifyInstance`'s uncovered-HEAD step) enters `eligibleInstances`
+  // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
+  // exhausted the rerun-once budget, rule 1 above applies to it exactly the
+  // same way it already applies to any other budget-held eligible instance:
+  // `anyEligibleHeld` becomes `true` and `recoveryRefreshPlan` is withheld
+  // for the WHOLE rollup, even when a separate, still-genuinely-stuck
+  // `bot-gated-skip` sibling exists. This is not a #1806-specific carve-out
+  // -- #1806 only widens which instances CAN reach `eligibleInstances` in
+  // the first place; rule 1's own boundary (a human must look at a
+  // budget-exhausted eligible instance rather than have the tool silently
+  // route around it via a different instance's rerun) applies uniformly
+  // once an instance is there, regardless of how it got classified
+  // `rerun-eligible`. See the "budget-exhausted recovered instance" test.
+  const anyEligibleHeld = eligibleInstances.some(
+    (instance) =>
+      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',
+  );
+  const everyReRunningEligibleIsBotTriggered = reRunningEligibleInstances.every(
+    (instance) => isBotTriggered(instance, classifyOptions),
+  );
+  const allowRecoveryRefresh =
+    !anyEligibleHeld && everyReRunningEligibleIsBotTriggered;
+  const refreshDecisions = allowRecoveryRefresh
+    ? new Map(
+        recoveryRefreshCandidates.map((instance) => [
+          instance.checkRunId,
+          resolveInstanceRerunDecision(instance, rerunPolicy),
+        ]),
+      )
+    : new Map();
+  const recoveryRefreshPlan = allowRecoveryRefresh
+    ? buildOrderedPlan(
+        recoveryRefreshCandidates.filter(
+          (instance) =>
+            refreshDecisions.get(instance.checkRunId)?.action === 'rerun',
+        ),
+        owner,
+        repo,
+      )
+    : [];
+  const heldEligibleCount = [...eligibleDecisions.values()].filter(
+    (decision) => decision.action === 'hold',
+  ).length;
+  const heldRefreshCount = [...refreshDecisions.values()].filter(
+    (decision) => decision.action === 'hold',
+  ).length;
+  const totalHeldCount = heldEligibleCount + heldRefreshCount;
+  // Per-instance reasons a non-"hold" policy still withheld an instance:
+  // a confirmed-exhausted budget ('rerun-budget-exhausted') and one that
+  // could not be confirmed at all ('run-attempt-unknown', CodeRabbit
+  // review, #1434) are reported distinctly below rather than conflated,
+  // so the notice never claims a budget is "already used" when it was
+  // actually just never confirmed.
+  const allHeldReasons = new Set(
+    [...eligibleDecisions.values(), ...refreshDecisions.values()]
+      .filter((decision) => decision.action === 'hold')
+      .map((decision) => decision.reason),
+  );
+  const rerunPolicyHoldNotice =
+    totalHeldCount === 0
+      ? ''
+      : rerunPolicy === 'hold'
+        ? `ciWait.rerunPolicy is "hold": ${describeHeldCounts(heldEligibleCount, heldRefreshCount)} found, but auto-rerun is disallowed by this repository's policy -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics).`
+        : `ciWait.rerunPolicy is "rerun-once" and ${describeRerunOnceHoldReasons(allHeldReasons)}: ${describeHeldCounts(heldEligibleCount, heldRefreshCount)} withheld from the plan -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics).`;
+  const budgetHeldCheckRunIds = new Set(
+    [...eligibleDecisions.entries(), ...refreshDecisions.entries()]
+      .filter(
+        ([, decision]) =>
+          decision.reason === 'rerun-budget-exhausted' ||
+          decision.reason === 'run-attempt-unknown',
+      )
+      .map(([checkRunId]) => checkRunId),
+  );
+  const finalInstances = instances.map((instance) => ({
+    ...instance,
+    rerunBudgetHeld: budgetHeldCheckRunIds.has(instance.checkRunId),
+  }));
+  const counts = {
+    pass: 0,
+    pending: 0,
+    botGatedSkip: 0,
+    unresolved: 0,
+    awaitingFreshReview: 0,
+    rerunEligible: 0,
+    rerunBudgetHeld: budgetHeldCheckRunIds.size,
+    total: instances.length,
+  };
+  for (const instance of instances) {
+    if (instance.classification === 'pass') counts.pass += 1;
+    else if (instance.classification === 'pending') counts.pending += 1;
+    else if (instance.classification === 'bot-gated-skip')
+      counts.botGatedSkip += 1;
+    else if (instance.classification === 'unresolved') counts.unresolved += 1;
+    else if (instance.classification === 'awaiting-fresh-review')
+      counts.awaitingFreshReview += 1;
+    else counts.rerunEligible += 1;
+  }
+  return {
+    protocolVersion: '1',
+    prNumber: Number(input.prNumber),
+    prHeadSha,
+    checkName,
+    now,
+    instances: finalInstances,
+    counts,
+    plan,
+    planCaveat: PLAN_CAVEAT,
+    recoveryRefreshPlan,
+    recoveryRefreshCaveat:
+      recoveryRefreshPlan.length > 0 ? RECOVERY_REFRESH_CAVEAT : '',
+    rerunPolicy,
+    rerunPolicyHoldNotice,
+  };
+}
+/**
+ * Resolve whether `instance` may still be rerun under `rerunPolicy`, given
+ * its own `runAttempt`. Reuses {@link resolveCiRerunDecision}
+ * (ci-wait-policy.mts) -- the same rerun-once-budget decision
+ * `idd-ci.instructions.md` §Rerun mechanics documents CI-wait itself
+ * applying -- rather than re-deriving the budget rule here, so this
+ * helper's recovery recommendations can never drift out of sync with the
+ * policy CI-wait already enforces.
+ *
+ * Fails closed when `runAttempt` is `null` under a non-`"hold"` policy
+ * (an unresolved or not-yet-enriched instance): this previously defaulted
+ * the missing value to `1` (treating it as "never rerun", the single
+ * MOST PERMISSIVE interpretation) and silently derived `rerunCount: 0`
+ * from that guess, rather than withholding an instance whose budget this
+ * helper cannot actually confirm (CodeRabbit review, #1434). Reported
+ * with its own distinct `reason: 'run-attempt-unknown'` (not conflated
+ * with a confirmed-exhausted budget's `'rerun-budget-exhausted'`), so the
+ * operator-facing notice can still tell "known, already used" apart from
+ * "unconfirmed" -- but both withhold the instance the same way. Under a
+ * `"hold"` policy this distinction is moot (every instance is withheld
+ * regardless of its own attempt count, and `resolveCiRerunDecision`
+ * already reports the correct shared `'policy-hold'` reason for it), so
+ * the null-`runAttempt` short-circuit only applies to the non-`"hold"`
+ * path where `rerunCount` would otherwise actually be read.
+ */
+function resolveInstanceRerunDecision(instance, rerunPolicy) {
+  if (instance.runAttempt === null && rerunPolicy !== 'hold') {
+    return {
+      action: 'hold',
+      reason: 'run-attempt-unknown',
+      rerunPolicy,
+      rerunCount: 0,
+    };
+  }
+  const rerunCount = Math.max(0, (instance.runAttempt ?? 0) - 1);
+  return resolveCiRerunDecision({ rerunPolicy, rerunCount });
+}
+/** Render "N rerun-eligible instance(s)" and/or "N recovery-refresh
+ * candidate(s)" for {@link RerunAdvisoryConvergencePlan.rerunPolicyHoldNotice},
+ * omitting either half when its own count is zero. */
+function describeHeldCounts(eligibleCount, refreshCount) {
+  const parts = [];
+  if (eligibleCount > 0)
+    parts.push(`${eligibleCount} rerun-eligible instance(s)`);
+  if (refreshCount > 0) {
+    parts.push(`${refreshCount} recovery-refresh candidate(s)`);
+  }
+  return parts.join(' and ');
+}
+/**
+ * Render the reason clause for a `"rerun-once"` policy's
+ * {@link RerunAdvisoryConvergencePlan.rerunPolicyHoldNotice}, distinguishing
+ * a confirmed-exhausted budget from one that could not be confirmed (CodeRabbit
+ * review, #1434) -- joined when a single run produces both reasons across
+ * different instances, so the notice never overstates certainty ("the
+ * budget is already used") for an instance that was actually withheld
+ * because its `run_attempt` could not be confirmed at all.
+ */
+function describeRerunOnceHoldReasons(reasons) {
+  const parts = [];
+  if (reasons.has('rerun-budget-exhausted')) {
+    parts.push('the one-rerun budget is already used (run_attempt > 1)');
+  }
+  if (reasons.has('run-attempt-unknown')) {
+    parts.push("one or more instances' own run_attempt could not be confirmed");
+  }
+  // Every "hold" decision under a non-"hold" policy carries one of the
+  // two reasons above (resolveCiRerunDecision / resolveInstanceRerunDecision
+  // have no third hold reason on that path) -- this fallback is
+  // defensive, not a reachable case today.
+  return parts.length > 0
+    ? parts.join(', and ')
+    : 'the one-rerun budget is already used (run_attempt > 1)';
+}
+/**
+ * Select already-passing, non-bot, pull_request-family instances eligible
+ * to serve as the recovery-refresh target when no genuine rerun-eligible
+ * instance exists but a bot-gated-skip instance does -- see
+ * {@link RerunAdvisoryConvergencePlan.recoveryRefreshPlan}. Reuses the
+ * exact same bot-detection logic ({@link isBotTriggered}) classification
+ * already applies, so a "passing" instance is never suggested for rerun
+ * if it was itself bot-triggered (rerunning it would not help either).
+ */
+function selectRecoveryRefreshCandidates(instances, options) {
+  const hasBotGatedSkip = instances.some(
+    (instance) => instance.classification === 'bot-gated-skip',
+  );
+  if (!hasBotGatedSkip) return [];
+  return instances.filter((instance) => {
+    if (instance.classification !== 'pass') return false;
+    if (instance.runId === null || instance.runLookupFailed) return false;
+    const runEvent = String(instance.runEvent ?? '')
+      .trim()
+      .toLowerCase();
+    if (!PULL_REQUEST_FAMILY_EVENTS.has(runEvent)) return false;
+    return !isBotTriggered(instance, options);
+  });
+}
+function normalizeLoginList(logins) {
+  return logins
+    .map((login) =>
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    )
+    .filter(Boolean);
+}
+/**
+ * Classify one check-run instance. Evaluated as a strict, ordered decision
+ * list -- see the module header for the rationale behind each state and
+ * why `pending`/`unresolved` exist beyond the issue's three named buckets.
+ */
+function classifyInstance(instance, options) {
+  const status = String(instance.status ?? '')
+    .trim()
+    .toLowerCase();
+  const conclusion = instance.conclusion
+    ? String(instance.conclusion).trim().toLowerCase()
+    : null;
+  // 1. Pass-equivalent -- no action needed.
+  if (conclusion && PASS_CONCLUSIONS.has(conclusion)) {
+    return {
+      ...instance,
+      classification: 'pass',
+      reason: `conclusion "${conclusion}" is pass-equivalent`,
+    };
+  }
+  // 2. Still running -- rerunning a live run cancels it, never helps.
+  if (!conclusion && PENDING_STATUSES.has(status)) {
+    return {
+      ...instance,
+      classification: 'pending',
+      reason: `status "${status}" has not concluded yet; rerunning a live run would cancel it instead of recovering it`,
+    };
+  }
+  // 3. Bot-gated: `action_required` conclusion ONLY (#1745 narrowed this
+  // from the prior "action_required OR bot-triggered actor" rule -- #1424
+  // established just the action_required case; a bot-triggered instance
+  // with any other conclusion, e.g. CANCELLED, reruns and completes
+  // normally, per #1745's direct experiment on PR #1741). `botTriggered` is
+  // still computed here (and reused at step 7 below) purely to annotate the
+  // reason text and to feed `selectRecoveryRefreshCandidates`, which still
+  // must exclude a bot-triggered PASS instance from the refresh
+  // suggestion -- it no longer decides this instance's classification by
+  // itself.
+  const botTriggered = isBotTriggered(instance, options);
+  const actorDescription =
+    instance.triggeringActorLogin ?? instance.actorLogin ?? 'unknown actor';
+  if (conclusion === 'action_required') {
+    const reason = botTriggered
+      ? `conclusion is "action_required" and the triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`
+      : 'conclusion is "action_required"; rerunning without a non-bot trigger or maintainer approval re-enters action_required (#1424)';
+    return { ...instance, classification: 'bot-gated-skip', reason };
+  }
+  // 4. Fail closed on an unresolvable run identity -- never guess.
+  if (instance.runId === null) {
+    return {
+      ...instance,
+      classification: 'unresolved',
+      reason:
+        "could not parse a workflow run id from this check-run's URL; inspect manually",
+    };
+  }
+  if (instance.runLookupFailed) {
+    return {
+      ...instance,
+      classification: 'unresolved',
+      reason:
+        'the underlying workflow run could not be fetched (network/permission/transient failure); inspect manually',
+    };
+  }
+  // 5. Fail closed on a completed run with no conclusion (malformed/
+  // unexpected payload) -- never assume it is safe to rerun.
+  if (!conclusion) {
+    return {
+      ...instance,
+      classification: 'unresolved',
+      reason: `status "${status}" reported no conclusion; inspect manually`,
+    };
+  }
+  // 6. Fail closed on a non-pull_request-family trigger event (most
+  // commonly workflow_dispatch): rerunning it is not documented as a
+  // reliable way to refresh the PR's required-check rollup, so never
+  // recommend it -- see idd-ci.instructions.md Rerun mechanics.
+  const runEvent = String(instance.runEvent ?? '')
+    .trim()
+    .toLowerCase();
+  if (!PULL_REQUEST_FAMILY_EVENTS.has(runEvent)) {
+    return {
+      ...instance,
+      classification: 'unresolved',
+      reason: runEvent
+        ? `triggering event "${runEvent}" is not pull_request-family (pull_request / pull_request_review / pull_request_review_comment); rerunning it is not a reliable way to refresh the PR's required-check rollup -- inspect manually`
+        : 'triggering event is unknown; inspect manually rather than assuming it is safe to rerun',
+    };
+  }
+  // 7. Uncovered-HEAD hold (#1775): the instance's own
+  // advisory-convergence JSON verdict (from the workflow job log) says
+  // the latest Copilot review does not cover the current HEAD. Rerunning
+  // cannot change that -- only a fresh review can -- so never place this
+  // in the plan and never spend the rerun-once budget on it. Only fires
+  // when `verdictReasons` was actually consulted and matched; a missing
+  // / unparsed log leaves classification unchanged (no invented hold).
+  //
+  // #1806 live-coverage recovery: the job log above is an IMMUTABLE
+  // snapshot from when THAT run executed, so it can go stale once a
+  // fresh review actually lands after the run failed (observed on PR
+  // #1854). `options.headCoverageSatisfied` is a LIVE, per-PR signal
+  // (see `RerunPlanOptions.headCoverageSatisfied`) that lets this hold
+  // recover instead of staying stuck forever. Only `=== true` recovers;
+  // `false`, `null`, and `undefined` all keep the historical hold exactly
+  // as before #1806 -- fail-closed, so an unreadable or not-yet-covered
+  // live signal never invents a rerun.
+  if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
+    const matched =
+      instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
+      UNCOVERED_HEAD_REASON_MARKER;
+    if (options.headCoverageSatisfied !== true) {
+      return {
+        ...instance,
+        classification: 'awaiting-fresh-review',
+        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+      };
+    }
+    return {
+      ...instance,
+      classification: 'rerun-eligible',
+      reason: `advisory-convergence verdict historically reported "${matched}", but a live check now confirms the current HEAD is covered by a fresh review; the historical hold is stale -- safe to rerun (live-coverage recovery, #1806)`,
+    };
+  }
+  // 8. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
+  // A bot-triggered actor does not withhold this instance by itself
+  // (#1745) -- only a genuinely `action_required` conclusion does, handled
+  // in step 3 above -- so the reason notes bot-triggering when present
+  // instead of asserting "non-bot" for an instance that may well be one.
+  const botNote = botTriggered
+    ? ` (triggering actor ${actorDescription} is a bot, but conclusion "${conclusion}" is not action_required-gated)`
+    : '';
+  return {
+    ...instance,
+    classification: 'rerun-eligible',
+    reason: `conclusion "${conclusion}" is non-passing and resolved (event "${runEvent}")${botNote}; safe to rerun`,
+  };
+}
+/**
+ * `true` when `reason` is an advisory-convergence Clause 1
+ * uncovered-HEAD reason (see {@link UNCOVERED_HEAD_REASON_MARKER}).
+ */
+export function isUncoveredHeadVerdictReason(reason) {
+  return String(reason ?? '')
+    .toLowerCase()
+    .includes(UNCOVERED_HEAD_REASON_MARKER.toLowerCase());
+}
+/**
+ * `true` when a consulted `reasons` list contains an uncovered-HEAD
+ * reason. A `null` / `undefined` list means "not consulted" and never
+ * matches -- so a missing log cannot invent an `awaiting-fresh-review`
+ * hold (#1775).
+ */
+export function hasUncoveredHeadVerdictReason(reasons) {
+  if (!reasons) return false;
+  return reasons.some((reason) => isUncoveredHeadVerdictReason(reason));
+}
+/**
+ * Extract the advisory-convergence JSON verdict's `reasons` array from a
+ * workflow job log (`gh run view --log` / Actions job-logs API output).
+ * Returns `null` when no well-formed verdict JSON is found, so callers
+ * can leave `verdictReasons` unset rather than inventing an empty list
+ * that would look like "fetched, no reasons". Pure and unit-testable;
+ * production collection feeds it the log text for each non-pass run.
+ *
+ * The log lines are typically prefixed with a job/step/timestamp column
+ * (and may carry ANSI color codes); both are stripped before brace-
+ * matching so the same parser works on raw job logs and on
+ * `gh run view --log` output.
+ */
+export function extractAdvisoryVerdictReasonsFromLog(logText) {
+  // Strip ANSI CSI color sequences without a control-character regex
+  // (Biome disallows `\u001b` in regex literals). ESC is code 27.
+  const esc = String.fromCharCode(27);
+  const text = String(logText ?? '')
+    .split(esc)
+    .map((chunk, index) =>
+      index === 0 ? chunk : chunk.replace(/^\[[0-9;]*m/, ''),
+    )
+    .join('');
+  if (!text) return null;
+  // Rebuild candidate JSON payloads by walking braces across lines after
+  // stripping the `gh run view --log` prefix (everything through the
+  // first `Z ` timestamp marker on each line, when present). Prefer the
+  // LAST well-formed advisory-convergence verdict in the log -- a single
+  // job can echo intermediate output, and the final `--assert` document
+  // is what actually determined the check-run conclusion.
+  const payloadChunks = [];
+  let depth = 0;
+  let buf = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const timestampMatch = rawLine.match(/Z (.*)$/);
+    const line =
+      timestampMatch && timestampMatch[1] !== undefined
+        ? timestampMatch[1]
+        : rawLine;
+    for (const ch of line) {
+      if (ch === '{') {
+        if (depth === 0) buf = ['{'];
+        else buf.push(ch);
+        depth += 1;
+      } else if (ch === '}') {
+        if (depth === 0) continue;
+        buf.push(ch);
+        depth -= 1;
+        if (depth === 0) {
+          payloadChunks.push(buf.join(''));
+          buf = [];
+        }
+      } else if (depth > 0) {
+        buf.push(ch);
+      }
+    }
+  }
+  let lastReasons = null;
+  for (const chunk of payloadChunks) {
+    if (!chunk.includes('"reasons"') || !chunk.includes('"ready"')) continue;
+    try {
+      const parsed = JSON.parse(chunk);
+      if (!Array.isArray(parsed.reasons) || typeof parsed.ready !== 'boolean') {
+        continue;
+      }
+      const reasons = parsed.reasons
+        .filter((entry) => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+      lastReasons = reasons;
+    } catch {
+      // not valid JSON -- skip
+    }
+  }
+  return lastReasons;
+}
+/**
+ * `true` when the check-run instance's underlying workflow run was
+ * triggered by a bot actor. `type === "Bot"` (checked on both `actor` and
+ * `triggering_actor`) is the primary signal -- GitHub sets this
+ * consistently for App/bot accounts regardless of login spelling. A
+ * configured-login match (`isCopilotReviewerLogin` for the primary
+ * advisory bot, or membership in the resolved `advisoryBotLogins` list)
+ * is a defensive fallback for a payload that omits `type`.
+ *
+ * The `advisoryBotLogins` fallback, and the `primaryBotLogin` comparison
+ * below it, both compare via {@link advisoryBotIdentityToken} (the same
+ * normalization the shared advisory-notice matcher already uses) rather
+ * than a raw, un-normalized comparison: a repository can configure a bare
+ * login (`my-bot`) while the Actions payload reports the GitHub-appended
+ * `[bot]`-suffixed form (`my-bot[bot]`), or vice versa. An un-normalized
+ * comparison would miss that match and let a bot-triggered run fall
+ * through as rerun-eligible (#1434 review, Codex P2).
+ *
+ * `isCopilotReviewerLogin` itself only normalizes this way for the
+ * *default* Copilot login (an exact-set match against `copilot`/
+ * `copilot-pull-request-reviewer`/`copilot-pull-request-reviewer[bot]` --
+ * #1686 narrowed this from a `copilot-pull-request-reviewer*` prefix
+ * match); once a repository configures a non-default
+ * `primaryBotLogin`, it falls back to an exact `normalized === configured`
+ * comparison with no `[bot]`-suffix handling -- the same gap the
+ * `advisoryBotLogins` fallback already closed for its own set, just on
+ * the separate `primaryBotLogin` path (#1434 review, Codex P2, second
+ * occurrence). Re-normalizing `primaryBotLogin` here (rather than
+ * changing the shared `isCopilotReviewerLogin` itself, which many other
+ * callers rely on for its existing exact-match contract) closes it
+ * locally without widening that shared function's behavior.
+ */
+function isBotTriggered(instance, options) {
+  if (instance.actorType === 'Bot' || instance.triggeringActorType === 'Bot') {
+    return true;
+  }
+  const actorLogin = String(instance.actorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const triggeringLogin = String(instance.triggeringActorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  if (
+    (actorLogin &&
+      isCopilotReviewerLogin(actorLogin, options.primaryBotLogin)) ||
+    (triggeringLogin &&
+      isCopilotReviewerLogin(triggeringLogin, options.primaryBotLogin))
+  ) {
+    return true;
+  }
+  const actorToken = advisoryBotIdentityToken(actorLogin);
+  const triggeringToken = advisoryBotIdentityToken(triggeringLogin);
+  const primaryBotToken = advisoryBotIdentityToken(options.primaryBotLogin);
+  if (
+    primaryBotToken &&
+    ((Boolean(actorToken) && actorToken === primaryBotToken) ||
+      (Boolean(triggeringToken) && triggeringToken === primaryBotToken))
+  ) {
+    return true;
+  }
+  const configuredBotTokens = new Set(
+    options.advisoryBotLogins.map((login) => advisoryBotIdentityToken(login)),
+  );
+  return (
+    (Boolean(actorToken) && configuredBotTokens.has(actorToken)) ||
+    (Boolean(triggeringToken) && configuredBotTokens.has(triggeringToken))
+  );
+}
+/**
+ * Build the ordered, deduplicated-by-run-id rerun plan from an already-
+ * filtered candidate list (the caller decides which classification(s)
+ * qualify -- `rerun-eligible` for the normal plan,
+ * {@link selectRecoveryRefreshCandidates}'s output for the recovery-refresh
+ * plan). A `gh run rerun <id>` targets a workflow run, not a check-run
+ * entry, so two check-run instances that resolved to the same run id
+ * collapse into a single plan entry. Ordered by earliest known `startedAt`
+ * (empty/unknown sorts first, as the more cautious default), then numeric
+ * run id, so the output is deterministic across runs with the same input.
+ *
+ * `owner`/`repo` are embedded as `-R owner/repo` on each generated command
+ * (when both are non-empty) so the plan is safe to run from outside the
+ * checkout this helper itself was invoked from -- `gh run rerun <id>` alone
+ * resolves its target repository from the caller's cwd/`GH_REPO`, not from
+ * whatever `--owner`/`--repo` this helper was given.
+ */
+function buildOrderedPlan(candidates, owner, repo) {
+  const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
+  const byRunId = new Map();
+  for (const instance of candidates) {
+    // Both candidate sources already guarantee a resolved, non-null runId
+    // (rerun-eligible via classifyInstance step 4; recovery-refresh via
+    // selectRecoveryRefreshCandidates's own filter), but guard defensively
+    // rather than trusting that invariant silently.
+    const runId = String(instance.runId ?? '').trim();
+    if (!runId) continue;
+    const list = byRunId.get(runId) ?? [];
+    list.push(instance);
+    byRunId.set(runId, list);
+  }
+  const entries = [...byRunId.entries()].map(([runId, items]) => {
+    const startedAts = items
+      .map((item) => item.startedAt)
+      .filter((value) => Boolean(value))
+      .sort();
+    return {
+      runId,
+      command: `gh run rerun ${runId}${repoFlag}`,
+      // Sorted (not insertion order, which merely reflects the source
+      // API/candidate iteration order and is not guaranteed stable) so
+      // the emitted JSON is deterministic for the same logical plan
+      // (#1434 review, Copilot).
+      checkRunIds: [...new Set(items.map((item) => item.checkRunId))].sort(),
+      startedAt: startedAts[0] ?? '',
+    };
+  });
+  entries.sort((left, right) => {
+    if (left.startedAt !== right.startedAt) {
+      return left.startedAt < right.startedAt ? -1 : 1;
+    }
+    const leftId = Number(left.runId);
+    const rightId = Number(right.runId);
+    if (
+      Number.isFinite(leftId) &&
+      Number.isFinite(rightId) &&
+      leftId !== rightId
+    ) {
+      return leftId - rightId;
+    }
+    return left.runId < right.runId ? -1 : left.runId > right.runId ? 1 : 0;
+  });
+  return entries;
+}
+/**
+ * Parse a workflow run id out of a GitHub Actions check-run `html_url` (or
+ * `details_url`) such as
+ * `https://github.com/{owner}/{repo}/actions/runs/<run-id>/job/<job-id>` --
+ * the same URL shape `idd-ci.instructions.md`'s Rerun mechanics already
+ * document extracting a run id from. Returns `null` (fails closed) rather
+ * than guessing when the URL does not match.
+ *
+ * The run id may be followed by `/` (a job segment), `?` (GitHub appends
+ * query strings such as `?check_suite_focus=true` to some check-run
+ * permalinks), or end-of-string -- a run id immediately followed by `?`
+ * was previously misclassified `unresolved` (#1434 review, Copilot).
+ */
+export function parseRunIdFromUrl(url) {
+  const match = /\/actions\/runs\/(\d+)(?:[/?]|$)/.exec(String(url ?? ''));
+  return match ? match[1] : null;
+}
+/** A conservative GitHub owner/repo identifier character class --
+ * alphanumeric, hyphen, underscore, period. Not GitHub's own exact
+ * validation rule (real usernames additionally forbid a leading/trailing
+ * hyphen and consecutive hyphens); this is a defensive CLI-input guard,
+ * not the authoritative source of what GitHub itself allows, so erring
+ * slightly permissive-of-valid-names is fine -- the goal is rejecting
+ * whitespace and shell metacharacters, not exactly replicating GitHub's
+ * own registration rules. */
+const GITHUB_IDENTIFIER_PATTERN = /^[A-Za-z0-9_.-]+$/;
+/**
+ * Rewrite a `--pr VALUE` pair into the single token `--pr=VALUE` whenever
+ * `VALUE` starts with a single dash (not `--`) -- `node:util`'s own
+ * `parseArgs` (`strict: true`) throws `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`
+ * ("... argument is ambiguous") for a bare `--pr -5`, since a
+ * single-dash-prefixed value could plausibly be another short option
+ * instead. Left uncaught, this crashed the CLI with a raw, uncaught Node
+ * stack trace instead of this file's own documented `--pr` contract ("an
+ * invalid --pr resolves to null (fails closed at the caller)") --
+ * verified empirically (`--pr -5` threw before this fix; a negative PR
+ * number is never valid, but the failure mode should be the same clean
+ * `prNumber: null` every other malformed `--pr` value already gets, not
+ * an uncaught crash) (self-discovered while evaluating #1446's shared
+ * `cli-args.mts` wrapper, which solves this same class of gap generically
+ * -- adopting it here is out of scope for #1431; this is the narrow,
+ * `--pr`-only equivalent). Only `--pr` needs this: none of this file's
+ * other flags (`--owner`, `--repo`, `--now`) can realistically take a
+ * dash-prefixed value, and `--help`/`-h` is boolean (no value to
+ * disambiguate).
+ */
+function disambiguateSingleDashPrValue(argv) {
+  const rewritten = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+    const isAmbiguousValue =
+      typeof next === 'string' &&
+      next.startsWith('-') &&
+      !next.startsWith('--');
+    if (token === '--pr' && isAmbiguousValue) {
+      rewritten.push(`--pr=${next}`);
+      index += 1;
+      continue;
+    }
+    rewritten.push(token);
+  }
+  return rewritten;
+}
+/**
+ * Mechanical CLI-argument parsing is delegated to `node:util`'s own
+ * stable (since Node 20; this repo's engines floor is `^22.22.2 || >=24`)
+ * `parseArgs`, per a maintainer's review suggestion on PR #1434: it
+ * already rejects a missing value, a value that looks like another
+ * option (long `--foo` or short `-h` alike -- the hand-rolled
+ * `requireFlagValue` this replaced only checked for `--`, so `--owner -h`
+ * silently consumed `-h` as the owner instead of erroring), and an
+ * unknown option, each with Node's own stable `ERR_PARSE_ARGS_*` error
+ * codes. `allowPositionals: false` closes one more gap `strict: true`
+ * alone does not: `strict` governs unknown *options*, not leftover
+ * positional (non-option) tokens, so an invocation like
+ * `--pr 1431 extra` would otherwise silently accept `extra` instead of
+ * failing fast -- risky for a recovery/rerun helper where a typo should
+ * error, not run against unintended, silently-ignored input (#1434
+ * review, Copilot). This function's own job narrows to the
+ * domain-specific validation `parseArgs` cannot express declaratively:
+ * the `--pr` value must be all digits (not just numeric-prefixed), and
+ * `--owner`/`--repo` must be given together or not at all.
+ */
+export function parseArgs(argv) {
+  const { values } = nodeParseArgs({
+    args: disambiguateSingleDashPrValue(argv),
+    options: {
+      pr: { type: 'string' },
+      owner: { type: 'string' },
+      repo: { type: 'string' },
+      now: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+      apply: { type: 'boolean' },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  if (values.help) {
+    return {
+      prNumber: null,
+      owner: '',
+      repo: '',
+      now: '',
+      help: true,
+      apply: false,
+    };
+  }
+  const owner = String(values.owner ?? '').trim();
+  const repo = String(values.repo ?? '').trim();
+  // A caller inspecting a different repository must fully specify it --
+  // mixing a user-supplied owner with a `gh repo view`-derived repo (or
+  // vice versa) would query a mismatched, unintended repository
+  // (#1434 review, Copilot).
+  if (Boolean(owner) !== Boolean(repo)) {
+    throw new Error('provide both --owner and --repo, or neither');
+  }
+  // A conservative GitHub-identifier character class, rejected otherwise:
+  // --owner/--repo are only trimmed above, never validated, so whitespace
+  // or a shell metacharacter would still build a syntactically-valid
+  // `-R owner/repo` string here, but the generated `gh run rerun <id> -R
+  // owner/repo` recovery commands are meant to be copy-pasted directly
+  // by an operator -- an unvalidated value could make that copy-paste
+  // unsafe (Copilot review, #1434).
+  if (owner && !GITHUB_IDENTIFIER_PATTERN.test(owner)) {
+    throw new Error(
+      '--owner must contain only letters, digits, hyphens, underscores, or periods',
+    );
+  }
+  if (repo && !GITHUB_IDENTIFIER_PATTERN.test(repo)) {
+    throw new Error(
+      '--repo must contain only letters, digits, hyphens, underscores, or periods',
+    );
+  }
+  // Number.parseInt parses only a leading numeric prefix ("1431abc" ->
+  // 1431), which would silently run this recovery helper -- and whatever
+  // `gh run rerun` plan it prints -- against the wrong PR on a typo.
+  // Require the entire value to be digits before parsing (#1434 review,
+  // Codex P2).
+  const rawPr = String(values.pr ?? '').trim();
+  const parsedPr = /^\d+$/.test(rawPr)
+    ? Number.parseInt(rawPr, 10)
+    : Number.NaN;
+  return {
+    prNumber: Number.isInteger(parsedPr) && parsedPr >= 1 ? parsedPr : null,
+    owner,
+    repo,
+    now: String(values.now ?? '').trim(),
+    help: false,
+    apply: Boolean(values.apply),
+  };
+}
+/**
+ * Describe outstanding `pending` / `bot-gated-skip` / `unresolved` /
+ * `awaiting-fresh-review` instance counts, or `''` when none exist.
+ * Extracted from {@link describeNoActionState} so the CLI can surface
+ * these states independently of whether a rerun plan, recovery-refresh
+ * plan, or hold notice ALSO exists for a different instance in the same
+ * run -- previously these were only ever shown when NONE of those three
+ * existed, silently hiding e.g. 2 still-pending instances whenever the
+ * output happened to also have a rerun plan for a different instance
+ * (CodeRabbit review, #1434).
+ */
+export function describeOutstandingStates(plan) {
+  const notes = [];
+  if (plan.counts.pending > 0) {
+    notes.push(
+      `${plan.counts.pending} instance(s) are still running -- wait for them to complete, then re-run this diagnosis`,
+    );
+  }
+  if (plan.counts.botGatedSkip > 0) {
+    notes.push(
+      `${plan.counts.botGatedSkip} instance(s) are bot-gated -- they need a non-bot trigger or maintainer approval (see idd-ci.instructions.md §Rerun mechanics), not a rerun`,
+    );
+  }
+  if (plan.counts.unresolved > 0) {
+    notes.push(
+      `${plan.counts.unresolved} instance(s) could not be resolved -- inspect each instance's "reason" above manually`,
+    );
+  }
+  if (plan.counts.awaitingFreshReview > 0) {
+    notes.push(
+      `${plan.counts.awaitingFreshReview} instance(s) are awaiting a fresh review covering the current HEAD -- wait for Copilot (or the configured primary bot) to re-review rather than rerunning (#1775)`,
+    );
+  }
+  return notes.join('; ');
+}
+/**
+ * Describe the terminal state when there is truly nothing to report:
+ * no rerun plan, no recovery-refresh plan, no hold notice, AND no
+ * outstanding `pending` / `unresolved` / `bot-gated-skip` /
+ * `awaiting-fresh-review` instance (see {@link describeOutstandingStates},
+ * which the CLI now also consults independently of this function).
+ * "Nothing to do" would be accurate only when every instance is `pass`
+ * (or there are no instances at all) -- `pending`, `unresolved`,
+ * `bot-gated-skip`, and `awaiting-fresh-review` all still require an
+ * operator action (waiting, manual inspection, approval, a non-bot
+ * trigger, or a fresh review, per each instance's own `reason`), so
+ * presenting them as no-action risked leaving a genuinely stuck required
+ * check unresolved (#1434 review, Codex P2; #1775).
+ */
+export function describeNoActionState(plan) {
+  if (plan.counts.total === 0) {
+    return `No "${plan.checkName}" check-run instances found for this HEAD; nothing to do.`;
+  }
+  const notes = describeOutstandingStates(plan);
+  if (!notes) {
+    return 'Every instance is pass-equivalent; nothing to do.';
+  }
+  return `No rerun-eligible instance and no recovery-refresh option, but this is not a clean "nothing to do": ${notes}.`;
+}
+/**
+ * Header line introducing the recovery-refresh section of the CLI's stderr
+ * summary. Two independent conditions ({@link
+ * RerunAdvisoryConvergencePlan.plan} and {@link
+ * RerunAdvisoryConvergencePlan.recoveryRefreshPlan}) can both be non-empty
+ * at once since #1745 (a bot-triggered rerun-eligible instance in `plan`,
+ * e.g. a CANCELLED sibling, does not itself supply the non-bot trigger a
+ * separately bot-gated instance still needs from `recoveryRefreshPlan`) --
+ * a hardcoded "No rerun-eligible instances" header became false in that
+ * combined case (#1752, post-merge Codex review on #1749/#1745).
+ * `idd-ci.instructions.md` §Rerun mechanics documents the recovery-refresh
+ * rerun as the recommended FIRST step in that combined scenario (rerun the
+ * already-passing non-bot instance; only rerun the CANCELLED-conclusion
+ * bot-triggered sibling(s) next if that alone does not clear the rollup),
+ * so the combined-case wording says so explicitly rather than relying on
+ * {@link buildRerunPlanTextSections}'s print order alone.
+ */
+export function describeRecoveryRefreshHeader(plan) {
+  return plan.plan.length > 0
+    ? 'A recovery-refresh option is also available -- try this FIRST, per idd-ci.instructions.md §Rerun mechanics; only fall back to the sequential recovery plan below if it does not clear the rollup:'
+    : 'No rerun-eligible instances, but a recovery-refresh option is available:';
+}
+/**
+ * Ordered, fully-rendered stderr sections for the recovery-refresh option
+ * and the sequential rerun-eligible plan, selected and formatted
+ * independently of each other -- the CLI entry point below previously
+ * treated these as mutually exclusive (`if`/`else if`), so whenever both
+ * `plan.recoveryRefreshPlan` and `plan.plan` were non-empty at once (#1745
+ * made that possible), only the first-checked one ever printed, silently
+ * dropping the other's recovery command from the human-readable summary an
+ * operator actually follows even though the JSON document above already
+ * carried both correctly (#1752). Extracted as its own pure, directly
+ * unit-testable function -- mirroring {@link describeOutstandingStates} /
+ * {@link describeNoActionState} -- so SECTION SELECTION (which sections
+ * appear, and in what order), not just wording, has direct test coverage
+ * instead of being reachable only through the `import.meta.main` CLI entry
+ * point.
+ *
+ * Order: the recoveryRefreshPlan section prints first when both are
+ * present, matching `idd-ci.instructions.md` §Rerun mechanics' documented
+ * recovery order for this exact combined scenario (see {@link
+ * describeRecoveryRefreshHeader}). Each returned entry is pre-joined with
+ * internal newlines; the caller wraps each in the same single leading and
+ * trailing blank line every other CLI-summary section already uses.
+ */
+export function buildRerunPlanTextSections(plan) {
+  const sections = [];
+  if (plan.recoveryRefreshPlan.length > 0) {
+    sections.push(
+      [
+        describeRecoveryRefreshHeader(plan),
+        ...plan.recoveryRefreshPlan.map(
+          (entry, index) => `  ${index + 1}. ${entry.command}`,
+        ),
+        '',
+        plan.recoveryRefreshCaveat,
+      ].join('\n'),
+    );
+  }
+  if (plan.plan.length > 0) {
+    sections.push(
+      [
+        'Sequential recovery plan (run one at a time; wait for each to finish before the next):',
+        ...plan.plan.map((entry, index) => `  ${index + 1}. ${entry.command}`),
+        '',
+        plan.planCaveat,
+      ].join('\n'),
+    );
+  }
+  return sections;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--apply] [--help]
+
+By default (without --apply): read-only. Fetches every
+"${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
+(commit check-runs API, paged -- not the recent-runs list, which can page
+the target run out of view), classifies each as pass / pending /
+bot-gated-skip / unresolved / awaiting-fresh-review / rerun-eligible, and
+prints the ordered sequential "gh run rerun <id>" recovery plan for the
+rerun-eligible instances (each command includes "-R <owner>/<repo>" when
+the repository is known, so the plan is safe to run outside this
+checkout). An instance whose own advisory-convergence verdict reports
+that the latest review does not cover the current HEAD is classified
+awaiting-fresh-review (not rerun-eligible) so the diagnosis tells the
+operator to wait for a fresh review rather than burning the rerun-once
+budget (#1775). Never calls "gh run rerun" (or any other mutating
+command) itself.
+
+With --apply: after printing the same diagnostic plan as above, executes
+it -- "gh run rerun"-ing each rerun-eligible (never bot-gated-skip,
+awaiting-fresh-review, or rerun-budget-held) instance one at a time,
+waiting for each to reach a terminal state before starting the next,
+exactly as "planCaveat" already documents. Prefers the recovery-refresh
+plan first when one exists, matching idd-ci.instructions.md's documented
+recovery order. After each rerun, the plan is recomputed from fresh
+evidence and the loop stops early as soon as it resolves (no
+rerun-eligible or recovery-refresh instance remains) instead of running
+the rest of the original plan. A final summary of what ran and whether
+the target state resolved is printed to stderr.
+
+--owner and --repo must be given together (to inspect a PR outside the
+current checkout) or omitted together (to auto-detect the current
+checkout's own repository) -- providing only one is rejected.
+
+Honors the inspected repository's configured ciWait.rerunPolicy: when
+it is "hold", both the rerun plan and the recovery-refresh plan stay
+empty (with a notice explaining why) instead of recommending reruns a
+repository has deliberately opted out of -- --apply then has nothing
+eligible to execute either.
+
+On a normal (non-help) run, stdout carries ONLY the JSON plan document
+(safe to pipe into "jq" or similar); the human-readable recovery-plan
+summary (and, under --apply, the final apply summary) is printed to
+stderr. (This --help text itself is the one exception: it is plain usage
+text on stdout, not JSON.)
+`);
+}
+const defaultDeps = { collect: collectFromGitHub };
+/**
+ * Parse argv, collect evidence (via `deps.collect`, real `gh` calls by
+ * default), and compute the plan. Mirrors `runAdvisoryConvergence`'s DI
+ * pattern (advisory-convergence.mts) so tests can substitute a fake
+ * `collect` instead of shelling out to `gh`.
+ */
+export function runRerunAdvisoryConvergence(argv, deps = defaultDeps) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { plan: null, help: true, args };
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const { input, options } = deps.collect(args);
+  const plan = computeRerunPlan(input, options);
+  return { plan, help: false, args };
+}
+// --- --apply: execute the plan's rerun-eligible instances ---------------
+/** Safety bound on how many `gh run rerun` invocations {@link
+ * applyRerunPlan} will execute in a single call, guarding against an
+ * unexpected oscillating state (a fresh rerun-eligible instance appearing
+ * after every rerun) turning into an unbounded loop. Comfortably above
+ * any real plan observed in dogfooding (5 stale instances was the largest
+ * single-PR case motivating #1766). */
+const MAX_APPLY_RERUNS = 20;
+/**
+ * Execute `initialPlan`'s rerun-eligible instances one at a time, waiting
+ * for each to complete and recomputing the plan before deciding whether
+ * to continue. Pure aside from the injected `deps` (no direct I/O of its
+ * own), mirroring {@link computeRerunPlan}'s own separation of policy
+ * from I/O -- directly unit-testable with a fake `deps`, no network
+ * dependency (#1766 acceptance criteria).
+ *
+ * Prefers `recoveryRefreshPlan`'s next entry over `plan`'s whenever both
+ * are non-empty, matching {@link describeRecoveryRefreshHeader}'s
+ * documented recovery order (try the recovery-refresh rerun first; only
+ * fall back to the sequential plan if it does not clear the rollup).
+ * `bot-gated-skip`, `awaiting-fresh-review`, and rerun-budget-held
+ * instances are never candidates here: neither `plan` nor
+ * `recoveryRefreshPlan` ever contains them (see {@link computeRerunPlan}),
+ * so this loop cannot reach them regardless of `deps.recomputePlan`'s
+ * output (#1775 keeps uncovered-HEAD failures out of both plans).
+ */
+export function applyRerunPlan(initialPlan, deps) {
+  const executed = [];
+  let plan = initialPlan;
+  for (let attempt = 0; attempt < MAX_APPLY_RERUNS; attempt += 1) {
+    const fromRefresh = plan.recoveryRefreshPlan[0];
+    const next = fromRefresh ?? plan.plan[0];
+    if (!next) {
+      return { executed, finalPlan: plan, resolved: true };
+    }
+    const section = fromRefresh ? 'recoveryRefreshPlan' : 'plan';
+    deps.rerunAndWait(next);
+    executed.push({ runId: next.runId, command: next.command, section });
+    plan = deps.recomputePlan();
+  }
+  return { executed, finalPlan: plan, resolved: false };
+}
+/**
+ * Human-readable final summary for `--apply`, printed to stderr after
+ * {@link applyRerunPlan} finishes. Pure and directly unit-testable,
+ * mirroring {@link buildRerunPlanTextSections} / {@link
+ * describeOutstandingStates} rather than being reachable only through the
+ * CLI entry point.
+ */
+export function formatApplySummary(result) {
+  const lines = [`--apply: executed ${result.executed.length} rerun(s).`];
+  for (const [index, entry] of result.executed.entries()) {
+    lines.push(`  ${index + 1}. [${entry.section}] ${entry.command}`);
+  }
+  lines.push(
+    result.resolved
+      ? 'Target state resolved: no rerun-eligible or recovery-refresh instance remains.'
+      : `Target state NOT resolved after ${MAX_APPLY_RERUNS} rerun(s) -- instances still remain. Re-run this helper to continue, or investigate manually.`,
+  );
+  return lines.join('\n');
+}
+/**
+ * Fetch every check-run instance named `checkName` for `ref` via the
+ * commit check-runs API, paginated.
+ *
+ * Deliberately NOT the recent-runs / workflow-runs list
+ * (`GET /repos/{owner}/{repo}/actions/runs?head_sha=...`): that list is
+ * ordered across every workflow in the repository, so a specific run for
+ * a busy SHA can sit many pages deep -- exactly the "paged out of the
+ * recent-runs window" problem the issue calls out. This endpoint is
+ * scoped to the single commit and check name instead, via the documented
+ * `check_name` query parameter.
+ *
+ * `--method GET` is required alongside the `-f check_name=...` field:
+ * `gh api` defaults to POST as soon as any `-f`/`-F` value is present
+ * (its own `--help` text: "The default HTTP request method is GET
+ * normally and POST if any parameters were added"), and this endpoint
+ * only accepts GET -- an unqualified `-f` here silently sends a POST that
+ * 404s, confirmed against the live API while fixing #1431. `--method GET`
+ * is what makes `-f` append to the query string instead.
+ *
+ * `-f filter=all` is required alongside `check_name`: this endpoint's own
+ * `filter` query parameter defaults to `latest`, which -- per GitHub's own
+ * documented behavior, confirmed empirically against this repo's actual
+ * PR history during review -- collapses same-named check runs down to
+ * only the most-recently-completed instance, silently dropping exactly
+ * the older non-passing instance this helper exists to recover. Without
+ * `filter=all`, `instances` can (and did, in the reproduction above) omit
+ * real check-run instances even though `--paginate` runs correctly.
+ *
+ * Not built on {@link ghApiJson}'s own `paginate` option: that option
+ * hardcodes `--jq '.[]'`, which assumes a bare top-level array, but this
+ * endpoint's shape is `{ total_count, check_runs: [...] }` -- so this
+ * function passes `--jq '.check_runs[]'` directly and reuses the same
+ * {@link parsePaginatedGhNdjson} parser `ghApiJson` uses internally.
+ */
+/**
+ * Args for downloading one workflow run's combined job logs as plain
+ * text via `gh run view --log`. Prefer this over
+ * `GET /repos/.../actions/jobs/{id}/logs`, which redirects to a ZIP
+ * archive that `ghText` would decode as garbage UTF-8 and leave
+ * `verdictReasons` null (Copilot review on #1790). Scoped with `-R
+ * owner/repo` so a cross-repository diagnosis still hits the right
+ * run.
+ */
+export function buildRunViewLogArgs(owner, repo, runId) {
+  return ['run', 'view', runId, '-R', `${owner}/${repo}`, '--log'];
+}
+/**
+ * Fetch and parse the advisory-convergence `reasons` array for one
+ * workflow run, or `null` when the log cannot be read / parsed. Uses
+ * {@link buildRunViewLogArgs} (`gh run view --log`) for plain-text logs
+ * and feeds them to {@link extractAdvisoryVerdictReasonsFromLog}.
+ * Failures are swallowed into `null` so a flaky log download cannot
+ * invent an uncovered-HEAD hold or abort the whole diagnosis (#1775).
+ */
+function fetchAdvisoryVerdictReasonsForRun(owner, repo, runId) {
+  try {
+    const logText = ghText(
+      buildRunViewLogArgs(owner, repo, runId),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    return extractAdvisoryVerdictReasonsFromLog(logText);
+  } catch {
+    return null;
+  }
+}
+export function buildCheckRunsForRefArgs(owner, repo, ref, checkName) {
+  const path = `repos/${owner}/${repo}/commits/${ref}/check-runs`;
+  return [
+    'api',
+    path,
+    '--method',
+    'GET',
+    '-f',
+    `check_name=${checkName}`,
+    '-f',
+    'filter=all',
+    '--paginate',
+    '--jq',
+    '.check_runs[]',
+  ];
+}
+/**
+ * Resolve the URL used to extract a check-run's workflow-run id, preferring
+ * `details_url` over `html_url`. For a GitHub-Actions-created check run
+ * (which `idd-advisory-convergence` always is) the two are typically
+ * identical, but the Checks API's own field semantics make `html_url` the
+ * one more likely to diverge to a non-Actions permalink (e.g. a
+ * `/checks/<check_run_id>`-shaped URL) -- `details_url` is documented as
+ * "the full details of the check" and is the one this repo's own
+ * `idd-ci.instructions.md` Rerun mechanics already document extracting a
+ * run id from. Preferring it first costs nothing when the two agree and
+ * avoids a spurious `unresolved` classification when they do not.
+ */
+export function resolveCheckRunUrl(run) {
+  return String(run.details_url ?? run.html_url ?? '');
+}
+function fetchCheckRunsForRef(owner, repo, ref, checkName) {
+  // GH_TEXT_LOOP_TIMEOUT_OPTIONS (stdin ignored, 30s timeout) here too --
+  // sibling gap to the per-run lookup loop's own fix above. Not the FIRST
+  // `gh` call this helper makes overall (collectFromGitHub's own
+  // `repo view` / `pr view` calls run before this one) but the first
+  // potentially long-running one: `--paginate` can mean several HTTP
+  // round-trips within the one `execFileSync` invocation on a busy PR's
+  // check-run history, so a stalled or unexpectedly-interactive `gh`
+  // (rate limiting, network stall, an auth re-prompt) here would hang
+  // this read-only helper before it ever reaches the fail-closed
+  // classification logic below, let alone the per-run loop's own timeout
+  // (#1434 review, Copilot).
+  const raw = ghText(
+    buildCheckRunsForRefArgs(owner, repo, ref, checkName),
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+  return parsePaginatedGhNdjson(raw);
+}
+/**
+ * Fetch and parse `.github/idd/config.json` for `owner/repo` **at `ref`**
+ * via the Contents API. Used unconditionally -- both a same-repo and a
+ * true cross-repository invocation -- rather than a local `readFileSync`
+ * fallback for the same-repo case (`loadIddConfig`, idd-config.mts).
+ *
+ * `ref` must be the repository's TRUSTED default branch (see
+ * {@link resolveDefaultBranch}), never `prHeadSha` and never a local
+ * working-tree read: the `idd-advisory-convergence` workflow this helper
+ * diagnoses deliberately checks out the DEFAULT branch, not the PR head,
+ * for both its verdict script and `.github/idd/config.json` --
+ * `idd-advisory-convergence.yml`'s own header comment documents this
+ * exact "trusted-code checkout" posture, precisely so a PR cannot edit
+ * its own bot-identity config to disguise a bot-triggered run as
+ * non-bot, or loosen `ciWait.rerunPolicy` to grant itself a rerun the
+ * repository's real policy forbids. This helper must resolve the SAME
+ * trusted config the workflow itself used to produce the check-run
+ * verdicts being diagnosed, or its classification and rerun
+ * recommendations can disagree with (and be gamed relative to) what
+ * actually governed those runs (#1434 review, Codex P2, second
+ * occurrence -- reverts this file's own prior "always prHeadSha" fix,
+ * which solved the "unpinned ref" bug but pinned the wrong ref).
+ *
+ * `--method GET` is required alongside the `-f ref=...` field, for the
+ * same reason `buildCheckRunsForRefArgs` above needs it: `gh api` defaults
+ * to POST as soon as any `-f` value is present, and the Contents API only
+ * accepts GET -- an unqualified `-f ref=...` here would 404 on every call
+ * (confirmed empirically), which this function's own catch block would
+ * silently treat as "config genuinely absent, use defaults" instead of
+ * surfacing the real problem.
+ *
+ * Returns `null` -- falls back to documented defaults, same as a missing
+ * local file -- **only** on a confirmed 404 (`ref` genuinely has no
+ * config committed, the same "absent" state `loadIddConfig` treats as
+ * "use defaults" locally). Any other failure -- a permission error, a
+ * transient Contents API failure, or malformed content -- means this
+ * helper cannot confirm whether `ref` configures a non-default bot
+ * identity, so silently substituting defaults could misclassify a
+ * bot-triggered run there as rerun-eligible. Per this repo's own
+ * fail-closed default (`idd-overview-core.instructions.md`), that
+ * ambiguity throws instead of guessing, rejecting the diagnosis outright
+ * rather than proceeding on unconfirmed bot identity (#1434 review, Codex
+ * P2).
+ */
+export function buildIddConfigContentsArgs(owner, repo, ref) {
+  return [
+    'api',
+    `repos/${owner}/${repo}/contents/.github/idd/config.json`,
+    '--method',
+    'GET',
+    '-f',
+    `ref=${ref}`,
+    '--jq',
+    '.content',
+  ];
+}
+function loadRemoteIddConfig(owner, repo, ref) {
+  try {
+    const encoded = ghText(
+      buildIddConfigContentsArgs(owner, repo, ref),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    const decoded = Buffer.from(encoded.replace(/\n/g, ''), 'base64').toString(
+      'utf8',
+    );
+    return JSON.parse(decoded);
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return null;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `cannot confirm .github/idd/config.json for ${owner}/${repo}@${ref}: bot-identity resolution for this diagnosis requires this file to be readable or genuinely absent (404) at this ref, not merely unreadable -- ${message}`,
+    );
+  }
+}
+/**
+ * Resolve `owner/repo`'s default branch via the Repository API -- the
+ * `ref` {@link loadRemoteIddConfig} must read `.github/idd/config.json`
+ * from (see its own doc comment for why). Never hardcoded to `main`:
+ * both this source repository's own `idd-advisory-convergence.yml` and
+ * the `idd-template/` copy distributed to adopters document their
+ * checkout's `ref: main` as standing in for "your own default branch
+ * name if it differs" -- a portable, reusable helper must resolve this
+ * dynamically per target repository rather than assume the source
+ * repository's own convention. No `-f` value is present, so `gh api`
+ * defaults to GET here without needing `--method GET` (confirmed
+ * empirically; the POST-default only triggers once a `-f`/`-F` value is
+ * added, unlike the other `gh api` calls in this file).
+ */
+function resolveDefaultBranch(owner, repo) {
+  return ghText(
+    ['api', `repos/${owner}/${repo}`, '--jq', '.default_branch'],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+}
+/**
+ * Discard whichever of `ciWait`, `advisoryWait`, and `advisoryBotLogins`
+ * fails schema validation against {@link POLICY_SCHEMA}, treating an
+ * invalid section as absent -- the same fail-closed contract
+ * `readCiWaitPolicy` (ci-wait-policy.mts) and `readAdvisoryPrimaryBotLogin`
+ * (advisory-wait-policy.mts) already give their own local-disk config
+ * reads, applied here to the already-fetched remote config object instead
+ * (those two functions read from a local file path; this helper's config
+ * comes from the Contents API, so their own validation cannot be reused
+ * directly -- only the shared {@link validateConfigSection} check they
+ * both build on can).
+ *
+ * Without this, a `ciWait` section shaped like `{ rerunPolicy: "hold",
+ * unknownProperty: true }` (an otherwise-valid `rerunPolicy` value
+ * alongside a schema violation elsewhere in the same section --
+ * `additionalProperties: false` in policy.schema.json) would still have
+ * this helper's `normalizeCiWaitPolicy` read `rerunPolicy: "hold"`
+ * directly and suppress every recovery command, even though
+ * `readCiWaitPolicy` discards the WHOLE section on that same violation
+ * and falls back to the documented default `"rerun-once"` -- letting
+ * this helper disagree with, and incorrectly override, the established
+ * policy resolution (#1434 review, Codex P2). `advisoryWait`
+ * (`primaryBotLogin`) and the top-level `advisoryBotLogins` array get the
+ * identical treatment for the same reason, on the bot-identity side.
+ *
+ * Every downstream resolver this helper calls (`resolveAdvisoryPrimaryBotLogin`,
+ * `resolveAdvisoryBotLogins`, `normalizeCiWaitPolicy`) already treats an
+ * ABSENT section as "use the default", so discarding an invalid section
+ * here is enough -- no caller-side change needed beyond running the
+ * fetched config through this function once.
+ */
+export function sanitizeRemoteConfig(config) {
+  if (!config || typeof config !== 'object') {
+    return config;
+  }
+  const sanitized = { ...config };
+  for (const sectionKey of ['ciWait', 'advisoryWait', 'advisoryBotLogins']) {
+    if (validateConfigSection(config, POLICY_SCHEMA, sectionKey).length > 0) {
+      delete sanitized[sectionKey];
+    }
+  }
+  return sanitized;
+}
+/**
+ * Live counterpart to the uncovered-HEAD hold (#1806): re-derives whether
+ * the latest trusted primary-bot review's commit now matches the PR's
+ * current HEAD, reusing `review-clause.mts`'s own review-clause evidence
+ * (`fetchReviewsAndHeadCommit` + `resolveLatestCopilotReviewClause` -- the
+ * SAME evidence `advisory-convergence.mts`'s real `converged` verdict is
+ * built on) instead of a second ad-hoc GraphQL path. Only called from
+ * `collectFromGitHub` when at least one collected instance's own
+ * historical `verdictReasons` already reports an uncovered-HEAD reason --
+ * see that call site -- so a PR with no such instance never pays for this
+ * extra fetch.
+ *
+ * Fails closed to `null` ("evidence unreadable") on ANY error -- never
+ * `false` -- so a transient GraphQL/network failure can never be
+ * indistinguishable from "checked, not covered" if a future caller wants
+ * to tell the two apart; `classifyInstance`'s uncovered-HEAD step treats
+ * both `false` and `null` identically (hold), matching the existing
+ * `verdictReasons`-null pattern elsewhere in this file (a missing/failed
+ * fetch never invents a hold OR a rerun).
+ */
+function resolveLiveHeadCoverage(
+  owner,
+  repo,
+  prNumber,
+  prHeadSha,
+  primaryBotLogin,
+) {
+  try {
+    const { reviews } = fetchReviewsAndHeadCommit(owner, repo, prNumber);
+    return resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin)
+      .matchesHead;
+  } catch {
+    return null;
+  }
+}
+function collectFromGitHub(args) {
+  // A true cross-repository invocation only when the caller explicitly
+  // named both --owner and --repo (parseArgs already rejects naming only
+  // one) -- the common case (neither given) auto-detects the local
+  // checkout's own repo below. Same-repo and cross-repo are no longer
+  // treated differently anywhere in this function: both fetch
+  // .github/idd/config.json from owner/repo's trusted default branch
+  // (resolveDefaultBranch + loadRemoteIddConfig below), and neither reads
+  // the caller's own IDD_ADVISORY_BOT_LOGINS environment variable (the
+  // idd-advisory-convergence workflow's own verdict step never reads it
+  // either -- see the doc comment on `resolveAdvisoryBotLogins`'s call
+  // site below). A same-repo/cross-repo distinction is no longer needed
+  // (#1434 review, Copilot + Codex P2: this comment, and the
+  // now-unused `isCrossRepo` boolean it used to justify, both went stale
+  // in stages as each remaining local-context special-case was removed).
+  // GH_TEXT_LOOP_TIMEOUT_OPTIONS on every `gh` call in this function,
+  // including these first three (owner/repo/PR-head resolution) -- same
+  // hang hazard as fetchCheckRunsForRef and the per-run lookup loop below:
+  // a stalled or unexpectedly-interactive `gh` here would hang this
+  // read-only helper before it resolves even the basic identity of what
+  // it is diagnosing (#1434 review, Copilot).
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repoRef = `${owner}/${repo}`;
+  const prHeadSha = ghText(
+    [
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid',
+      '--jq',
+      '.headRefOid',
+    ],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ).toLowerCase();
+  const rawCheckRuns = fetchCheckRunsForRef(
+    owner,
+    repo,
+    prHeadSha,
+    RERUN_PLAN_CHECK_NAME,
+  );
+  // Resolve each unique run id exactly once (a direct by-ID GET, never a
+  // list scan -- see fetchCheckRunsForRef's doc comment for why lists are
+  // avoided here).
+  const runIdsToResolve = [
+    ...new Set(
+      rawCheckRuns
+        .map((run) => parseRunIdFromUrl(resolveCheckRunUrl(run)))
+        .filter((id) => id !== null),
+    ),
+  ];
+  const runMetaById = new Map();
+  // GH_TEXT_LOOP_TIMEOUT_OPTIONS (stdin ignored, 30s timeout), not a bare
+  // `ghApiJson` call: this loop can run once per distinct run id on a busy
+  // PR, and `ghApiJson` execs `gh` with no stdio override and no timeout,
+  // so a single stalled or unexpectedly-interactive `gh` invocation (rate
+  // limiting, network stall, an auth re-prompt) would hang this read-only
+  // helper indefinitely instead of failing closed into the existing
+  // per-run `catch` below -- the same tight-loop hazard every other
+  // high-volume `gh api` loop in this repo already guards against with
+  // this shared options constant (#1434 review, Copilot).
+  for (const runId of runIdsToResolve) {
+    try {
+      const runPayload = JSON.parse(
+        ghText(
+          ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        ),
+      );
+      runMetaById.set(runId, {
+        event: runPayload.event ? String(runPayload.event) : null,
+        actorLogin: runPayload.actor?.login ?? null,
+        actorType: runPayload.actor?.type ?? null,
+        triggeringActorLogin: runPayload.triggering_actor?.login ?? null,
+        triggeringActorType: runPayload.triggering_actor?.type ?? null,
+        runAttempt:
+          typeof runPayload.run_attempt === 'number' &&
+          Number.isInteger(runPayload.run_attempt)
+            ? runPayload.run_attempt
+            : null,
+      });
+    } catch {
+      runMetaById.set(runId, null);
+    }
+  }
+  // Per-run advisory-convergence verdict reasons (#1775). Only non-pass
+  // terminal check-runs need them -- pass / pending never reach the
+  // uncovered-HEAD classifier, so skipping those saves a log download
+  // per green instance. Failures to fetch or parse leave the map entry
+  // absent (`null` on the instance) rather than inventing an empty list,
+  // so a flaky log API cannot invent an awaiting-fresh-review hold.
+  const runIdsNeedingVerdict = new Set(
+    rawCheckRuns
+      .map((run) => {
+        const conclusion = run.conclusion
+          ? String(run.conclusion).trim().toLowerCase()
+          : '';
+        if (!conclusion || PASS_CONCLUSIONS.has(conclusion)) return null;
+        return parseRunIdFromUrl(resolveCheckRunUrl(run));
+      })
+      .filter((id) => id !== null),
+  );
+  const verdictReasonsByRunId = new Map();
+  for (const runId of runIdsNeedingVerdict) {
+    verdictReasonsByRunId.set(
+      runId,
+      fetchAdvisoryVerdictReasonsForRun(owner, repo, runId),
+    );
+  }
+  const instances = rawCheckRuns.map((run) => {
+    const url = resolveCheckRunUrl(run);
+    const runId = parseRunIdFromUrl(url);
+    const meta = runId !== null ? runMetaById.get(runId) : undefined;
+    return {
+      checkRunId: String(run.id ?? ''),
+      status: String(run.status ?? ''),
+      conclusion: run.conclusion ? String(run.conclusion) : null,
+      htmlUrl: url,
+      startedAt: run.started_at ? String(run.started_at) : null,
+      completedAt: run.completed_at ? String(run.completed_at) : null,
+      runId,
+      runLookupFailed: runId !== null && meta === null,
+      runEvent: meta?.event ?? null,
+      actorLogin: meta?.actorLogin ?? null,
+      actorType: meta?.actorType ?? null,
+      triggeringActorLogin: meta?.triggeringActorLogin ?? null,
+      triggeringActorType: meta?.triggeringActorType ?? null,
+      runAttempt: meta?.runAttempt ?? null,
+      verdictReasons:
+        runId !== null ? (verdictReasonsByRunId.get(runId) ?? null) : null,
+    };
+  });
+  // Fetched from owner/repo's TRUSTED DEFAULT BRANCH, unconditionally --
+  // same-repo and cross-repo alike -- never the PR head and never a local
+  // `loadIddConfig()` read: the idd-advisory-convergence workflow whose
+  // check-runs this helper diagnoses deliberately checks out the default
+  // branch (never the PR head) for both its verdict script and this
+  // config, so this is the config that actually governed the runs being
+  // diagnosed. Reading the PR-head config instead (this file's own prior
+  // fix) would let a PR redefine its own bot identity or loosen
+  // `ciWait.rerunPolicy` to influence its own classification/rerun
+  // recommendation -- see buildIddConfigContentsArgs's doc comment for
+  // the full rationale (#1434 review, Codex P2, second occurrence).
+  const configRef = resolveDefaultBranch(owner, repo);
+  // Schema-validated the same way readCiWaitPolicy / readAdvisoryPrimaryBotLogin
+  // already validate their own local-disk reads, before ANY resolver below
+  // sees it -- see sanitizeRemoteConfig's own doc comment for the full
+  // rationale (#1434 review, Codex P2).
+  const rawConfig = sanitizeRemoteConfig(
+    loadRemoteIddConfig(owner, repo, configRef),
+  );
+  const primaryBotLogin = resolveAdvisoryPrimaryBotLogin(rawConfig);
+  // Never read IDD_ADVISORY_BOT_LOGINS from the caller's own local
+  // environment -- for a same-repo invocation any more than a cross-repo
+  // one. The idd-advisory-convergence workflow's own verdict step
+  // supplies only GH_TOKEN (.github/workflows/idd-advisory-convergence.yml);
+  // it never reads this env var, so it describes only the CALLER's own
+  // machine/session, never the trusted config that actually governed the
+  // runs being diagnosed. `resolveAdvisoryBotLogins` gives an env value
+  // priority over `config`, so passing it through at all -- even scoped
+  // to same-repo only, this file's own prior fix -- could still let a
+  // locally-set env var silently override the target repository's own
+  // configured bot logins and disagree with the workflow's real
+  // behavior: if the env var omits a bot the repo's config lists, and
+  // that bot's run happens to omit `actor.type`, the run would be
+  // misclassified as non-bot and rerun-eligible (#1434 review, Codex P2,
+  // third occurrence -- same family as the earlier PR-head-vs-default-
+  // branch config fix).
+  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+    config: rawConfig,
+  });
+  // Same config source as the bot-identity fields above -- the trusted
+  // default-branch ciWait.rerunPolicy, never a stale local read, the PR's
+  // own (possibly loosened) policy, or (for a cross-repo invocation) the
+  // caller's own repo's policy.
+  const { rerunPolicy } = normalizeCiWaitPolicy(rawConfig?.ciWait);
+  // #1806: only pay for the live-coverage fetch when at least one
+  // collected instance's own historical verdict already reports an
+  // uncovered-HEAD reason -- the ONLY situation `classifyInstance`'s
+  // uncovered-HEAD step consults `headCoverageSatisfied` at all. A PR
+  // with no such instance never triggers the extra GraphQL round trip.
+  const anyHistoricalUncoveredHead = [...verdictReasonsByRunId.values()].some(
+    (reasons) => hasUncoveredHeadVerdictReason(reasons),
+  );
+  const headCoverageSatisfied = anyHistoricalUncoveredHead
+    ? resolveLiveHeadCoverage(
+        owner,
+        repo,
+        Number(args.prNumber),
+        prHeadSha,
+        primaryBotLogin,
+      )
+    : null;
+  return {
+    input: {
+      prNumber: Number(args.prNumber),
+      prHeadSha,
+      checkName: RERUN_PLAN_CHECK_NAME,
+      owner,
+      repo,
+      instances,
+    },
+    options: {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      primaryBotLogin,
+      advisoryBotLogins,
+      rerunPolicy,
+      headCoverageSatisfied,
+    },
+  };
+}
+/** Polling interval for {@link waitForNewAttempt}. A synchronous sleep
+ * (`Atomics.wait` on a throwaway `SharedArrayBuffer`, not a subprocess),
+ * so this file can stay fully synchronous like every other helper here. */
+const APPLY_POLL_INTERVAL_MS = 5_000;
+/** Safety bound: {@link waitForNewAttempt} fails closed (throws) instead
+ * of polling forever when a rerun never reaches a new completed attempt
+ * within this window. A workflow run can legitimately take several
+ * minutes, unlike this file's other quick read-only `gh` calls (all
+ * bounded by {@link GH_TEXT_LOOP_TIMEOUT_OPTIONS}'s 30s). */
+const APPLY_POLL_TIMEOUT_MS = 15 * 60_000;
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+/**
+ * Blocks until `runId` (within `owner`/`repo`) reports BOTH a
+ * `run_attempt` strictly greater than `priorAttempt` AND
+ * `status === 'completed'` -- i.e. the NEW attempt `gh run rerun` just
+ * requested has actually finished, never a stale read of the attempt
+ * that existed before the rerun.
+ *
+ * Deliberately does not shell out to `gh run watch`: that command's very
+ * first status read can race a just-issued `gh run rerun` -- GitHub's
+ * backend has not necessarily flipped the run's `status` off its
+ * PRE-rerun `completed` value by the time `gh run watch` takes its first
+ * look, which would make the caller's wait return instantly against the
+ * OLD attempt instead of the new one, silently defeating the
+ * one-at-a-time, wait-for-completion guarantee `--apply` exists to
+ * provide (the exact failure mode `planCaveat`'s ordering rule protects
+ * against). Comparing `run_attempt` against the value captured
+ * immediately BEFORE `gh run rerun` closes that race by construction: a
+ * stale `completed` read is correctly recognized as still describing the
+ * OLD attempt, and polling continues. Reuses the same `gh api
+ * repos/{owner}/{repo}/actions/runs/{run_id}` shape
+ * (`RawWorkflowRunPayload`) `collectFromGitHub`'s own per-run lookup loop
+ * already parses.
+ */
+function waitForNewAttempt(owner, repo, runId, priorAttempt) {
+  const deadline = Date.now() + APPLY_POLL_TIMEOUT_MS;
+  for (;;) {
+    const payload = JSON.parse(
+      ghText(
+        ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    );
+    const attempt =
+      typeof payload.run_attempt === 'number' ? payload.run_attempt : null;
+    const isNewAttempt = attempt !== null && attempt > priorAttempt;
+    if (isNewAttempt && payload.status === 'completed') {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `timed out waiting for run ${runId} (${owner}/${repo}) to complete a new attempt after rerun`,
+      );
+    }
+    sleepSync(APPLY_POLL_INTERVAL_MS);
+  }
+}
+/** Resolves `{owner, repo}` the same way {@link collectFromGitHub} does
+ * (explicit `--owner`/`--repo` first, else `gh repo view` auto-detection)
+ * -- duplicated as these two lines rather than extracted into a shared
+ * helper `collectFromGitHub` also calls, since that function's own
+ * structure has already been shaped by several rounds of review (#1434)
+ * and splitting it now for this narrow reuse is not worth the regression
+ * risk. */
+function resolveOwnerRepo(args) {
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  return { owner, repo };
+}
+/** Production {@link RerunApplyDeps}: a real `gh run rerun` plus {@link
+ * waitForNewAttempt} polling, and a fresh {@link collectFromGitHub} +
+ * {@link computeRerunPlan} for `recomputePlan`. `rerunAndWait` never
+ * swallows a failure -- unlike this file's many read-only lookups, a
+ * mutating `gh run rerun` (or a poll that never observes a new completed
+ * attempt) genuinely failing is worth surfacing to the operator, not
+ * silently treating as "no change" (matching `ghText`'s own
+ * throw-by-default contract). `owner`/`repo` are resolved once, up
+ * front, and reused for every rerun in the loop -- `recomputePlan` still
+ * re-resolves them itself on each call (via its own fresh
+ * `collectFromGitHub`), which is redundant but harmless (two cheap `gh
+ * repo view` calls) and keeps `recomputePlan` a self-contained unit. */
+function buildProductionApplyDeps(args) {
+  const { owner, repo } = resolveOwnerRepo(args);
+  return {
+    rerunAndWait: (command) => {
+      const priorPayload = JSON.parse(
+        ghText(
+          ['api', `repos/${owner}/${repo}/actions/runs/${command.runId}`],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        ),
+      );
+      // Fail closed BEFORE issuing the rerun (Copilot review, #1772):
+      // waitForNewAttempt's whole race-avoidance guarantee rests on
+      // comparing this pre-rerun run_attempt against the post-rerun
+      // value, so a missing/non-numeric run_attempt here means that
+      // guarantee cannot be verified at all -- proceeding anyway (e.g.
+      // treating "unknown" as automatically "new") would silently
+      // reopen the exact stale-read race this function exists to close.
+      if (typeof priorPayload.run_attempt !== 'number') {
+        throw new Error(
+          `cannot verify a new rerun attempt for run ${command.runId} (${owner}/${repo}): the current run_attempt is missing or non-numeric`,
+        );
+      }
+      const priorAttempt = priorPayload.run_attempt;
+      ghText(
+        ['run', 'rerun', command.runId, '-R', `${owner}/${repo}`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      waitForNewAttempt(owner, repo, command.runId, priorAttempt);
+    },
+    recomputePlan: () => {
+      const { input, options } = collectFromGitHub(args);
+      return computeRerunPlan(input, options);
+    },
+  };
+}
+// CLI: emit the plan as JSON plus a human-readable ordered command list.
+// Guarded behind `import.meta.main` (Node's own native CLI-entry-point
+// detection, matching every other already-migrated helper in this repo)
+// so importing this module (for unit tests) never parses process.argv,
+// prints usage, or makes a `gh` call.
+if (import.meta.main) {
+  const { plan, help, args } = runRerunAdvisoryConvergence(
+    process.argv.slice(2),
+  );
+  if (help) {
+    printHelp();
+  } else if (plan) {
+    // stdout carries ONLY the JSON document -- nothing else -- so the
+    // overall stdout stream stays valid, machine-parseable JSON (e.g.
+    // safely pipeable into `jq`). The human-readable recovery-plan
+    // summary below is real, useful output, but it belongs on stderr:
+    // mixing it into stdout after the JSON previously broke piping
+    // despite the stream *starting* with a well-formed document
+    // (#1434 review, Copilot).
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    // plan.recoveryRefreshPlan and plan.plan are printed as two
+    // INDEPENDENT sections (never else-if): #1745 made it possible for
+    // both to be non-empty at once (a bot-triggered rerun-eligible
+    // instance in `plan` does not itself supply the non-bot trigger a
+    // separately bot-gated instance still needs from
+    // `recoveryRefreshPlan`), and an `else if` here previously printed
+    // only whichever section was checked first, silently dropping the
+    // other's recovery command from this human-readable summary even
+    // though the JSON document above already carried both correctly
+    // (#1752, post-merge Codex review on #1749/#1745). Section selection
+    // and order are delegated to buildRerunPlanTextSections so the
+    // combined case has direct unit-test coverage instead of being
+    // reachable only through this CLI entry point.
+    for (const section of buildRerunPlanTextSections(plan)) {
+      process.stderr.write(`\n${section}\n`);
+    }
+    // Independent of whichever section(s) above fired: rerunPolicyHoldNotice
+    // describes a policy-held or budget-held instance, which is a
+    // DIFFERENT instance than whichever one just populated `plan` or
+    // `recoveryRefreshPlan` above -- printing it only in an `else if`
+    // alongside those two hid it whenever any instance ALSO had a plan
+    // entry, even though the JSON output (and a genuinely-held instance)
+    // still carried it (Copilot review, #1434; same family as the
+    // describeOutstandingStates fix immediately below, a distinct
+    // remaining gap in the same exclusive-branching area).
+    if (plan.rerunPolicyHoldNotice) {
+      process.stderr.write(`\n${plan.rerunPolicyHoldNotice}\n`);
+    }
+    // Independent of all of the above: outstanding pending / bot-gated /
+    // unresolved instances are reported unconditionally whenever they
+    // exist, rather than only when NONE of the branches above already
+    // had something to say -- those branches are about a DIFFERENT
+    // instance's rerun/refresh/hold outcome, and previously hid a
+    // genuinely-still-outstanding instance (e.g. 2 pending check-runs)
+    // any time a rerun plan also existed for a separate instance in the
+    // same run (CodeRabbit review, #1434).
+    const outstanding = describeOutstandingStates(plan);
+    if (outstanding) {
+      process.stderr.write(`\n${outstanding}\n`);
+    } else if (
+      plan.plan.length === 0 &&
+      plan.recoveryRefreshPlan.length === 0 &&
+      !plan.rerunPolicyHoldNotice
+    ) {
+      // Genuinely nothing to report at all.
+      process.stderr.write(`\n${describeNoActionState(plan)}\n`);
+    }
+    // --apply executes AFTER the full read-only diagnosis above has
+    // already printed -- an operator (or a log) always sees the same
+    // diagnostic output whether or not --apply was passed, with the
+    // execution summary appended, never substituted in its place.
+    if (args.apply) {
+      const applyResult = applyRerunPlan(plan, buildProductionApplyDeps(args));
+      process.stderr.write(`\n${formatApplySummary(applyResult)}\n`);
+    }
+  }
+  // Set exitCode and let the process end naturally instead of calling
+  // process.exit(0) directly: an explicit exit() can terminate the process
+  // before a large stdout write finishes flushing through a pipe (a
+  // well-established Node.js footgun, confirmed empirically during
+  // review), silently truncating the emitted JSON or recovery plan.
+  process.exitCode = 0;
+}

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -1,0 +1,535 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/resolve-review-thread.mts
+//
+// The scripts/resolve-review-thread.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Perform the common E13 review-thread disposition in one invocation: post the
+// reply comment to the thread that owns a review comment AND resolve that
+// thread. This is the write-side companion to the read-side review helpers
+// (`review-activity-snapshot`, `review-disposition-verify`). It follows the
+// write-side helper family conventions: dry-run by default, `--apply` mutates
+// and requires `--claim-issue` / `--claim-id` so the active claim is
+// revalidated immediately before the reply is posted (fail-closed). Reply
+// first, resolve second — a failed reply never leaves a silently-resolved
+// thread with no disposition.
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
+import { resolveActiveClaimForWriteGate } from './protocol-helpers.mjs';
+/**
+ * Find the review thread that owns the review comment whose REST database id is
+ * `commentId`. The GraphQL `PullRequestReviewComment.databaseId` equals the REST
+ * comment id, so the lookup is exact. Pure: takes already-fetched thread nodes
+ * and returns the owning thread's node id plus its current resolution state, or
+ * `null` when no thread contains that comment.
+ */
+export function findThreadForComment(threads, commentId) {
+  for (const thread of Array.isArray(threads) ? threads : []) {
+    const nodes = thread.comments?.nodes ?? [];
+    for (const comment of nodes) {
+      if (
+        comment.databaseId !== null &&
+        comment.databaseId !== undefined &&
+        Number(comment.databaseId) === Number(commentId)
+      ) {
+        // The top-level review comment is the first node in the thread's
+        // comments connection; the reply must target it, even when the request
+        // named a later reply in the thread.
+        const rootDatabaseId = nodes[0]?.databaseId;
+        return {
+          threadId: thread.id,
+          isResolved: Boolean(thread.isResolved),
+          rootCommentId:
+            rootDatabaseId !== null && rootDatabaseId !== undefined
+              ? Number(rootDatabaseId)
+              : null,
+        };
+      }
+    }
+  }
+  return null;
+}
+/**
+ * Orchestrate the apply-mode mutation with injected side effects so the
+ * reply→resolve sequencing is testable without the network. Revalidate the
+ * active claim before **each** GitHub-side mutation (E13 requires a claim
+ * revalidation before every reply/resolve side effect): the first check aborts
+ * before the reply is posted, and the second aborts before the resolve if the
+ * claim was released or handed off in the window between the two mutations.
+ * Resolve only after the reply lands, so a failed reply never leaves a
+ * silently-resolved thread with no disposition.
+ */
+export function applyResolveReviewThread(deps) {
+  deps.assertClaim();
+  const reply = deps.postReply();
+  deps.assertClaim();
+  deps.resolveThread();
+  return { replyId: reply.id };
+}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const RESOLVE_REVIEW_THREAD_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--comment-id': { type: 'string' },
+  '--body': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--claim-issue': { type: 'string' },
+  '--claim-id': { type: 'string', default: '' },
+  '--agent-id': { type: 'string', default: '' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--apply': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function splitList(value) {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+/**
+ * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
+ * absent resolves to `null` (the original `pr: null` / `claimIssue: null`
+ * default, never overwritten when the flag is absent); present feeds the
+ * raw token straight to `Number.parseInt`, which accepts trailing-garbage
+ * ("42abc" -> 42) and leading-zero ("007" -> 7) tokens the same way the
+ * original hand-rolled `Number.parseInt(next(), 10)` always did.
+ * `cli-args.mts`'s `parseCanonicalIntegerOrNull` is a poor substitute here:
+ * its canonical-pattern regex rejects those same tokens outright, which is
+ * a real contract change a CodeRabbit review on PR #1466 caught -- #1450's
+ * acceptance criteria protect the post-parse integer contract as-is, only
+ * flag *syntax* (missing/flag-shaped values, unknown flags) is meant to
+ * tighten. The downstream `!Number.isInteger(...) || (... ?? 0) <= 0`
+ * guards below already treat `NaN` (an invalid parseInt result) the same
+ * as `null`, so this restores the exact original resolved value, not just
+ * an equivalent downstream verdict.
+ */
+function parseLenientIntegerOrNull(token) {
+  return token === undefined ? null : Number.parseInt(token, 10);
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, RESOLVE_REVIEW_THREAD_FLAG_SPEC);
+  return {
+    pr: parseLenientIntegerOrNull(values.pr),
+    commentId: parseLenientIntegerOrNull(values['comment-id']),
+    body: values.body,
+    owner: values.owner,
+    repo: values.repo,
+    claimIssue: parseLenientIntegerOrNull(values['claim-issue']),
+    claimId: values['claim-id'],
+    agentId: values['agent-id'],
+    trustedMarkerLogins: splitList(values['trusted-marker-logins']),
+    apply: values.apply,
+    help,
+  };
+}
+const USAGE = `usage: node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id> [options]
+
+Post a reply to the review thread that owns <comment-id> and resolve that
+thread in one invocation (E13). Dry-run by default; --apply mutates.
+
+  --pr <number>                  PR number (required)
+  --comment-id <id>              review comment REST id whose thread to resolve (required)
+  --body <text>                  reply body (required with --apply)
+  --owner <owner>                repo owner (default: gh repo view)
+  --repo <repo>                  repo name (default: gh repo view)
+  --claim-issue <number>         issue carrying the active claim (required with --apply)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
+  --agent-id <agent-id>          current session agent id (optional, tightens the claim check)
+  --trusted-marker-logins a,b    logins whose claim markers are trusted
+                                 (default: your gh login)
+  --apply                        post the reply and resolve the thread (default: dry-run)
+  -h, --help                     show this help
+`;
+function ghJson(args) {
+  return JSON.parse(ghText(args));
+}
+/**
+ * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
+ * one JSON array per page; `--jq '.[]'` flattens each page to one JSON value per
+ * line (NDJSON), which we parse line-by-line (mirrors the sibling helpers).
+ */
+function ghJsonPaginated(args) {
+  const out = ghText([...args, '--paginate', '--jq', '.[]'], {
+    timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line));
+}
+function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(ghText(args) || '{}');
+}
+/**
+ * Throw when a GraphQL response carries top-level `errors`, so a bad
+ * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
+ * message instead of being silently read as an empty result (which would
+ * masquerade as "no review thread found").
+ */
+export function assertNoGraphqlErrors(payload, context) {
+  const errors = payload?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(
+      `${context} failed: ${errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+}
+/**
+ * Fetch every review thread of a PR (paginated), each with its node id,
+ * resolution state, and member comment database ids — enough to map a REST
+ * comment id to its owning thread. Both the threads connection **and** each
+ * thread's nested comments connection are paginated to completion, so a target
+ * comment buried past the first 100 replies in a deep thread still resolves.
+ */
+function fetchReviewThreads(owner, repo, prNumber) {
+  const nodes = [];
+  let cursor = null;
+  while (true) {
+    const payload = ghGraphql(
+      `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                isResolved
+                comments(first: 100) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { databaseId }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    assertNoGraphqlErrors(payload, 'review thread lookup');
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread comment pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes = [
+          ...(thread.comments.nodes ?? []),
+          ...fetchThreadCommentIds(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        ];
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+/**
+ * Page the remaining comment-id nodes of one review thread, starting after
+ * `afterCursor`, until the connection is exhausted. Mirrors the sibling
+ * snapshot helper's nested-comment pagination.
+ */
+function fetchThreadCommentIds(threadId, afterCursor) {
+  const nodes = [];
+  let cursor = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `query($id: ID!, $cursor: String) {
+        node(id: $id) {
+          ... on PullRequestReviewThread {
+            comments(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes { databaseId }
+            }
+          }
+        }
+      }`,
+      { id: threadId, cursor },
+    );
+    assertNoGraphqlErrors(payload, 'review thread comment pagination');
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
+  }
+  return nodes;
+}
+/** Post a reply to the review thread that owns `commentId` (REST). */
+function postReply(owner, repo, pr, commentId, body) {
+  return ghJson([
+    'api',
+    '--method',
+    'POST',
+    `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+    '-f',
+    `body=${body}`,
+  ]);
+}
+/** Resolve a review thread by its GraphQL node id, confirming the result. */
+function resolveThread(threadId) {
+  const payload = ghGraphql(
+    `mutation($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread { id isResolved }
+      }
+    }`,
+    { threadId },
+  );
+  assertNoGraphqlErrors(payload, 'resolveReviewThread');
+  if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
+    throw new Error(
+      'resolveReviewThread returned without confirming thread.isResolved',
+    );
+  }
+}
+/**
+ * Re-fetch the claim issue and return the active claim **owned by this session**
+ * (its `claimId`, and `agentId` when supplied, match), or `null` when the claim
+ * was lost. Scoped to trusted marker authors via the shared
+ * `resolveActiveClaimForWriteGate` state machine. A forced-handoff marker is
+ * honored only when it is an operator-approved, authorized handoff
+ * (forced-handoff mode enabled, `forced-by` is an authorized maintainer, and
+ * the comment author matches `forced-by`); otherwise the original claim stays
+ * active and an unauthorized/forged successor's `--claim-id` still fails the
+ * ownership comparison below. This is an issue-scoped revalidation
+ * (`expectedLinkedPrs: null`), so a legitimate issue-only handoff is accepted.
+ * Aborting on a contested claim is always safe (the manual E13 path remains).
+ * The returned `branch` lets the caller bind the mutation to the PR whose head
+ * is that branch.
+ */
+function activeOwnedClaim(
+  owner,
+  repo,
+  issue,
+  agentId,
+  claimId,
+  isTrustedAuthor,
+  forcedHandoffOptions,
+) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${issue}/comments`,
+  ]);
+  const events = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const active = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor,
+    forcedHandoffEnabled: forcedHandoffOptions.forcedHandoffEnabled,
+    // Issue-scoped revalidation: accept a legitimate issue-only handoff.
+    expectedLinkedPrs: null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      forcedHandoffOptions.isAuthorizedForcedHandoff(forcedBy),
+    requireAuthorMatchesForcedBy: true,
+  });
+  if (active?.claimId !== claimId) {
+    return null;
+  }
+  if (agentId && active.agentId !== agentId) {
+    return null;
+  }
+  return active;
+}
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (
+    args.help ||
+    !Number.isInteger(args.pr) ||
+    (args.pr ?? 0) <= 0 ||
+    !Number.isInteger(args.commentId) ||
+    (args.commentId ?? 0) <= 0
+  ) {
+    process.stdout.write(USAGE);
+    process.exit(args.help ? 0 : 1);
+  }
+  // Fail closed: --apply mutates PR state, so the active-claim revalidation and
+  // a reply body are mandatory. Missing inputs must abort before any read or
+  // write rather than silently bypassing the gate.
+  if (
+    args.apply &&
+    (!Number.isInteger(args.claimIssue) ||
+      (args.claimIssue ?? 0) <= 0 ||
+      !args.claimId ||
+      !args.body)
+  ) {
+    process.stderr.write(
+      '--apply requires --body and the --claim-issue / --claim-id pair for the mandatory claim revalidation\n',
+    );
+    process.exit(1);
+  }
+  const pr = args.pr;
+  const commentId = args.commentId;
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const match = findThreadForComment(
+    fetchReviewThreads(owner, repo, pr),
+    commentId,
+  );
+  const report = {
+    mode: args.apply ? 'apply' : 'dry-run',
+    prNumber: pr,
+    commentId,
+    ...(match ? { threadId: match.threadId } : {}),
+    alreadyResolved: match?.isResolved ?? false,
+  };
+  if (!match) {
+    report.error = `no review thread found for comment ${commentId} on PR #${pr}`;
+    if (args.apply) {
+      report.status = 'failed';
+    }
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    // A missing thread is informational in dry-run but a hard failure in apply.
+    process.exit(args.apply ? 1 : 0);
+  }
+  if (!args.apply) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  }
+  // The reply targets the thread's top-level review comment, so a thread with
+  // no exposed comment id cannot be replied to — fail closed before mutating.
+  const rootCommentId = match.rootCommentId;
+  if (rootCommentId === null) {
+    report.status = 'failed';
+    report.error = `review thread ${match.threadId} exposes no top-level comment id to reply to`;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
+  }
+  // Bind the mutation to the claimed PR: the active claim's branch must be the
+  // PR's head branch, so a valid claim on the issue cannot be used to reply to
+  // and resolve a thread on some other PR passed as --pr.
+  const prHeadRef = ghText([
+    'api',
+    `repos/${owner}/${repo}/pulls/${pr}`,
+    '--jq',
+    '.head.ref',
+  ]);
+  // --apply: default the trusted claim authors to this gh login so the
+  // revalidation recognizes the session's own claim markers.
+  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const trustedAuthors = new Set(
+    (args.trustedMarkerLogins.length > 0
+      ? args.trustedMarkerLogins
+      : [viewerLogin]
+    ).map((login) => login.toLowerCase()),
+  );
+  const isTrustedAuthor = (login) =>
+    trustedAuthors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  // Resolve the forced-handoff policy and build the collaborator-permission
+  // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
+  // .github/idd/config.json and re-hitting the collaborators API would be a
+  // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
+  // readActiveClaim comment.
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffPermissionCache = new Map();
+  const forcedHandoffOptions = {
+    forcedHandoffEnabled,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        forcedHandoffPermissionCache,
+      ),
+  };
+  // Retain the posted reply id across a later failure so a partial apply (reply
+  // posted, resolve not confirmed) reports the reply id instead of looking like
+  // nothing was posted — that distinguishes "retry the resolve" from "re-post".
+  let postedReplyId;
+  try {
+    const result = applyResolveReviewThread({
+      assertClaim: () => {
+        const active = activeOwnedClaim(
+          owner,
+          repo,
+          args.claimIssue,
+          args.agentId,
+          args.claimId,
+          isTrustedAuthor,
+          forcedHandoffOptions,
+        );
+        if (!active) {
+          throw new Error(
+            `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${args.claimIssue}`,
+          );
+        }
+        if (active.branch !== prHeadRef) {
+          throw new Error(
+            `claim/PR mismatch: active claim branch "${active.branch}" does not match PR #${pr} head branch "${prHeadRef}"`,
+          );
+        }
+      },
+      postReply: () => {
+        const posted = postReply(owner, repo, pr, rootCommentId, args.body);
+        postedReplyId = posted.id;
+        return posted;
+      },
+      resolveThread: () => resolveThread(match.threadId),
+    });
+    report.status = 'applied';
+    report.replyId = result.replyId;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  } catch (error) {
+    report.status = 'failed';
+    if (postedReplyId !== undefined) {
+      report.replyId = postedReplyId;
+    }
+    report.error = error.message;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -1,0 +1,923 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/resume-claim-routing.mts
+//
+// The scripts/resume-claim-routing.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { parseCliArgs } from './cli-args.mjs';
+import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { normalizePolicyConfig } from './policy-helpers.mjs';
+import {
+  buildForcedHandoffEnableGate,
+  DEFAULT_STALE_AGE_MS,
+  findActivationNonceWinner,
+  isStaleByAge,
+  normalizeLinkedPrReference,
+  parseClaimComment,
+  parseReleaseComment,
+  resolveActiveClaim,
+} from './protocol-helpers.mjs';
+
+const LEGACY_CLAIM_PATTERN =
+  /^<!--\s*claimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+branch:\s+([^\s>]+)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
+const LEGACY_RELEASE_PATTERN =
+  /^<!--\s*unclaimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const RESUME_CLAIM_ROUTING_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--token': { type: 'string' },
+  '--claim-id': { type: 'string' },
+  '--nonce': { type: 'string' },
+  '--now': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--stale-age-ms': { type: 'string' },
+  '--trusted-marker-logins': { type: 'string' },
+  '--fresh-claim-gate': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * Build the `isForcedHandoffEnabled` gate used by the resume CLI.
+ *
+ * Mirrors `summarizeClaimValidation`'s gate so a forced handoff that
+ * displaces a **PR-backed** claim is honored only with `issue-plus-pr`
+ * evidence naming that PR:
+ *
+ * - forced-handoff mode disabled → never honor;
+ * - no open linked PR backs the claim (`expectedLinkedPrReferences`
+ *   empty, including the fail-safe lookup-error case) → honor an
+ *   `issue-only` handoff as before;
+ * - an open linked PR backs the claim → require `contextScope` of
+ *   `issue-plus-pr` whose `linkedPr` matches one of the expected PRs.
+ */
+export function buildForcedHandoffEnabledGate(options) {
+  // Delegate to the shared builder so resume routing and the merge-gate /
+  // write-side helpers cannot drift. Resume routing never passes
+  // `prFirstCommitAt`, so this stays byte-identical to the prior behavior:
+  // an issue-only handoff against a PR-backed claim is rejected.
+  return buildForcedHandoffEnableGate({
+    forcedHandoffEnabled: options.forcedHandoffEnabled,
+    expectedLinkedPrReferences: options.expectedLinkedPrReferences,
+  });
+}
+export function evaluateResumeClaimRouting(input, options = {}) {
+  const nowIso =
+    normalizeIso(input.now) ?? normalizeIso(new Date().toISOString()) ?? '';
+  const staleAgeMs = normalizeStaleAgeMs(input.staleAgeMs);
+  const trustedAuthor =
+    typeof options.isTrustedAuthor === 'function'
+      ? options.isTrustedAuthor
+      : () => true;
+  const isForcedHandoffEnabled =
+    typeof options.isForcedHandoffEnabled === 'function'
+      ? options.isForcedHandoffEnabled
+      : () => false;
+  const isAuthorizedForcedHandoff =
+    typeof options.isAuthorizedForcedHandoff === 'function'
+      ? options.isAuthorizedForcedHandoff
+      : () => false;
+  const events = normalizeEvents(input.events).filter((event) =>
+    trustedAuthor(event.author?.login ?? ''),
+  );
+  const state = resolveClaimState(events, nowIso, staleAgeMs, {
+    isForcedHandoffEnabled,
+    isAuthorizedForcedHandoff,
+  });
+  const claimIdChecked = normalizeToken(input.claimId);
+  const sameSecondContenders = state.activeClaim
+    ? findSameSecondContenders(events, state.activeClaim)
+    : [];
+  const laterCompetingClaim = state.activeClaim
+    ? findLaterCompetingClaim(events, state.activeClaim)
+    : null;
+  const activationNonceWinner = state.activeClaim
+    ? findActivationNonceWinner(events, state.activeClaim.claimId)
+    : null;
+  const nonceChecked = normalizeToken(input.nonce);
+  const warnings = [...state.warnings];
+  let routeState = 'unclaimed';
+  let action = 're_claim';
+  let reason = 'no-active-claim';
+  if (state.mode === 'legacy-only') {
+    if (!state.legacyClaim) {
+      routeState = 'unclaimed';
+      action = 're_claim';
+      reason = 'legacy-absent';
+    } else if (state.legacyReleased) {
+      routeState = 'unclaimed';
+      action = 're_claim';
+      reason = 'legacy-released';
+    } else if (isStaleByAge(state.legacyClaim.createdAt, nowIso, staleAgeMs)) {
+      routeState = 'stale';
+      action = 'takeover';
+      reason = 'legacy-claim-stale';
+    } else {
+      routeState = 'non_inheritable';
+      action = 'stop';
+      reason = 'legacy-claim-non-stale';
+    }
+  } else if (!state.activeClaim) {
+    routeState = 'unclaimed';
+    action = 're_claim';
+    reason = 'no-active-claim';
+  } else if (claimIdChecked && claimIdChecked === state.activeClaim.claimId) {
+    // Owner-resume path: the checking session already proved ownership of
+    // the active claim-id. A later competing claim disputes an owner
+    // unconditionally here, regardless of the active claim's own staleness
+    // (#1687 keeps this test-locked semantic byte-identical -- only the
+    // non-owner / fresh-claim-gate path below gains a staleness escape).
+    //
+    // The claim-id matches, but claim-id alone cannot distinguish a second,
+    // independent activation of the same id (the sticky forced-handoff
+    // adopt-verbatim collision #1522 exists to catch) -- so when both a
+    // local nonce and a trusted activation-nonce winner are available,
+    // require them to agree too. Either side being absent (no nonce posted
+    // yet, or this caller never opted in) skips the comparison and keeps
+    // the claim-id-only outcome, matching pre-#1522 behavior exactly.
+    //
+    // Computed unconditionally (not only when laterCompetingClaim is falsy)
+    // so a later-competing-claim dispute can still surface a concurrent
+    // nonce mismatch in `reason` (CodeRabbit, PR #1770) -- a caller that
+    // mechanically releases on "step 4 is the sole failing check" must be
+    // able to tell a step-4-only dispute apart from a dispute where step 5
+    // also fails, since releasing a claim-id/agent-id pair that a second,
+    // legitimate activation shares would evict that other session.
+    const nonceMismatch =
+      activationNonceWinner !== null &&
+      nonceChecked &&
+      activationNonceWinner !== nonceChecked;
+    if (laterCompetingClaim && nonceMismatch) {
+      routeState = 'disputed';
+      action = 'stop';
+      reason = 'later-competing-claim-and-activation-nonce-mismatch';
+    } else if (laterCompetingClaim) {
+      routeState = 'disputed';
+      action = 'stop';
+      reason = 'later-competing-claim';
+    } else if (nonceMismatch) {
+      routeState = 'disputed';
+      action = 'stop';
+      reason = 'activation-nonce-mismatch';
+    } else {
+      routeState = 'already_owned';
+      action = 'keep';
+      reason = 'claim-id-match';
+    }
+  } else if (claimIdChecked && sameSecondContenders.includes(claimIdChecked)) {
+    routeState = 'disputed';
+    action = 'stop';
+    reason = 'same-second-claim-tie-break-loss';
+  } else if (isStaleByAge(state.activeClaim.createdAt, nowIso, staleAgeMs)) {
+    // Non-owner path (a fresh session, or --fresh-claim-gate, which always
+    // ignores claim-id): staleness of the active claim is now evaluated
+    // BEFORE laterCompetingClaim, so a stale disputed claim still escapes to
+    // a takeover-eligible route once claim-stale-age elapses (#1687) --
+    // closing the livelock where a lost different-second claim race left the
+    // issue permanently disputed even past the 24h stale-takeover backstop.
+    routeState = 'stale';
+    action = 'takeover';
+    reason = 'active-claim-stale';
+  } else if (laterCompetingClaim) {
+    routeState = 'disputed';
+    action = 'stop';
+    reason = 'later-competing-claim';
+  } else {
+    routeState = 'non_inheritable';
+    action = 'stop';
+    reason = 'active-claim-non-stale';
+  }
+  return {
+    state: routeState,
+    action,
+    reason,
+    claim_id_checked: claimIdChecked || null,
+    active_claim:
+      routeState === 'unclaimed'
+        ? null
+        : state.activeClaim
+          ? {
+              agent_id: state.activeClaim.agentId,
+              claim_id: state.activeClaim.claimId,
+              created_at: state.activeClaim.createdAt,
+              branch: state.activeClaim.branch,
+            }
+          : state.legacyClaim
+            ? {
+                agent_id: state.legacyClaim.agentId,
+                claim_id: null,
+                created_at: state.legacyClaim.createdAt,
+                branch: state.legacyClaim.branch,
+              }
+            : null,
+    stale_age_ms: staleAgeMs,
+    now: nowIso,
+    warnings,
+    evidence: {
+      trusted_event_count: events.length,
+      new_format_claim_seen: state.mode === 'new-format',
+      legacy_claim_seen: state.mode === 'legacy-only',
+      same_second_contenders: sameSecondContenders,
+      later_competing_claim: laterCompetingClaim,
+      activation_nonce_winner: activationNonceWinner,
+    },
+  };
+}
+/**
+ * Mechanical fresh-claim (A5) claimability gate.
+ *
+ * It reuses the shared `evaluateResumeClaimRouting` resolver (which itself
+ * builds on `resolveActiveClaim`) over a fresh marker fetch and maps the
+ * routing state to the fresh-claim vocabulary, so the write-side path never
+ * forks claim-state logic:
+ *
+ * - `unclaimed` → `claimable`
+ * - `stale` → `stale-reclaimable`
+ * - `non_inheritable` / `disputed` (a live competitor) → `already-claimed`
+ *
+ * A fresh claim owns no prior claim-id, so any `claimId` on `input` is ignored
+ * (the resolver's already-owned / same-second-loss branches need a checked id
+ * and would otherwise mask pure contention). `winningClaimId` is the active
+ * claim's `{claim-id}`, or `null` when there is no active claim or the active
+ * claim is a legacy (claim-id-less) marker. GitHub issue comments have no
+ * compare-and-swap, so this **narrows** the A5(c) TOCTOU window rather than
+ * closing it; the 24 h stale-takeover and same-second tie-break remain the
+ * race-recovery backstop.
+ */
+export function evaluateFreshClaimGate(input, options = {}) {
+  const routing = evaluateResumeClaimRouting(
+    { ...input, claimId: undefined },
+    options,
+  );
+  const verdict =
+    routing.state === 'unclaimed'
+      ? 'claimable'
+      : routing.state === 'stale'
+        ? 'stale-reclaimable'
+        : 'already-claimed';
+  return {
+    verdict,
+    winningClaimId: routing.active_claim?.claim_id ?? null,
+    reason: routing.reason,
+  };
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.token) {
+    process.env.GH_TOKEN = args.token;
+    process.env.GITHUB_TOKEN = args.token;
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repository = `${owner}/${repo}`;
+  const policy = loadPolicy(args.policy);
+  const staleAgeMs = args.staleAgeMs > 0 ? args.staleAgeMs : policy.staleAgeMs;
+  const trustedLogins = resolveTrustedLogins({
+    fromArgs: args.trustedMarkerLogins,
+    fromPolicy: policy.trustedMarkerActors,
+    currentLogin: ghText(
+      ['api', 'user', '--jq', '.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    ),
+  });
+  const trustedSet = new Set(trustedLogins.map((login) => login.toLowerCase()));
+  const comments = fetchIssueComments(repository, args.issue);
+  const issue = ghJson(['api', `repos/${repository}/issues/${args.issue}`]);
+  const forcedHandoffEnabled = policy.forcedHandoff.mode === 'human-gated';
+  const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
+  const permissionCache = new Map();
+  // A forced handoff that displaces a PR-backed claim must carry
+  // issue-plus-pr evidence naming that PR; detect the open linked PR(s)
+  // so the gate below can enforce it (fail-safe to no enforcement). Skip
+  // the lookup entirely when forced-handoff mode is off — the gate never
+  // honors a handoff then, so the PR context would go unused.
+  const expectedLinkedPrReferences = forcedHandoffEnabled
+    ? fetchOpenLinkedPrReferences(repository, args.issue)
+    : new Set();
+  const routingEvents = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const routingOptions = {
+    isTrustedAuthor: (login) =>
+      trustedSet.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+    isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
+      forcedHandoffEnabled,
+      expectedLinkedPrReferences,
+    }),
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        permissionCache,
+      ),
+  };
+  const result = evaluateResumeClaimRouting(
+    {
+      events: routingEvents,
+      claimId: args.claimId,
+      nonce: args.nonce || undefined,
+      staleAgeMs,
+      now: args.now || undefined,
+    },
+    routingOptions,
+  );
+  // The fresh-claim (A5) gate re-uses the same resolver over the same markers
+  // but ignores any --claim-id (a fresh claim owns none yet), mapping the
+  // routing state to the write-side claimability vocabulary.
+  const freshClaimGate = args.freshClaimGate
+    ? evaluateFreshClaimGate(
+        { events: routingEvents, staleAgeMs, now: args.now || undefined },
+        routingOptions,
+      )
+    : null;
+  const output = {
+    repository: { owner, repo },
+    issue: {
+      number: Number.parseInt(String(issue.number), 10),
+      title: String(issue.title ?? ''),
+      state: String(issue.state ?? ''),
+      url: String(issue.html_url ?? issue.url ?? ''),
+    },
+    policy: {
+      source: policy.source,
+      stale_age_ms: staleAgeMs,
+      trusted_marker_logins: trustedLogins,
+      forced_handoff_mode: policy.forcedHandoff.mode,
+      forced_handoff_authority_policy: forcedHandoffAuthorityPolicy,
+    },
+    ...result,
+    ...(freshClaimGate
+      ? {
+          fresh_claim_gate: {
+            verdict: freshClaimGate.verdict,
+            winning_claim_id: freshClaimGate.winningClaimId,
+          },
+        }
+      : {}),
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
+  const isForcedHandoffEnabled =
+    typeof options.isForcedHandoffEnabled === 'function'
+      ? options.isForcedHandoffEnabled
+      : () => false;
+  const isAuthorizedForcedHandoff =
+    typeof options.isAuthorizedForcedHandoff === 'function'
+      ? options.isAuthorizedForcedHandoff
+      : () => false;
+  // hasNewFormatClaim drives the new-format vs legacy-only mode. Detect
+  // it by scanning before delegating to the canonical parser so the
+  // wrapper can return the right legacy-fallback shape.
+  const hasNewFormatClaim = events.some(
+    (event) =>
+      parseClaimComment(event.body ?? '', event.createdAt ?? '') !== null,
+  );
+  const warnings = [];
+  const onAnomalousHeartbeat = ({ claimId, activeBranch, heartbeatBranch }) => {
+    warnings.push(
+      `ignored anomalous heartbeat for ${claimId}: branch ${heartbeatBranch} != ${activeBranch}`,
+    );
+  };
+  const onIgnoredForcedHandoff = ({ reason, forcedHandoff, event }) => {
+    if (reason === 'mode-disabled') {
+      warnings.push(
+        `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forced-handoff mode is not enabled`,
+      );
+      return;
+    }
+    if (reason === 'author-forced-by-mismatch') {
+      warnings.push(
+        `ignored forced-handoff for ${forcedHandoff.oldClaimId}: comment author ${event.author?.login ?? '(unknown)'} does not match forcedBy ${forcedHandoff.forcedBy}`,
+      );
+      return;
+    }
+    if (reason === 'forced-by-unauthorized') {
+      warnings.push(
+        `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forcedBy ${forcedHandoff.forcedBy} is not an authorized maintainer`,
+      );
+    }
+  };
+  const activeClaim = hasNewFormatClaim
+    ? resolveActiveClaim(events, {
+        isTrustedAuthor: () => true, // events were already filtered by caller
+        isForcedHandoffEnabled,
+        isAuthorizedForcedHandoff,
+        isStale: (activeCreatedAt, nextCreatedAt) =>
+          isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs),
+        // Resume routing enforces the rule-7 author/forcedBy binding to
+        // block the same-identity self-signed hijack path — the strict half
+        // of the strict-resume vs. lenient-relay-merge split (see
+        // docs/idd-design-rationale.md, "Claim resolution"). The merge-side
+        // summarizeClaimValidation path leaves it off because it may receive a
+        // maintainer-authorized handoff relayed by a separate automation actor,
+        // so the two callers can return different verdicts for the same
+        // corrected-handoff state (resume `already_owned` vs. merge
+        // `claimLost`) by design.
+        requireAuthorMatchesForcedBy: true,
+        onAnomalousHeartbeat,
+        onIgnoredForcedHandoff,
+      })
+    : null;
+  if (hasNewFormatClaim) {
+    return {
+      mode: 'new-format',
+      activeClaim,
+      warnings,
+      legacyClaim: null,
+      legacyReleased: false,
+    };
+  }
+  const orderedEvents = [...events].sort(compareEvents);
+  const legacy = resolveLegacyClaimState(orderedEvents, nowIso, staleAgeMs);
+  return {
+    mode: 'legacy-only',
+    activeClaim: null,
+    warnings,
+    legacyClaim: legacy.claim,
+    legacyReleased: legacy.released,
+  };
+}
+function resolveLegacyClaimState(orderedEvents, _nowIso, _staleAgeMs) {
+  let latestClaim = null;
+  let latestMatchingRelease = null;
+  for (const event of orderedEvents) {
+    const claim = parseLegacyClaimComment(event.body, event.createdAt);
+    if (claim) {
+      latestClaim = claim;
+      latestMatchingRelease = null;
+      continue;
+    }
+    const release = parseLegacyReleaseComment(event.body, event.createdAt);
+    if (
+      release &&
+      latestClaim &&
+      release.agentId === latestClaim.agentId &&
+      compareIso(release.createdAt, latestClaim.createdAt) > 0
+    ) {
+      latestMatchingRelease = release;
+    }
+  }
+  if (!latestClaim) {
+    return { claim: null, released: false };
+  }
+  const released = Boolean(latestMatchingRelease);
+  return { claim: latestClaim, released };
+}
+function findSameSecondContenders(events, activeClaim) {
+  const activeSecond = toSecond(activeClaim.createdAt);
+  if (activeSecond === null) {
+    return [];
+  }
+  return events
+    .map((event) => parseClaimComment(event.body, event.createdAt))
+    .filter((claim) => Boolean(claim))
+    .filter((claim) => toSecond(claim.createdAt) === activeSecond)
+    .map((claim) => claim.claimId)
+    .filter((claimId) => claimId !== activeClaim.claimId)
+    .sort();
+}
+function findLaterCompetingClaim(events, activeClaim) {
+  // Baseline on the active claim's ORIGINAL event time, not
+  // activeClaim.createdAt: applyClaimEvent refreshes the latter to the most
+  // recent heartbeat, which would hide a competing claim posted between the
+  // original claim and that heartbeat. Take the earliest matching claim
+  // event by timestamp rather than array position, since `events` is not
+  // guaranteed to be sorted oldest-first.
+  const originalCreatedAt = events
+    .map((event) => parseClaimComment(event.body, event.createdAt))
+    .filter((claim) => Boolean(claim) && claim?.claimId === activeClaim.claimId)
+    .reduce(
+      (earliest, claim) =>
+        earliest === null || compareIso(claim.createdAt, earliest) < 0
+          ? claim.createdAt
+          : earliest,
+      null,
+    );
+  const activeSecond = toSecond(originalCreatedAt ?? activeClaim.createdAt);
+  if (activeSecond === null) {
+    return null;
+  }
+  const contenders = events
+    .map((event) => parseClaimComment(event.body, event.createdAt))
+    .filter((claim) => Boolean(claim))
+    .filter((claim) => claim.claimId !== activeClaim.claimId)
+    .filter((claim) => {
+      const claimSecond = toSecond(claim.createdAt);
+      return claimSecond !== null && claimSecond > activeSecond;
+    })
+    // Reconcile competitor releases (#1687): a competing claimed-by whose
+    // {agent-id}/{claim-id} pair has a later matching trusted unclaimed-by
+    // no longer counts as a live competitor -- a courteous loser that
+    // releases its raced claim must clear the dispute it created, instead
+    // of leaving the issue permanently disputed against a claim nobody
+    // holds anymore.
+    .filter((claim) => !isClaimReleased(events, claim))
+    .sort((left, right) => compareIso(left.createdAt, right.createdAt));
+  if (contenders.length === 0) {
+    return null;
+  }
+  return {
+    claim_id: contenders[0].claimId,
+    created_at: contenders[0].createdAt,
+  };
+}
+/**
+ * True when a trusted `unclaimed-by` event releases `claim` -- its parsed
+ * `{agentId, claimId}` (via `parseReleaseComment`, which carries no
+ * timestamp of its own) matches `claim`'s, and the release event's own
+ * GitHub `created_at` (`event.createdAt`, the raw comment metadata) is
+ * strictly later than `claim.createdAt`. Uses the same `{agentId, claimId}`
+ * match as `applyClaimEvent`'s release check, but is evaluated
+ * independently here: `findLaterCompetingClaim`'s candidate
+ * never became the active claim (rule 4 of Claim-state parsing rejects a
+ * `supersedes: none` competitor while a claim already exists), so its own
+ * release never flows through `resolveActiveClaim`'s state machine and must
+ * be checked directly against the raw trusted event stream instead.
+ *
+ * Deliberately fail-closed, not a byte-identical mirror of
+ * `resolveActiveClaim`'s ordering: GitHub `created_at` is second-precision,
+ * so a claim and its release can share an identical timestamp string.
+ * `resolveActiveClaim`'s own sort breaks that tie by array/index order
+ * (effectively trusting fetch order) when resolving the *active* claim;
+ * this check requires a strictly later second instead, so an
+ * indistinguishable same-second ordering is never treated as proof of
+ * release -- the competing claim stays counted as live (the safer default)
+ * until a later, unambiguous release lands.
+ */
+function isClaimReleased(events, claim) {
+  return events.some((event) => {
+    const release = parseReleaseComment(event.body);
+    if (
+      !release ||
+      release.agentId !== claim.agentId ||
+      release.claimId !== claim.claimId
+    ) {
+      return false;
+    }
+    return compareIso(event.createdAt, claim.createdAt) > 0;
+  });
+}
+// `findActivationNonceWinner` moved to marker-helpers.mts (#1528) so the
+// F2/F3 merge-time write-gate (`summarizeClaimValidation` in
+// protocol-helpers.mts) can share the identical primitive instead of
+// forking its own copy. Imported above from './protocol-helpers.mts'.
+function parseLegacyClaimComment(body, createdAt) {
+  const match = String(body ?? '')
+    .trimEnd()
+    .match(LEGACY_CLAIM_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    createdAt: normalizeIso(match[2]) ?? normalizeIso(createdAt) ?? createdAt,
+    branch: match[3],
+  };
+}
+function parseLegacyReleaseComment(body, createdAt) {
+  const match = String(body ?? '')
+    .trimEnd()
+    .match(LEGACY_RELEASE_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    createdAt: normalizeIso(match[2]) ?? normalizeIso(createdAt) ?? createdAt,
+  };
+}
+function normalizeEvents(events) {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+  return events
+    .map((event) => ({
+      body: String(event?.body ?? ''),
+      createdAt: normalizeIso(event?.createdAt ?? event?.created_at),
+      author: {
+        login: String(event?.author?.login ?? event?.user?.login ?? ''),
+      },
+    }))
+    .filter((event) => event.createdAt !== null);
+}
+function compareEvents(left, right) {
+  const leftSecond = toSecond(left.createdAt);
+  const rightSecond = toSecond(right.createdAt);
+  if (
+    leftSecond !== null &&
+    rightSecond !== null &&
+    leftSecond !== rightSecond
+  ) {
+    return leftSecond - rightSecond;
+  }
+  if (leftSecond !== null && rightSecond === null) {
+    return -1;
+  }
+  if (leftSecond === null && rightSecond !== null) {
+    return 1;
+  }
+  const leftClaim = parseClaimComment(left.body, left.createdAt);
+  const rightClaim = parseClaimComment(right.body, right.createdAt);
+  if (leftClaim && rightClaim && leftClaim.claimId !== rightClaim.claimId) {
+    return leftClaim.claimId < rightClaim.claimId ? -1 : 1;
+  }
+  return compareIso(left.createdAt, right.createdAt);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, RESUME_CLAIM_ROUTING_FLAG_SPEC);
+  const issueToken = values.issue;
+  const staleAgeMsToken = values['stale-age-ms'];
+  return {
+    // Both --issue and --stale-age-ms are kept as lenient Number.parseInt
+    // (not the canonical-integer helper), matching the pre-migration
+    // contract exactly: --issue is re-validated by this file's own
+    // "!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0" post-check
+    // (in runCli, unchanged), and --stale-age-ms already flows through
+    // normalizeStaleAgeMs()'s own fail-safe (falls back to
+    // DEFAULT_STALE_AGE_MS on any non-finite / non-positive value) --
+    // tightening either at this layer would be an untested, out-of-scope
+    // behavior change for this behavior-preserving migration (see #1451).
+    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    token: values.token ?? '',
+    claimId: values['claim-id'] ?? '',
+    nonce: values.nonce ?? '',
+    now: values.now ?? '',
+    policy: values.policy ?? '',
+    staleAgeMs:
+      staleAgeMsToken === undefined ? 0 : Number.parseInt(staleAgeMsToken, 10),
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    freshClaimGate: values['fresh-claim-gate'],
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--nonce <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+
+  --fresh-claim-gate  emit the write-side A5(c) claimability verdict for the
+                      issue from current marker state, ignoring --claim-id (a
+                      fresh claim owns none yet). Run it on a fresh fetch
+                      immediately before the claim write; it re-uses the same
+                      resolver so claim-state logic never forks.
+  --nonce <token>     this session's own recorded activation-nonce (#1522):
+                      when --claim-id matches the active claim, also require
+                      it to equal the winning trusted <!-- activation-nonce:
+                      --> marker for that claim-id (lexicographically
+                      earliest nonce among however many were posted). A
+                      mismatch means a second, independent session activated
+                      the identical claim-id -- routes to "disputed" the same
+                      as a later-competing-claim loss. Omit --nonce, or leave
+                      the claim-id's nonce not posted, to skip the comparison
+                      (unchanged pre-#1522 behavior).
+
+Output (selected fields; the JSON also carries repository / issue / policy /
+warnings / evidence):
+{
+  "state": "unclaimed|already_owned|stale|non_inheritable|disputed",
+  "action": "re_claim|takeover|keep|stop",
+  "reason": "...",
+  "active_claim": {"agent_id":"...","claim_id":"...","created_at":"...","branch":"..."} | null,
+  "evidence": {"...": "...", "activation_nonce_winner": "..."|null},
+  "fresh_claim_gate": {"verdict":"claimable|already-claimed|stale-reclaimable","winning_claim_id":"..."|null}  // only with --fresh-claim-gate
+}
+`);
+}
+function fetchIssueComments(repository, issueNumber) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const pageItems = ghJson([
+      'api',
+      `repos/${repository}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+    ]);
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
+}
+// Read-and-parse failure semantics (explicit path throws; default path
+// silently falls back only on ENOENT) are converged in idd-config.mts's
+// loadPolicyConfig (#1721). It already implements exactly what this
+// function's former `strict` option hand-rolled -- the caller always passed
+// `strict: Boolean(args.policy)`, the same "was an explicit path given" test
+// loadPolicyConfig makes internally -- so the option (and this function's
+// own try/catch around the read) is no longer needed; a load failure now
+// propagates the shared reader's own error.
+function loadPolicy(policyPath) {
+  const { path: source, config } = loadPolicyConfig(policyPath);
+  const typedConfig = config;
+  const normalized = normalizePolicyConfig(typedConfig);
+  return {
+    source,
+    staleAgeMs:
+      parseDurationToMs(typedConfig?.claimTiming?.staleAge) ??
+      DEFAULT_STALE_AGE_MS,
+    trustedMarkerActors: Array.isArray(typedConfig?.trustedMarkerActors)
+      ? typedConfig.trustedMarkerActors
+          .map((value) => String(value ?? '').trim())
+          .filter(Boolean)
+      : [],
+    forcedHandoff: {
+      mode: normalized.forcedHandoff.mode,
+      authorityPolicy: normalized.forcedHandoff.authorityPolicy,
+    },
+  };
+}
+function parseDurationToMs(value) {
+  const text = String(value ?? '').trim();
+  if (!text) {
+    return null;
+  }
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(
+    text,
+  );
+  if (!match) {
+    return null;
+  }
+  const days = Number.parseInt(match[1] ?? '0', 10);
+  const hours = Number.parseInt(match[2] ?? '0', 10);
+  const minutes = Number.parseInt(match[3] ?? '0', 10);
+  const seconds = Number.parseInt(match[4] ?? '0', 10);
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+}
+function resolveTrustedLogins({ fromArgs, fromPolicy, currentLogin }) {
+  const fromCsv = String(fromArgs ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const merged = [
+    ...fromCsv,
+    ...(fromPolicy ?? []),
+    String(currentLogin ?? '').trim(),
+  ]
+    .map((value) => value.toLowerCase())
+    .filter(Boolean);
+  return [...new Set(merged)];
+}
+function normalizeStaleAgeMs(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_STALE_AGE_MS;
+  }
+  return Math.floor(value);
+}
+function normalizeIso(value) {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+function compareIso(left, right) {
+  const leftTime = Date.parse(String(left ?? ''));
+  const rightTime = Date.parse(String(right ?? ''));
+  if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) {
+    return 0;
+  }
+  return leftTime - rightTime;
+}
+function toSecond(iso) {
+  const milliseconds = Date.parse(String(iso ?? ''));
+  if (!Number.isFinite(milliseconds)) {
+    return null;
+  }
+  return Math.floor(milliseconds / 1000);
+}
+function normalizeToken(value) {
+  const token = String(value ?? '').trim();
+  return token.length > 0 ? token : '';
+}
+/**
+ * Resolve the set of open pull requests that back this issue's claim, as
+ * normalized PR references. Uses a precise signal — a PR connected to the
+ * issue via `CONNECTED_EVENT` (reconciled against later
+ * `DISCONNECTED_EVENT`s) that is currently `OPEN` — rather than a bare
+ * cross-reference/mention, so an unrelated open PR merely mentioning the
+ * issue does not falsely block a legitimate `issue-only` forced handoff.
+ * Fails safe to an empty set (no enforcement) on any lookup error.
+ */
+function fetchOpenLinkedPrReferences(repository, issueNumber) {
+  const references = new Set();
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo || !Number.isInteger(issueNumber)) {
+    return references;
+  }
+  const query =
+    'query($owner:String!,$repo:String!,$number:Int!){' +
+    'repository(owner:$owner,name:$repo){issue(number:$number){' +
+    // `last` so the most recent connect/disconnect events win: an issue
+    // with many such events must not have newer DISCONNECTED_EVENTs missed.
+    'timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
+    '{nodes{__typename ' +
+    '... on ConnectedEvent{subject{__typename ... on PullRequest{number state}}} ' +
+    '... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}' +
+    '}}}}}';
+  let data;
+  try {
+    data = ghJson([
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${issueNumber}`,
+    ]);
+  } catch {
+    return references;
+  }
+  const nodes = data?.data?.repository?.issue?.timelineItems?.nodes;
+  if (!Array.isArray(nodes)) {
+    return references;
+  }
+  // The last connect/disconnect event per PR wins (timeline is chronological).
+  const connected = new Map();
+  const states = new Map();
+  for (const node of nodes) {
+    const record = node;
+    const subject = record?.subject;
+    if (subject?.__typename !== 'PullRequest') {
+      continue;
+    }
+    const number =
+      typeof subject.number === 'number' ? subject.number : Number.NaN;
+    if (!Number.isInteger(number)) {
+      continue;
+    }
+    if (record?.__typename === 'ConnectedEvent') {
+      connected.set(number, true);
+      states.set(number, String(subject.state ?? ''));
+    } else if (record?.__typename === 'DisconnectedEvent') {
+      connected.set(number, false);
+    }
+  }
+  for (const [number, isConnected] of connected) {
+    if (isConnected && states.get(number) === 'OPEN') {
+      references.add(normalizeLinkedPrReference(number));
+    }
+  }
+  return references;
+}
+function ghJson(args) {
+  return JSON.parse(runGh(args).trim() || '[]');
+}
+function runGh(args) {
+  try {
+    return ghText(args, GH_TEXT_LOOP_TIMEOUT_OPTIONS);
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -1,0 +1,625 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/resume-route-selection.mts
+//
+// The scripts/resume-route-selection.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { execFileSync } from 'node:child_process';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+} from './gh-exec.mjs';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+
+const RUNNING_STATES = new Set([
+  'queued',
+  'in_progress',
+  'pending',
+  'waiting',
+  'requested',
+]);
+const FAILURE_STATES = new Set(['failure', 'cancelled', 'timed_out']);
+const PASS_EQUIVALENT_STATES = new Set([
+  'success',
+  'skipped',
+  'neutral',
+  'not_applicable',
+]);
+/**
+ * The documented branch-state taxonomy: every value {@link classifyBranchState}
+ * can return and that {@link selectResumeRoute} routes on. A caller-supplied
+ * `branchState` outside this set is unrecognized and normalizes to the cautious
+ * `'unknown'` (which routes to `stop`) rather than the permissive `'clean'`.
+ */
+const BRANCH_STATES = new Set([
+  'clean',
+  'behind-no-conflict',
+  'content-conflict',
+  'dirty',
+  'computing',
+  'unknown',
+]);
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const RESUME_ROUTE_SELECTION_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--token': { type: 'string' },
+  '--table-dump': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+export function selectResumeRoute(input) {
+  const state = normalizeState(input);
+  const reasonParts = [];
+  if (state.prAmbiguous) {
+    return result('stop', 'multiple-open-prs-for-issue', state, reasonParts);
+  }
+  if (!state.prExists) {
+    if (state.hasUnpushedCommits && !state.worktreeDirty) {
+      return result('D1', 'no-pr-unpushed-clean-worktree', state, reasonParts);
+    }
+    if (!state.requiredChecksGenerated) {
+      return result(
+        'D4',
+        'no-pr-required-checks-not-generated',
+        state,
+        reasonParts,
+      );
+    }
+    return result('stop', 'no-pr-no-unpushed-clean-path', state, reasonParts);
+  }
+  if (!state.requiredChecksGenerated) {
+    return result(
+      state.reviewExists ? 'E15' : 'D4',
+      'pr-required-checks-not-generated',
+      state,
+      reasonParts,
+    );
+  }
+  if (state.ciRunning) {
+    return result(
+      state.reviewExists ? 'E15' : 'D4',
+      'pr-ci-running',
+      state,
+      reasonParts,
+    );
+  }
+  if (state.ciFailed) {
+    return result(
+      state.reviewExists ? 'E15' : 'D4',
+      'pr-ci-failed',
+      state,
+      reasonParts,
+    );
+  }
+  if (state.ciSuccess) {
+    if (state.reviewPending) {
+      return result('E1', 'pr-ci-success-review-pending', state, reasonParts);
+    }
+    if (state.branchState === 'content-conflict') {
+      return result(
+        'Esync',
+        'pr-ci-success-content-conflict',
+        state,
+        reasonParts,
+      );
+    }
+    if (state.branchState === 'dirty' || state.branchState === 'unknown') {
+      return result(
+        'stop',
+        'pr-ci-success-branch-dirty-or-unknown',
+        state,
+        reasonParts,
+      );
+    }
+    if (state.branchState === 'computing') {
+      // Mergeability is still computing (transient `UNKNOWN`); resume into F1,
+      // whose bounded re-poll resolves it instead of stopping on a
+      // self-resolving state.
+      return result('F1', 'pr-ci-success-branch-computing', state, reasonParts);
+    }
+    if (state.branchState === 'behind-no-conflict') {
+      return result(
+        'F1',
+        'pr-ci-success-branch-behind-no-conflict',
+        state,
+        reasonParts,
+      );
+    }
+    return result('F2', 'pr-ci-success-no-review-pending', state, reasonParts);
+  }
+  return result('stop', 'pr-ci-unknown-state', state, reasonParts);
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.token) {
+    process.env.GH_TOKEN = args.token;
+    process.env.GITHUB_TOKEN = args.token;
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repository = `${owner}/${repo}`;
+  const routingInput = collectRoutingInput({
+    repository,
+    issueNumber: args.issue,
+  });
+  const selected = selectResumeRoute(routingInput);
+  const output = {
+    repository: { owner, repo },
+    issue: args.issue,
+    route: selected.route,
+    reason: selected.reason,
+    state: selected.state,
+    evidence: selected.evidence,
+  };
+  if (args.tableDump) {
+    output.decision_table = decisionTable();
+  }
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+function collectRoutingInput({ repository, issueNumber }) {
+  const prs = findIssueRelatedOpenPrs({ repository, issueNumber });
+  const issuePr = prs.length === 1 ? prs[0] : null;
+  const viewerLogin = ghText(
+    ['api', 'user', '--jq', '.login'],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ).toLowerCase();
+  const gitState = collectLocalGitState();
+  if (!issuePr) {
+    return {
+      prAmbiguous: prs.length > 1,
+      prExists: false,
+      requiredChecksGenerated: false,
+      hasUnpushedCommits: gitState.hasUnpushedCommits,
+      worktreeDirty: gitState.worktreeDirty,
+      ciChecks: [],
+      ciRunning: false,
+      ciFailed: false,
+      ciSuccess: false,
+      reviewExists: false,
+      reviewPending: false,
+      unresolvedThreadCount: 0,
+      unrepliedCommentCount: 0,
+      changesRequestedCount: 0,
+      branchState: 'clean',
+      prCount: prs.length,
+      prNumber: null,
+      prUrl: null,
+    };
+  }
+  const checks = ghJson(
+    [
+      'pr',
+      'checks',
+      String(issuePr.number),
+      '--repo',
+      repository,
+      '--required',
+      '--json',
+      'name,state,completedAt',
+    ],
+    { allowNoRequiredChecks: true },
+  );
+  const normalizedStates = checks.map((check) =>
+    String(check.state ?? '').toLowerCase(),
+  );
+  const requiredChecksGenerated = checks.length > 0;
+  const ciRunning = normalizedStates.some((state) => RUNNING_STATES.has(state));
+  const ciFailed = normalizedStates.some((state) => FAILURE_STATES.has(state));
+  const ciSuccess =
+    requiredChecksGenerated &&
+    !ciRunning &&
+    !ciFailed &&
+    normalizedStates.every((state) => PASS_EQUIVALENT_STATES.has(state));
+  const reviewThreads = fetchReviewThreads({
+    owner: repository.split('/')[0],
+    repo: repository.split('/')[1],
+    number: issuePr.number,
+  });
+  const unresolvedThreadCount = reviewThreads.filter(
+    (thread) => thread.isResolved === false,
+  ).length;
+  const reviews = ghApiJson(
+    `repos/${repository}/pulls/${issuePr.number}/reviews`,
+    true,
+  );
+  const changesRequestedCount = countLatestChangesRequestedByReviewer(reviews);
+  const reviewExists = unresolvedThreadCount > 0 || reviews.length > 0;
+  const comments = ghApiJson(
+    `repos/${repository}/issues/${issuePr.number}/comments`,
+    true,
+  );
+  const unrepliedCommentCount = countUnrepliedRegularComments(
+    comments,
+    viewerLogin,
+  );
+  const reviewPending =
+    unresolvedThreadCount > 0 ||
+    unrepliedCommentCount > 0 ||
+    changesRequestedCount > 0;
+  const mergeState = ghJson([
+    'pr',
+    'view',
+    String(issuePr.number),
+    '--repo',
+    repository,
+    '--json',
+    'mergeable,mergeStateStatus',
+  ]);
+  const branchState = classifyBranchState(mergeState);
+  return {
+    prAmbiguous: false,
+    prExists: true,
+    requiredChecksGenerated,
+    hasUnpushedCommits: gitState.hasUnpushedCommits,
+    worktreeDirty: gitState.worktreeDirty,
+    ciChecks: checks,
+    ciRunning,
+    ciFailed,
+    ciSuccess,
+    reviewExists,
+    reviewPending,
+    unresolvedThreadCount,
+    unrepliedCommentCount,
+    changesRequestedCount,
+    branchState,
+    prCount: prs.length,
+    prNumber: issuePr.number,
+    prUrl: issuePr.url,
+  };
+}
+function collectLocalGitState() {
+  const worktreeDirty = runGit(['status', '--porcelain']).trim().length > 0;
+  const hasUnpushedCommits = detectUnpushedCommits();
+  return {
+    hasUnpushedCommits,
+    worktreeDirty,
+  };
+}
+function detectUnpushedCommits() {
+  const hasUpstream = runGitAllowFailure([
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{u}',
+  ]).ok;
+  if (hasUpstream) {
+    return runGit(['log', '--oneline', '@{u}..HEAD']).trim().length > 0;
+  }
+  return runGit(['rev-list', '--count', 'HEAD']).trim() !== '0';
+}
+function findIssueRelatedOpenPrs({ repository, issueNumber }) {
+  const candidates = ghJson([
+    'pr',
+    'list',
+    '--repo',
+    repository,
+    '--state',
+    'open',
+    '--limit',
+    '100',
+    '--json',
+    'number,title,body,url',
+  ]);
+  const issueRefPattern = new RegExp(`(^|[^0-9])#${issueNumber}([^0-9]|$)`);
+  return candidates.filter((pr) => issueRefPattern.test(String(pr.body ?? '')));
+}
+function countUnrepliedRegularComments(comments, viewerLogin) {
+  const sorted = [...comments]
+    .map((comment) => ({
+      createdAt: Date.parse(String(comment.created_at ?? '')),
+      author: String(comment.user?.login ?? '').toLowerCase(),
+    }))
+    .filter((comment) => Number.isFinite(comment.createdAt))
+    .sort((left, right) => left.createdAt - right.createdAt);
+  let count = 0;
+  for (let index = 0; index < sorted.length; index += 1) {
+    const comment = sorted[index];
+    if (!comment.author || comment.author === viewerLogin) {
+      continue;
+    }
+    const replied = sorted
+      .slice(index + 1)
+      .some((later) => later.author === viewerLogin);
+    if (!replied) {
+      count += 1;
+    }
+  }
+  return count;
+}
+export function classifyBranchState(mergeState) {
+  const rawMergeable = mergeState?.mergeable;
+  const mergeable = String(rawMergeable ?? '').toUpperCase();
+  const mergeStateStatus = String(
+    mergeState?.mergeStateStatus ?? '',
+  ).toUpperCase();
+  if (mergeable === 'CONFLICTING') return 'content-conflict';
+  if (mergeStateStatus === 'DIRTY') return 'dirty';
+  if (mergeStateStatus === 'CLEAN') return 'clean';
+  if (mergeStateStatus === 'BEHIND') return 'behind-no-conflict';
+  if (mergeable === 'MERGEABLE') return 'clean';
+  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` — or an
+  // explicit `null` mergeable on a present payload — means the result is still
+  // computing (transient), not a terminal classification failure. A genuinely
+  // missing/unparseable payload (no `mergeable` field at all, i.e. `undefined`)
+  // stays terminal `unknown`.
+  if (mergeable === 'UNKNOWN' || rawMergeable === null) return 'computing';
+  return 'unknown';
+}
+export function countLatestChangesRequestedByReviewer(reviews) {
+  const latestByReviewer = new Map();
+  for (const review of reviews) {
+    const reviewer = String(review.user?.login ?? '').toLowerCase();
+    const state = String(review.state ?? '').toUpperCase();
+    if (!reviewer || state === 'COMMENTED' || state === 'PENDING') {
+      continue;
+    }
+    const submittedAt = Date.parse(String(review.submitted_at ?? ''));
+    if (!Number.isFinite(submittedAt)) {
+      continue;
+    }
+    const current = latestByReviewer.get(reviewer);
+    if (!current || submittedAt >= current.submittedAt) {
+      latestByReviewer.set(reviewer, { state, submittedAt });
+    }
+  }
+  let count = 0;
+  for (const review of latestByReviewer.values()) {
+    if (review.state === 'CHANGES_REQUESTED') {
+      count += 1;
+    }
+  }
+  return count;
+}
+function normalizeState(input) {
+  return {
+    prAmbiguous: input.prAmbiguous === true,
+    prExists: input.prExists === true,
+    requiredChecksGenerated: input.requiredChecksGenerated === true,
+    hasUnpushedCommits: input.hasUnpushedCommits === true,
+    worktreeDirty: input.worktreeDirty === true,
+    ciRunning: input.ciRunning === true,
+    ciFailed: input.ciFailed === true,
+    ciSuccess: input.ciSuccess === true,
+    reviewExists: input.reviewExists === true,
+    reviewPending: input.reviewPending === true,
+    branchState:
+      typeof input.branchState === 'string' &&
+      BRANCH_STATES.has(input.branchState)
+        ? input.branchState
+        : 'unknown',
+  };
+}
+function result(route, reason, state, reasonParts) {
+  return {
+    route,
+    reason,
+    state,
+    evidence: {
+      rule_trace: [...reasonParts, reason],
+    },
+  };
+}
+function decisionTable() {
+  return [
+    { condition: 'multiple open PRs match issue', route: 'stop' },
+    { condition: 'no PR + required checks not generated', route: 'D4' },
+    { condition: 'no PR + clean worktree + unpushed commits', route: 'D1' },
+    { condition: 'PR + checks not generated + no reviews', route: 'D4' },
+    { condition: 'PR + checks not generated + reviews exist', route: 'E15' },
+    { condition: 'PR + CI running/failing + no reviews', route: 'D4' },
+    { condition: 'PR + CI running/failing + reviews exist', route: 'E15' },
+    { condition: 'PR + CI success + review pending', route: 'E1' },
+    {
+      condition: 'PR + CI success + no review pending + content conflict',
+      route: 'Esync',
+    },
+    {
+      condition:
+        'PR + CI success + no review pending + dirty or unknown branch state',
+      route: 'stop',
+    },
+    {
+      condition: 'PR + CI success + no review pending + behind (no conflict)',
+      route: 'F1',
+    },
+    {
+      condition: 'PR + CI success + no review pending + clean branch',
+      route: 'F2',
+    },
+  ];
+}
+function fetchReviewThreads({ owner, repo, number }) {
+  const threads = [];
+  let cursor = null;
+  while (true) {
+    const response = ghApiGraphqlJson({
+      query:
+        'query($owner:String!, $repo:String!, $number:Int!, $cursor:String) { repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100, after:$cursor){ nodes{ isResolved } pageInfo{ hasNextPage endCursor } } } } }',
+      variables: {
+        owner,
+        repo,
+        number,
+        cursor,
+      },
+    }).data?.repository?.pullRequest?.reviewThreads;
+    const nodes = response?.nodes ?? [];
+    threads.push(...nodes);
+    const pageInfo = response?.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      break;
+    }
+    // hasNextPage with a missing cursor would silently undercount
+    // unresolved threads; fail fast on the malformed payload instead,
+    // matching the other pagination loops in this cluster.
+    if (!pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = pageInfo.endCursor;
+  }
+  return threads;
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, RESUME_ROUTE_SELECTION_FLAG_SPEC);
+  const issueToken = values.issue;
+  return {
+    // Kept as lenient Number.parseInt (not the canonical-integer helper),
+    // matching the pre-migration contract exactly -- see #1451's PR
+    // description for why this is not tightened here.
+    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    token: values.token ?? '',
+    tableDump: values['table-dump'],
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/resume-route-selection.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--table-dump]
+
+Output schema:
+{
+  "route": "D1|D4|E1|E15|Esync|F1|F2|stop",
+  "reason": "...",
+  "state": {"prExists": true, "ciSuccess": false, ...},
+  "evidence": {"rule_trace": ["..."]}
+}
+`);
+}
+function ghApiGraphqlJson({ query, variables }) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (Number.isInteger(value)) {
+      args.push('-F', `${key}=${value}`);
+    } else {
+      args.push('-f', `${key}=${value}`);
+    }
+  }
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+function ghApiJson(path, paginate = false) {
+  const args = ['api', path];
+  if (paginate) {
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    args.push('--paginate', '--jq', '.[]');
+  }
+  const raw = runGh(args).trim();
+  if (!paginate) {
+    return JSON.parse(raw || '[]');
+  }
+  if (!raw) {
+    return [];
+  }
+  return parsePaginatedGhNdjson(raw);
+}
+function ghJson(args, options = {}) {
+  try {
+    return JSON.parse(runGh(args).trim() || '{}');
+  } catch (error) {
+    const recovered = recoverJsonFromGhFailure(error, options);
+    if (recovered.recovered) {
+      return recovered.value;
+    }
+    throw error;
+  }
+}
+export function recoverJsonFromGhFailure(error, options = {}) {
+  const stderr = String(error?.stderr ?? '');
+  if (
+    options.allowNoRequiredChecks &&
+    /no required checks reported/i.test(stderr)
+  ) {
+    return { recovered: true, value: [] };
+  }
+  const stdout = String(error?.stdout ?? '').trim();
+  if (stdout) {
+    return { recovered: true, value: JSON.parse(stdout) };
+  }
+  return { recovered: false, value: null };
+}
+function runGh(args) {
+  try {
+    return ghText(args, {
+      ...GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ...(args.includes('--paginate')
+        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
+        : {}),
+    });
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      const wrapped = new Error(`gh command failed: ${stderr}`);
+      wrapped.stderr = String(error?.stderr ?? '');
+      wrapped.stdout = String(error?.stdout ?? '');
+      throw wrapped;
+    }
+    throw error;
+  }
+}
+function runGit(args) {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      throw new Error(`git command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}
+function runGitAllowFailure(args) {
+  try {
+    const stdout = execFileSync('git', args, {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout };
+  } catch (error) {
+    return {
+      ok: false,
+      stderr: String(error?.stderr ?? ''),
+    };
+  }
+}

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/review-activity-snapshot.mts
+//
+// The scripts/review-activity-snapshot.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { parseCliArgs } from './cli-args.mjs';
+import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import {
+  buildActivitySnapshotSummary,
+  parsePaginatedGhNdjson,
+  resolveAdvisoryBotLogins,
+  resolveTrustedMarkerActors,
+  summarizeDispositionEvidenceForGate,
+} from './protocol-helpers.mjs';
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls main() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see ci-wait-policy.mts's identical note).
+const REVIEW_ACTIVITY_SNAPSHOT_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--advisory-bot-logins': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  main();
+}
+// The CLI body. Guarded behind `import.meta.main` so importing this
+// module (for unit tests) does not parse process.argv, fail, or make a
+// `gh` call.
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const iddConfig = loadIddConfig();
+  const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
+  // #1833: also reads `author.login` (not just `headRefOid`) in this same
+  // call -- `summarizeDispositionEvidenceForGate` below needs the PR
+  // author's login to exclude the author's own comments/thread replies from
+  // "missing disposition" (they never require one), the same way
+  // `buildPreMergeReadinessSummary`'s own call to that function does.
+  // `ghJson`'s empty-response fallback is `'[]'` (array-shaped, tuned for
+  // the paginated `checks` call above); on this object-shaped `pr view`
+  // call an empty response would leave `headRefOid`/`author` both
+  // undefined, so `headSha` below becomes `''` and
+  // `watermarkFieldsFromSnapshot` (post-idd-marker.mts) throws "missing a
+  // usable headSha" downstream -- fail-closed, not a silent bad watermark.
+  const prView = ghJson([
+    'pr',
+    'view',
+    String(args.prNumber),
+    '-R',
+    repoRef,
+    '--json',
+    'headRefOid,author',
+  ]);
+  const headSha = String(prView.headRefOid ?? '');
+  const prAuthorLogin = String(prView.author?.login ?? '')
+    .trim()
+    .toLowerCase();
+  const checks = ghJson(
+    [
+      'pr',
+      'checks',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'name,state,completedAt',
+      '--jq',
+      '.',
+    ],
+    { allowStatuses: [1, 8] },
+  );
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  );
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  );
+  const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const normalizedComments = comments.map(normalizeComment);
+  const normalizedThreads = threads.map(normalizeThread);
+  const summary = buildActivitySnapshotSummary(
+    {
+      comments: normalizedComments,
+      reviews: reviews.map(normalizeReview),
+      threads: normalizedThreads,
+      checks,
+    },
+    {
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource,
+      // Advisory bots are excluded from disposition authorship inside the
+      // summary builder, so the trusted-marker set is a safe default here.
+      dispositionAuthorLogins: trustedMarkerLogins,
+    },
+  );
+  // #1833: exposed so a `--from-pr` watermark post (post-idd-marker.mts) can
+  // warn, in its own success output, when the fresh snapshot it is about to
+  // become the watermark still has comments/threads lacking disposition
+  // evidence -- instead of that only surfacing later via the readiness
+  // report's `reviewCurrency.comparisonRoute`. Trimmed to the two counters,
+  // mirroring `AdvisoryConvergenceDispositionEvidence`
+  // (advisory-convergence.mts) rather than re-exporting the full
+  // `DispositionEvidenceSummary` shape (`pre-merge-readiness.mjs`'s own
+  // richer `dispositionEvidence` field) -- no `snapshotBoundaryAt` is
+  // available here (no watermark exists yet at snapshot time), so the
+  // advisory-only ack sub-flags this function also returns would be
+  // meaningless; only the two counters are stable to expose.
+  const dispositionEvidence = summarizeDispositionEvidenceForGate(
+    { comments: normalizedComments, threads: normalizedThreads },
+    {
+      iddAgentLogins: trustedMarkerLogins,
+      advisoryBotLogins,
+      trustedMarkerLogins,
+      prAuthorLogin,
+    },
+  );
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        headSha,
+        trustedMarkerActors: trustedMarkerLogins,
+        trustedMarkerActorsSource,
+        totalItemCount: summary.totalItemCount,
+        maxActivityUpdatedAt: summary.maxActivityUpdatedAt,
+        latestCiCompletedAt: summary.latestCiCompletedAt,
+        latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
+        counts: summary.counts,
+        ackOnly: summary.ackOnly,
+        effective: summary.effective,
+        dispositionEvidence: {
+          missingRegularCommentCount:
+            dispositionEvidence.missingRegularCommentCount,
+          missingThreadCount: dispositionEvidence.missingThreadCount,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+/**
+ * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
+ * `Number.parseInt` accepts trailing-garbage ("42abc" -> 42) and
+ * leading-zero ("007" -> 7) tokens the same way the original hand-rolled
+ * `Number.parseInt(value ?? '', 10)` always did, then the original's own
+ * `!Number.isInteger(...) || (... ?? 0) < 1` post-check collapses an
+ * invalid or absent value to `null`. `cli-args.mts`'s
+ * `parseCanonicalIntegerOrNull` is a poor substitute: its canonical-pattern
+ * regex rejects those same permissive tokens outright, which is a real
+ * contract change a CodeRabbit review on PR #1466 caught -- #1450's
+ * acceptance criteria protect the post-parse integer contract as-is, only
+ * flag *syntax* (missing/flag-shaped values, unknown flags) is meant to
+ * tighten.
+ */
+function parseLenientPositiveIntegerOrNull(token) {
+  const value = Number.parseInt(token ?? '', 10);
+  return Number.isInteger(value) && value >= 1 ? value : null;
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    REVIEW_ACTIVITY_SNAPSHOT_FLAG_SPEC,
+  );
+  return {
+    prNumber: parseLenientPositiveIntegerOrNull(values.pr),
+    owner: values.owner,
+    repo: values.repo,
+    trustedMarkerLogins: values['trusted-marker-logins'],
+    advisoryBotLogins: values['advisory-bot-logins'],
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/review-activity-snapshot.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>]
+`);
+}
+function normalizeComment(comment) {
+  return {
+    author: { login: comment.user?.login ?? '' },
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    updatedAt: comment.updated_at ?? comment.created_at ?? '',
+  };
+}
+function normalizeReview(review) {
+  return {
+    author: { login: review.user?.login ?? '' },
+    state: review.state ?? '',
+    submittedAt: review.submitted_at ?? '',
+    createdAt: review.submitted_at ?? '',
+    updatedAt: review.updated_at ?? review.submitted_at ?? '',
+  };
+}
+function normalizeThread(thread) {
+  return {
+    id: thread.id,
+    isResolved: Boolean(thread.isResolved),
+    updatedAt: '',
+    comments: {
+      pageInfo: {
+        hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage),
+      },
+      nodes: (thread.comments?.nodes ?? []).map((comment) => ({
+        author: { login: comment.author?.login ?? '' },
+        body: comment.body ?? '',
+        createdAt: comment.createdAt ?? '',
+        updatedAt: comment.updatedAt ?? comment.createdAt ?? '',
+        pullRequestReview: { id: comment.pullRequestReview?.id ?? null },
+      })),
+    },
+  };
+}
+function fetchReviewThreads(owner, repo, prNumber) {
+  const nodes = [];
+  let cursor = null;
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  comments(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      body
+                      createdAt
+                      updatedAt
+                      author { login }
+                      pullRequestReview { id }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+      {
+        owner,
+        repo,
+        number: Number.parseInt(String(prNumber), 10),
+        cursor,
+      },
+    );
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        // hasNextPage with a missing thread id or cursor is a malformed
+        // payload; fail fast with a clear message instead of a confusing
+        // GraphQL error or a silently truncated thread.
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes.push(
+          ...fetchThreadCommentPages(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        );
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) {
+      break;
+    }
+    // hasNextPage with a missing cursor would re-fetch the first page
+    // forever; fail fast on the malformed payload instead.
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+function fetchThreadCommentPages(threadId, afterCursor) {
+  const nodes = [];
+  let cursor = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  body
+                  createdAt
+                  updatedAt
+                  author { login }
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }`,
+      { id: threadId, cursor },
+    );
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
+  }
+  return nodes;
+}
+function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+function ghJson(args, options = {}) {
+  return JSON.parse(runGh(args, options).trim() || '[]');
+}
+function ghApiJson(path, paginate = false, fields = null) {
+  const args = ['api', path];
+  if (fields) {
+    for (const [key, value] of Object.entries(fields)) {
+      args.push(
+        '-f',
+        `${key}=${typeof value === 'string' ? value : JSON.stringify(value)}`,
+      );
+    }
+  }
+  // #1692: `--jq '.[]'` (not a bare `--paginate`) makes gh emit one JSON
+  // value per line, guaranteed newline-separated, for every element across
+  // every page -- without it, `--paginate` alone concatenates each page's
+  // whole-array response with no separator on gh 2.45.0 (this repo's
+  // documented compatibility floor), which broke a naive split('\n') on
+  // multi-page output. Matches the NDJSON convention `gh-exec.mts`'s
+  // shared `ghApiJson` already uses.
+  if (paginate) {
+    args.push('--paginate', '--jq', '.[]');
+  }
+  const raw = runGh(args).trim();
+  if (!raw) {
+    return [];
+  }
+  if (paginate) {
+    return parsePaginatedGhNdjson(raw);
+  }
+  return JSON.parse(raw);
+}
+function runGh(args, options = {}) {
+  try {
+    return ghText(
+      args,
+      args.includes('--paginate')
+        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
+        : {},
+    );
+  } catch (error) {
+    const status = Number(error?.status ?? -1);
+    if ((options.allowStatuses ?? []).includes(status)) {
+      const stdout = String(error?.stdout ?? '');
+      if (/^\s*[[{]/.test(stdout)) {
+        return stdout;
+      }
+    }
+    throw error;
+  }
+}

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -1,0 +1,214 @@
+// idd-generated-from: src/scripts/review-clause.mts
+//
+// The scripts/review-clause.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared "does the latest trusted primary-bot review cover the PR's
+// current HEAD" evidence (Clause 1 of `advisory-convergence.mts`'s
+// `converged` definition), extracted (#1806) so a second, independent
+// caller (`rerun-advisory-convergence.mts`) can reuse the SAME review
+// fetch and matching logic the real `idd-advisory-convergence` gate
+// already uses, instead of a second ad-hoc GraphQL path that could drift
+// out of sync with it. `advisory-convergence.mts` itself now imports these
+// from here too -- this file has no behavior of its own beyond what both
+// callers already relied on before the extraction.
+//
+// Kept deliberately small (only depends on `gh-exec.mts`'s shared
+// `ghGraphql`, `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`,
+// and -- as of #1880 -- `markdown-code.mts`'s shared
+// `stripMarkdownCodeRegions`) so a read-only, low-dependency caller like
+// `rerun-advisory-convergence.mts` can import it without also pulling in
+// `advisory-convergence.mts`'s full claim/waiver/disposition machinery --
+// see that file's own module-header "Reuse map" comment. The first two
+// dependencies are already reused directly by `rerun-advisory-convergence.mts`
+// itself today; `markdown-code.mts` has no imports of its own, so this adds
+// no heavy dependency surface to that caller either.
+import { ghGraphql } from './gh-exec.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
+
+/** Matches GitHub Copilot's `<summary>Suppressed comments (N)</summary>`
+ * heading, case-insensitively -- the only structured signal a suppressed
+ * finding leaves in the review body (#1880). Anchored to the surrounding
+ * `<summary>`/`</summary>` tags, not a bare `Suppressed comments (N)`
+ * substring search: this file's own diff (this pattern, its doc comments,
+ * and the regression test fixture) now contains that literal phrase, and
+ * an advisory bot reviewing THIS pull request could quote it back in
+ * ordinary prose (e.g. discussing the test fixture) without wrapping it in
+ * the real HTML tags -- the same prose-quoted-example false-positive class
+ * a marker parser elsewhere in this codebase already hit once
+ * (kurone-kito/idd-skill#1614). Requiring the literal tag pair keeps a
+ * plain-text mention from matching -- but is not sufficient alone: see
+ * {@link parseSuppressedCommentCount}'s own code-region stripping for the
+ * remaining case (the literal tags quoted INSIDE a code span/fence). */
+const SUPPRESSED_COMMENTS_HEADING_PATTERN =
+  /<summary>\s*suppressed comments \((\d+)\)\s*<\/summary>/i;
+/**
+ * Parse the `Suppressed comments (N)` count GitHub Copilot embeds in a
+ * review's top-level body when it folds a low-confidence finding into a
+ * collapsed `<details>` block instead of posting it as a separate review
+ * comment (kurone-kito/idd-skill#1880). Returns `0` when the body carries
+ * no such section, including an absent/empty/unparseable body -- unlike
+ * `itemCount`, there is no distinct "unknown" state to preserve here: a
+ * missing section unambiguously means zero suppressed comments.
+ *
+ * Strips fenced/inline Markdown code regions (`stripMarkdownCodeRegions`,
+ * markdown-code.mts) before matching, so a review body that quotes the
+ * literal `<summary>Suppressed comments (N)</summary>` tag pair inside
+ * backticks or a fenced code block (e.g. an advisory bot discussing this
+ * exact detection logic, as happened on this PR's own #1884 Copilot
+ * review) is not mistaken for a real suppressed-comments section -- the
+ * `<summary>`/`</summary>` anchoring above narrows the prose-quoting risk
+ * but does not by itself exclude a code-quoted example; stripping the code
+ * regions first closes that gap the same way #1614's marker-parser fix did.
+ * Real GitHub-rendered `<details>`/`<summary>` markup is raw HTML, never
+ * inside a code span/fence, so this never blanks the genuine heading.
+ */
+export function parseSuppressedCommentCount(body) {
+  if (typeof body !== 'string' || body.length === 0) return 0;
+  const match = stripMarkdownCodeRegions(body).match(
+    SUPPRESSED_COMMENTS_HEADING_PATTERN,
+  );
+  if (!match) return 0;
+  const count = Number(match[1]);
+  return Number.isFinite(count) ? count : 0;
+}
+/**
+ * `true` when `author` is a verified Copilot (or the configured primary
+ * bot login)-authored review/comment -- reuses `isCopilotReviewerLogin`
+ * (protocol-helpers.mts) for the login match itself (the exact,
+ * lookalike-resistant comparison #1686 hardened), plus (when the payload
+ * carries it) a `__typename === 'Bot'` check so a same-named `User`
+ * account cannot masquerade as the trusted bot even if it somehow matched
+ * the login. A payload that omits `__typename` is treated as "unknown",
+ * never as a rejection, since not every GraphQL query in this codebase
+ * selects that field.
+ */
+export function isVerifiedCopilotAuthor(author, primaryBotLogin) {
+  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
+    return false;
+  }
+  const typename = author?.__typename;
+  return typename === undefined || typename === null || typename === 'Bot';
+}
+/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
+ * per the issue's literal wording ("the latest Copilot review's commit_id
+ * equals current HEAD"), not "the latest review among those that happen to
+ * target current HEAD". Those two differ when Copilot's most recent
+ * activity targets a commit other than the current HEAD (e.g. an unusual
+ * force-push/revert ordering, see PR #1343 review): only looking within
+ * on-HEAD reviews could report `matchesHead: true` off a stale earlier
+ * review while ignoring what Copilot's true latest signal actually says.
+ * This simpler form still correctly handles a legitimate re-request
+ * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
+ * later review supersedes an earlier dirty one on the *same* commit): the
+ * absolute latest naturally IS that later, superseding review when both
+ * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
+ * GitHub's GraphQL `reviews` connection returns reviews in submission
+ * order -- this deliberately does NOT sort by `submittedAt`, since that
+ * field is nullable and could otherwise let an earlier, differently-
+ * ordered review win by comparator accident. */
+export function resolveLatestCopilotReviewClause(
+  reviews,
+  prHeadSha,
+  primaryBotLogin,
+) {
+  const latest = reviews
+    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
+    .at(-1);
+  if (!latest) {
+    return {
+      found: false,
+      commitId: '',
+      matchesHead: false,
+      itemCount: null,
+      submittedAt: '',
+      suppressedCount: 0,
+      satisfied: false,
+    };
+  }
+  const commitId = String(latest.commitId ?? '').toLowerCase();
+  const matchesHead = commitId === prHeadSha;
+  const itemCount = matchesHead
+    ? Number.isFinite(latest.itemCount)
+      ? Number(latest.itemCount)
+      : null
+    : null;
+  // #1880: gated by `matchesHead`, mirroring `itemCount` above -- moot for
+  // `satisfied` itself (already gated by `matchesHead &&`), but keeps an
+  // off-HEAD review's report fields consistent with each other rather than
+  // parsing a body this clause is about to ignore anyway.
+  const suppressedCount = matchesHead
+    ? parseSuppressedCommentCount(latest.body)
+    : 0;
+  return {
+    found: true,
+    commitId,
+    matchesHead,
+    itemCount,
+    submittedAt: String(latest.submittedAt ?? ''),
+    suppressedCount,
+    satisfied: matchesHead && itemCount === 0 && suppressedCount === 0,
+  };
+}
+/**
+ * Fetch every PR review (paginated) plus the current HEAD commit's
+ * `committedDate`, via the same GraphQL query `advisory-convergence.mts`'s
+ * own Clause 1 evidence collection has always used.
+ */
+export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
+  const nodes = [];
+  let headCommittedAt = '';
+  let cursor = null;
+  // Paginate `reviews`: a PR with more than one page of reviews would
+  // otherwise silently evaluate Clause 1 against only the first 100,
+  // potentially missing a later, dirty, current-HEAD review (see PR #1343
+  // review). `commits(last: 1)` is fetched once, on the first page, since
+  // it never changes across pages.
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  commit { oid }
+                  submittedAt
+                  author { login __typename }
+                  comments { totalCount }
+                  body
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
+              }
+            }
+          }
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    const pullRequest = payload?.data?.repository?.pullRequest;
+    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+    if (!headCommittedAt) {
+      headCommittedAt = String(
+        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+      );
+    }
+    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
+    if (!pullRequest.reviews.pageInfo.endCursor) {
+      throw new Error('review pagination payload is missing endCursor');
+    }
+    cursor = pullRequest.reviews.pageInfo.endCursor;
+  }
+  const reviews = nodes.map((node) => ({
+    author: node.author ?? null,
+    submittedAt: node.submittedAt ?? null,
+    commitId: node.commit?.oid ?? null,
+    itemCount: node.comments?.totalCount ?? null,
+    body: node.body ?? null,
+  }));
+  return { reviews, headCommittedAt };
+}

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/review-disposition-verify.mts
+//
+// The scripts/review-disposition-verify.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+import { parseCliArgs } from './cli-args.mjs';
+
+// Tolerate a single interior punctuation char `[.!:]` before the closing `**`
+// (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
+// required `\s+—` separator (whitespace before the em-dash; nothing after it is
+// enforced). Bounded so an interior-text body is not matched — mirrors the
+// disposition-marker predicates in protocol-helpers.mts.
+const MARKER_ACCEPTED_RE = /^\*\*Accepted[.!:]?\*\*\s+—/;
+const MARKER_REJECTED_RE = /^\*\*Rejected[.!:]?\*\*\s+—/;
+const MARKER_REJECTION_CONFIRMED_RE =
+  /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
+const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `items:`), per cli-args.mts's key-shape invariant -- parseCliArgs itself
+// rejects a bare key at runtime via NODE_OPTION_KEY_PATTERN. `--items` is
+// local to this file (not one of tests/flag-name-matrix.test.mts's shared
+// cross-helper flag concepts), so that guard is the only enforcement here.
+// Declared above the import.meta.main trigger below (not alongside
+// parseArgs further down) because the trigger calls parseArgs()
+// synchronously at module-evaluation time, and a `const` declared after
+// that point is still in the temporal dead zone
+// when the trigger fires (see #1177's entry-order TDZ hardening for the
+// same class of bug).
+const REVIEW_DISPOSITION_VERIFY_FLAG_SPEC = {
+  '--items': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.items === null) {
+    throw new Error('--items is required');
+  }
+  let rawItems;
+  try {
+    const parsed = JSON.parse(args.items);
+    if (Array.isArray(parsed)) {
+      rawItems = parsed;
+    } else if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'items' in parsed
+    ) {
+      const itemsField = parsed.items;
+      if (itemsField === null) {
+        throw new Error(
+          "--items JSON object has 'items: null'; expected an array",
+        );
+      }
+      rawItems = itemsField ?? [];
+    } else {
+      throw new Error("--items JSON object must have an 'items' key");
+    }
+  } catch (err) {
+    if (err.message.includes('--items')) {
+      throw err;
+    }
+    throw new Error(
+      "--items must be a valid JSON array or object with an 'items' key",
+    );
+  }
+  const result = verifyDispositions(rawItems);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+/**
+ * Verify E7 disposition evidence for a set of ReviewItems_snapshot items.
+ */
+export function verifyDispositions(items) {
+  if (!Array.isArray(items)) {
+    throw new TypeError('items must be an array');
+  }
+  if (items.length === 0) {
+    return {
+      passed: true,
+      summary: 'No items to verify.',
+      totalCount: 0,
+      passedCount: 0,
+      failedCount: 0,
+      items: [],
+    };
+  }
+  const results = items.map((item) => {
+    const normalized = normalizeItem(item);
+    if (normalized.path === 'A') {
+      return checkPathAItem(normalized);
+    }
+    if (normalized.path === 'B') {
+      return checkPathBItem(normalized);
+    }
+    return {
+      id: normalized.id,
+      path: normalized.path,
+      checks: {
+        decisionRecorded: false,
+        markerPresent: null,
+        markerMatchesDecision: null,
+        threadResolutionCorrect: null,
+      },
+      passed: false,
+      issues: [
+        `Unknown path value: ${JSON.stringify(normalized.path)}. Expected "A" or "B".`,
+      ],
+    };
+  });
+  const passedCount = results.filter((r) => r.passed).length;
+  const failedCount = results.length - passedCount;
+  const passed = failedCount === 0;
+  const summary = passed
+    ? `All ${results.length} item${results.length === 1 ? '' : 's'} verified.`
+    : `${failedCount} of ${results.length} item${results.length === 1 ? '' : 's'} failed E7 verification.`;
+  return {
+    passed,
+    summary,
+    totalCount: results.length,
+    passedCount,
+    failedCount,
+    items: results,
+  };
+}
+/**
+ * Classify a disposition marker reply.
+ * Returns "accepted" | "rejected" | "awaiting_maintainer" | null.
+ */
+export function classifyMarker(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    return null;
+  }
+  const trimmed = text.trim();
+  if (MARKER_ACCEPTED_RE.test(trimmed)) {
+    return 'accepted';
+  }
+  if (
+    MARKER_REJECTED_RE.test(trimmed) ||
+    MARKER_REJECTION_CONFIRMED_RE.test(trimmed)
+  ) {
+    return 'rejected';
+  }
+  if (MARKER_AMD_RE.test(trimmed)) {
+    return 'awaiting_maintainer';
+  }
+  return null;
+}
+/**
+ * Verify a PATH A item per E7 rules.
+ */
+export function checkPathAItem(item) {
+  const normalized = normalizeItem(item);
+  const { id, type, decision, markerReply, threadResolved } = normalized;
+  const checks = {
+    decisionRecorded: false,
+    markerPresent: null,
+    markerMatchesDecision: null,
+    threadResolutionCorrect: null,
+  };
+  const issues = [];
+  const validDecisions = new Set([
+    'accepted',
+    'rejected',
+    'awaiting_maintainer',
+  ]);
+  if (decision === null) {
+    checks.decisionRecorded = false;
+    issues.push('PATH A item has no recorded decision (null).');
+    return makeResult(id, 'A', checks, issues);
+  }
+  if (!validDecisions.has(decision)) {
+    checks.decisionRecorded = false;
+    issues.push(`Unknown decision value: ${JSON.stringify(decision)}.`);
+    return makeResult(id, 'A', checks, issues);
+  }
+  checks.decisionRecorded = true;
+  if (decision === 'accepted') {
+    return makeResult(id, 'A', checks, issues);
+  }
+  const markerType = classifyMarker(markerReply ?? '');
+  if (decision === 'rejected') {
+    const markerPresent = markerType === 'rejected';
+    checks.markerPresent = markerPresent;
+    checks.markerMatchesDecision = markerPresent;
+    if (!markerPresent) {
+      issues.push(
+        'PATH A Rejected item is missing the required `**Rejected** — {reason}` marker reply.',
+      );
+    }
+    if (type === 'review_thread') {
+      const resolutionCorrect = threadResolved === true;
+      checks.threadResolutionCorrect = resolutionCorrect;
+      if (!resolutionCorrect) {
+        issues.push(
+          'PATH A Rejected review_thread must be resolved after posting the rejection reply.',
+        );
+      }
+    } else {
+      if (threadResolved !== null) {
+        checks.threadResolutionCorrect = false;
+        issues.push(
+          `Non-thread item (type: ${type}) has unexpected non-null threadResolved: ${JSON.stringify(threadResolved)}.`,
+        );
+      } else {
+        checks.threadResolutionCorrect = true;
+      }
+    }
+    return makeResult(id, 'A', checks, issues);
+  }
+  if (decision === 'awaiting_maintainer') {
+    const markerPresent = markerType === 'awaiting_maintainer';
+    checks.markerPresent = markerPresent;
+    checks.markerMatchesDecision = markerPresent;
+    if (!markerPresent) {
+      issues.push(
+        'PATH A AMD item is missing the required `**Awaiting maintainer decision** — {reasoning}` marker reply.',
+      );
+    }
+    if (type === 'review_thread') {
+      const resolutionCorrect = threadResolved === false;
+      checks.threadResolutionCorrect = resolutionCorrect;
+      if (!resolutionCorrect) {
+        issues.push(
+          'PATH A AMD review_thread must NOT be resolved (leave unresolved so F2 gate blocks merge).',
+        );
+      }
+    } else {
+      if (threadResolved !== null) {
+        checks.threadResolutionCorrect = false;
+        issues.push(
+          `Non-thread AMD item (type: ${type}) has unexpected non-null threadResolved: ${JSON.stringify(threadResolved)}.`,
+        );
+      } else {
+        checks.threadResolutionCorrect = true;
+      }
+    }
+    return makeResult(id, 'A', checks, issues);
+  }
+  return makeResult(id, 'A', checks, issues);
+}
+/**
+ * Verify a PATH B item per E7 rules.
+ */
+export function checkPathBItem(item) {
+  const normalized = normalizeItem(item);
+  const { id, type, decision, markerReply, threadResolved } = normalized;
+  const checks = {
+    decisionRecorded: false,
+    markerPresent: null,
+    markerMatchesDecision: null,
+    threadResolutionCorrect: null,
+  };
+  const issues = [];
+  const validDecisions = new Set(['accepted', 'rejected']);
+  if (decision === null) {
+    checks.decisionRecorded = false;
+    issues.push('PATH B item has no recorded decision (null).');
+    return makeResult(id, 'B', checks, issues);
+  }
+  if (!validDecisions.has(decision)) {
+    checks.decisionRecorded = false;
+    issues.push(
+      `PATH B decision must be "accepted" or "rejected"; got: ${JSON.stringify(decision)}.`,
+    );
+    return makeResult(id, 'B', checks, issues);
+  }
+  checks.decisionRecorded = true;
+  const markerType = classifyMarker(markerReply ?? '');
+  const markerPresent = markerType === 'accepted' || markerType === 'rejected';
+  const markerMatchesDecision = markerType === decision;
+  checks.markerPresent = markerPresent;
+  checks.markerMatchesDecision = markerMatchesDecision;
+  if (!markerPresent) {
+    issues.push(
+      'PATH B item is missing the required `**Accepted** — ...` or `**Rejected** — ...` marker reply.',
+    );
+  } else if (!markerMatchesDecision) {
+    issues.push(
+      `PATH B marker type (${markerType}) does not match recorded decision (${decision}).`,
+    );
+  }
+  if (type === 'review_thread') {
+    const resolutionCorrect = threadResolved === true;
+    checks.threadResolutionCorrect = resolutionCorrect;
+    if (!resolutionCorrect) {
+      issues.push(
+        'PATH B review_thread must be resolved immediately after posting the marker.',
+      );
+    }
+  } else {
+    if (threadResolved !== null) {
+      checks.threadResolutionCorrect = false;
+      issues.push(
+        `Non-thread PATH B item (type: ${type}) has unexpected non-null threadResolved: ${JSON.stringify(threadResolved)}.`,
+      );
+    } else {
+      checks.threadResolutionCorrect = true;
+    }
+  }
+  return makeResult(id, 'B', checks, issues);
+}
+function makeResult(id, path, checks, issues) {
+  return {
+    id,
+    path,
+    checks,
+    passed: issues.length === 0,
+    issues,
+  };
+}
+function normalizeItem(item) {
+  const it = item ?? {};
+  return {
+    id: String(it.id ?? ''),
+    path: typeof it.path === 'string' ? it.path.toUpperCase() : it.path,
+    type: typeof it.type === 'string' ? it.type : null,
+    decision:
+      typeof it.decision === 'string' ? it.decision.toLowerCase() : null,
+    markerReply: typeof it.markerReply === 'string' ? it.markerReply : null,
+    threadResolved:
+      it.threadResolved === true
+        ? true
+        : it.threadResolved === false
+          ? false
+          : null,
+  };
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    REVIEW_DISPOSITION_VERIFY_FLAG_SPEC,
+  );
+  return {
+    items: values.items ?? null,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/review-disposition-verify.mjs --items '<json>' [--help]
+
+Input: JSON array of items or object with an 'items' key.
+
+Item shape:
+{
+  "id": "string",
+  "path": "A" | "B",
+  "type": "review_thread" | "regular_comment" | "changes_requested" | "critique_finding",
+  "decision": "accepted" | "rejected" | "awaiting_maintainer" | null,
+  "markerReply": "string | null",
+  "threadResolved": true | false | null
+}
+
+Output schema:
+{
+  "passed": true,
+  "summary": "All 3 items verified.",
+  "totalCount": 3,
+  "passedCount": 3,
+  "failedCount": 0,
+  "items": [{
+    "id": "...",
+    "path": "A",
+    "checks": {
+      "decisionRecorded": true,
+      "markerPresent": true,
+      "markerMatchesDecision": true,
+      "threadResolutionCorrect": true
+    },
+    "passed": true,
+    "issues": []
+  }]
+}
+`);
+}

--- a/scripts/select-desynced-index.mjs
+++ b/scripts/select-desynced-index.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/select-desynced-index.mts
+//
+// The scripts/select-desynced-index.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Deterministic, network-free CLI wrapper for the A4 Step 2
+// concurrent-selection desync index (`discover.selectionDesync:
+// session-offset` in `.github/instructions/idd-discover.instructions.md`).
+//
+// Delegates to the existing `selectDesyncedIndex` in `policy-helpers.mts`
+// rather than reimplementing the FNV-1a hash, so the CLI and the library
+// function can never drift. The written formula in the instructions remains
+// the canonical spec and fallback; this helper only removes the ad hoc
+// `node -e` hand-transcription error surface that motivated this issue.
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
+import { selectDesyncedIndex } from './policy-helpers.mjs';
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `token:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --band-size spec
+// key below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see #1177's entry-order TDZ hardening for the same class
+// of bug in this file).
+const SELECT_DESYNCED_INDEX_FLAG_SPEC = {
+  '--token': { type: 'string' },
+  '--band-size': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  // The CLI layer validates strictly on purpose: selectDesyncedIndex itself
+  // returns 0 for any invalid input (safe default for internal callers), but
+  // a CLI invocation with a missing token or a non-positive band size is
+  // almost always an operator/caller mistake that should fail loudly rather
+  // than silently print 0. An empty-string token (e.g. `--token "$VAR"` with
+  // an unset $VAR) is treated the same as a missing flag for this reason:
+  // otherwise it would silently degrade to the same output as `off`/no-tie
+  // instead of surfacing the caller's mistake.
+  if (args.token === null || args.token === '') {
+    throw new Error('--token is required');
+  }
+  if (args.bandSize === null) {
+    throw new Error('--band-size is required and must be a positive integer');
+  }
+  process.stdout.write(`${selectDesyncedIndex(args.token, args.bandSize)}\n`);
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, SELECT_DESYNCED_INDEX_FLAG_SPEC);
+  return {
+    token: values.token ?? null,
+    bandSize: parseCanonicalIntegerOrNull(values['band-size']),
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/select-desynced-index.mjs --token <session-token> --band-size <n>
+
+Prints the deterministic band index chosen by the A4 Step 2
+concurrent-selection desync rule (\`discover.selectionDesync:
+session-offset\`) for the given session token and same-score tie-band
+size, delegating to \`selectDesyncedIndex\` (a pure FNV-1a 32-bit hash mod
+band size). Deterministic and network-free.
+
+Example:
+  node scripts/select-desynced-index.mjs --token claude-loop-2 --band-size 5
+  => 4
+`);
+}

--- a/scripts/stalled-session-quiet-check.mjs
+++ b/scripts/stalled-session-quiet-check.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/stalled-session-quiet-check.mts
+//
+// The scripts/stalled-session-quiet-check.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+} from './gh-exec.mjs';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+
+const DEFAULT_QUIET_WINDOW_MS = 30 * 60 * 1000;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const STALLED_SESSION_QUIET_CHECK_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--token': { type: 'string' },
+  '--now': { type: 'string' },
+  '--quiet-window-ms': { type: 'string' },
+  '--claim-created-at': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * Evaluate whether a quiet window has been met for stalled-session detection.
+ *
+ * A quiet window is met when no externally observable progress appears
+ * in the window `[now - quietWindowMs, now]`. Activities of type
+ * `ci-running` represent currently-running CI and always break the window
+ * regardless of timestamp.
+ */
+export function evaluateQuietWindow(input) {
+  const inp = input;
+  const now = normalizeIso(inp?.now);
+  if (!now) {
+    throw new TypeError('input.now must be a valid ISO8601 timestamp');
+  }
+  const quietWindowMs = resolveQuietWindowMs(inp?.quietWindowMs);
+  const windowStart = new Date(Date.parse(now) - quietWindowMs)
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+  const activities = normalizeActivities(inp?.activities);
+  const blocking = [];
+  for (const activity of activities) {
+    if (activity.type === 'ci-running') {
+      blocking.push(activity);
+      continue;
+    }
+    if (
+      activity.timestamp &&
+      compareIso(activity.timestamp, windowStart) >= 0
+    ) {
+      blocking.push(activity);
+    }
+  }
+  const latestBlocking =
+    blocking.length > 0
+      ? blocking.reduce((latest, act) => {
+          if (!latest) return act;
+          if (act.type === 'ci-running' && latest.type !== 'ci-running')
+            return act;
+          if (latest.type === 'ci-running' && act.type !== 'ci-running')
+            return latest;
+          return compareIso(act.timestamp, latest.timestamp) > 0 ? act : latest;
+        }, null)
+      : null;
+  const quietWindowMet = blocking.length === 0;
+  const reason = quietWindowMet
+    ? 'no-activity-in-window'
+    : buildReason(blocking);
+  return {
+    quiet_window_met: quietWindowMet,
+    quiet_window_ms: quietWindowMs,
+    window_start: windowStart,
+    now,
+    latest_activity: latestBlocking?.timestamp ?? null,
+    latest_activity_type: latestBlocking?.type ?? null,
+    reason,
+    evidence: {
+      activity_count_in_window: blocking.length,
+      blocking_activities: blocking,
+      has_heartbeat_in_window: blocking.some((a) => a.type === 'heartbeat'),
+      has_ci_running: blocking.some((a) => a.type === 'ci-running'),
+      has_branch_tip_movement: blocking.some(
+        (a) => a.type === 'branch-tip-movement',
+      ),
+    },
+  };
+}
+function buildReason(blocking) {
+  const types = [...new Set(blocking.map((a) => a.type))];
+  return `activity-in-window: ${types.join(', ')}`;
+}
+function resolveQuietWindowMs(value) {
+  if (value === null || value === undefined) {
+    return DEFAULT_QUIET_WINDOW_MS;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_QUIET_WINDOW_MS;
+  }
+  return Math.floor(parsed);
+}
+function normalizeActivities(raw) {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((item) => ({
+      type: String(item?.type ?? ''),
+      timestamp: normalizeIso(item?.timestamp),
+    }))
+    .filter((item) => {
+      if (!item.type) return false;
+      if (item.type === 'ci-running') return true;
+      return item.timestamp !== null;
+    });
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.pr === null || !Number.isInteger(args.pr) || args.pr <= 0) {
+    throw new Error('--pr is required and must be a positive integer');
+  }
+  if (args.token) {
+    process.env.GH_TOKEN = args.token;
+    process.env.GITHUB_TOKEN = args.token;
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repository = `${owner}/${repo}`;
+  const now = args.now || new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const quietWindowMs =
+    args.quietWindowMs > 0
+      ? args.quietWindowMs
+      : resolveWindowFromPolicy(args.policy);
+  const claimCreatedAt = args.claimCreatedAt || null;
+  const activities = collectActivities({
+    repository,
+    pr: args.pr,
+    now,
+    claimCreatedAt,
+  });
+  const input = { now, quietWindowMs, activities };
+  const result = evaluateQuietWindow(input);
+  const pr = ghJson([
+    'api',
+    `repos/${repository}/pulls/${args.pr}`,
+    '--jq',
+    '{number: .number, title: .title, head_sha: .head.sha, html_url: .html_url}',
+  ]);
+  const output = {
+    repository: { owner, repo },
+    pr: {
+      number: Number(pr.number),
+      title: String(pr.title ?? ''),
+      head_sha: String(pr.head_sha ?? ''),
+      html_url: String(pr.html_url ?? ''),
+    },
+    policy: {
+      quiet_window_ms: quietWindowMs,
+      claim_created_at: claimCreatedAt,
+    },
+    ...result,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+function collectActivities({ repository, pr, now, claimCreatedAt }) {
+  const activities = [];
+  const prData = ghJson([
+    'api',
+    `repos/${repository}/pulls/${pr}`,
+    '--jq',
+    '{head_sha: .head.sha, merged_at: .merged_at}',
+  ]);
+  const headSha = prData.head_sha;
+  if (headSha) {
+    // Fetch head commit timestamp for branch-tip-movement. Prefer the
+    // committer date over the author date: the committer date is refreshed
+    // whenever the commit is (re)created — including rebase, cherry-pick,
+    // and amend — so it tracks when the commit was last placed on the
+    // branch, whereas the author date preserves the original authorship
+    // time and can be arbitrarily old. A recent push of an older-authored
+    // commit would otherwise look stale and falsely satisfy the quiet
+    // window. (Both are Git commit-object fields, not server timestamps.)
+    const headCommit = ghJson([
+      'api',
+      `repos/${repository}/commits/${headSha}`,
+      '--jq',
+      '{commit_timestamp: .commit.committer.date}',
+    ]);
+    if (headCommit.commit_timestamp) {
+      activities.push({
+        type: 'branch-tip-movement',
+        timestamp: headCommit.commit_timestamp,
+      });
+    }
+  }
+  // Paginate issue comments (includes PR comments)
+  const prComments = ghPaginatedJson([
+    'api',
+    `repos/${repository}/issues/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {timestamp: .created_at}',
+  ]);
+  for (const c of prComments) {
+    activities.push({ type: 'comment', timestamp: c.timestamp });
+  }
+  // Paginate PR reviews
+  const reviews = ghPaginatedJson([
+    'api',
+    `repos/${repository}/pulls/${pr}/reviews`,
+    '--paginate',
+    '--jq',
+    '.[] | {timestamp: .submitted_at}',
+  ]);
+  for (const r of reviews) {
+    activities.push({ type: 'review', timestamp: r.timestamp });
+  }
+  // Paginate PR review comments
+  const reviewComments = ghPaginatedJson([
+    'api',
+    `repos/${repository}/pulls/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {timestamp: .created_at}',
+  ]);
+  for (const rc of reviewComments) {
+    activities.push({ type: 'comment', timestamp: rc.timestamp });
+  }
+  if (headSha) {
+    // Paginate check-runs for CI activity
+    const checkRuns = ghPaginatedJson([
+      'api',
+      `repos/${repository}/commits/${headSha}/check-runs`,
+      '--paginate',
+      '--jq',
+      '.check_runs[] | {status: .status, started_at: .started_at, completed_at: .completed_at}',
+    ]);
+    for (const run of checkRuns) {
+      if (run.status === 'queued' || run.status === 'in_progress') {
+        activities.push({ type: 'ci-running', timestamp: now });
+      } else if (run.completed_at) {
+        activities.push({ type: 'ci-completed', timestamp: run.completed_at });
+      }
+    }
+  }
+  if (claimCreatedAt) {
+    activities.push({ type: 'heartbeat', timestamp: claimCreatedAt });
+  }
+  return activities;
+}
+function resolveWindowFromPolicy(policyPath) {
+  const source = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  try {
+    const config = JSON.parse(readFileSync(source, 'utf8'));
+    return (
+      parseDurationToMs(config?.stallRecovery?.quietWindow) ??
+      DEFAULT_QUIET_WINDOW_MS
+    );
+  } catch {
+    return DEFAULT_QUIET_WINDOW_MS;
+  }
+}
+function parseDurationToMs(value) {
+  const text = String(value ?? '').trim();
+  if (!text) return null;
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(
+    text,
+  );
+  if (!match) return null;
+  const days = Number.parseInt(match[1] ?? '0', 10);
+  const hours = Number.parseInt(match[2] ?? '0', 10);
+  const minutes = Number.parseInt(match[3] ?? '0', 10);
+  const seconds = Number.parseInt(match[4] ?? '0', 10);
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    STALLED_SESSION_QUIET_CHECK_FLAG_SPEC,
+  );
+  const prToken = values.pr;
+  const quietWindowMsToken = values['quiet-window-ms'];
+  return {
+    // Both --pr and --quiet-window-ms are kept as lenient Number.parseInt
+    // (not the canonical-integer helper), matching the pre-migration
+    // contract exactly: --pr is re-validated by this file's own
+    // "!Number.isInteger(args.pr) || args.pr <= 0" post-check (in runCli,
+    // unchanged), and --quiet-window-ms already flows through
+    // resolveQuietWindowMs()'s own fail-safe (falls back to
+    // DEFAULT_QUIET_WINDOW_MS on any non-finite / non-positive value) --
+    // tightening either at this layer would be an untested, out-of-scope
+    // behavior change for this behavior-preserving migration (see #1451).
+    pr: prToken === undefined ? null : Number.parseInt(prToken, 10),
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    token: values.token ?? '',
+    now: values.now ?? '',
+    quietWindowMs:
+      quietWindowMsToken === undefined
+        ? 0
+        : Number.parseInt(quietWindowMsToken, 10),
+    claimCreatedAt: values['claim-created-at'] ?? '',
+    policy: values.policy ?? '',
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/stalled-session-quiet-check.mjs --pr <number> [--owner <owner>] [--repo <repo>]
+    [--token <token>] [--now <ISO8601>] [--quiet-window-ms <ms>]
+    [--claim-created-at <ISO8601>] [--policy <path>]
+
+Evaluates the S2 quiet-window check for stalled-session detection.
+Outputs JSON with quiet_window_met and evidence fields.
+`);
+}
+function normalizeIso(value) {
+  if (!value) return null;
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+function compareIso(left, right) {
+  const leftTime = Date.parse(String(left ?? ''));
+  const rightTime = Date.parse(String(right ?? ''));
+  if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) return 0;
+  return leftTime - rightTime;
+}
+function ghJson(args) {
+  return JSON.parse(runGh(args).trim() || 'null') ?? [];
+}
+/**
+ * Run a `gh api ... --paginate --jq <program>` call and parse its output as
+ * NDJSON (#1692). `<program>` must stream individual values per page (e.g.
+ * `.[] | {...}` or `.check_runs[] | {...}`), not wrap them back into a
+ * per-page array (`[.[] | {...}]`) -- the latter made `gh --paginate` emit
+ * one JSON array per page, which this file's prior single whole-stdout
+ * `JSON.parse` (via `ghJson`) could not parse once there was more than one
+ * page. Matches the shared NDJSON convention `gh-exec.mts`'s `ghApiJson`
+ * already uses.
+ *
+ * Requires `args` to already include `--paginate` and `--jq` (Copilot
+ * review on PR #1763): a call site missing either flag would still parse
+ * without error -- `--jq`-less output as a single JSON.parse of one big
+ * value, or non-paginated output as a trivially "one item" NDJSON stream --
+ * silently returning only a first page or a wrong shape instead of failing
+ * loudly. Every current call site already passes both; this only guards
+ * against a future call site accidentally dropping one.
+ */
+function ghPaginatedJson(args) {
+  if (!args.includes('--paginate') || !args.includes('--jq')) {
+    throw new Error(
+      `ghPaginatedJson requires both --paginate and --jq in args, got: ${args.join(' ')}`,
+    );
+  }
+  return parsePaginatedGhNdjson(runGh(args));
+}
+function runGh(args) {
+  try {
+    return ghText(args, {
+      ...GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ...(args.includes('--paginate')
+        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
+        : {}),
+    });
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) throw new Error(`gh command failed: ${stderr}`);
+    throw error;
+  }
+}

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1,0 +1,1533 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/suitability-triage.mts
+//
+// The scripts/suitability-triage.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_BUNDLE_IDS,
+  DEFAULT_MANIFEST_PATH,
+  ghJson as ghJsonArray,
+  parseCandidateFiles,
+  resolveHighContentionFiles,
+} from './discover-shared-file-overlap.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import {
+  findMarkdownCodeRanges,
+  getMarkdownCodeRange,
+  maskMarkdownCodeRegionsPreservingPositions,
+} from './markdown-code.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
+import {
+  buildClosedByMergedPrArgs,
+  buildMergedPrListArgs,
+  buildPrDetailArgs,
+  evaluateHighConfidenceDuplicate,
+  findCandidateFileOverlap,
+  findTrustedSuitabilityRejection,
+  prReferencesIssue,
+  resolveCandidateFileSet,
+} from './supersession-detection.mjs';
+
+/**
+ * Wall-clock budget for the #1484 merged-PR file-overlap scan (CodeRabbit
+ * review finding on this PR): up to `supersession-detection.mts`'s own
+ * merged-PR-scan limit (50, mirroring B2.0's own documented `gh pr list
+ * --limit 50`) sequential `gh pr view` calls at 30s each could otherwise
+ * take ~25 minutes in the worst case (a degraded/rate-limited GitHub API).
+ * Stop early and return whatever has been collected once this budget
+ * elapses, rather than blocking the whole A4.5 evaluation on a slow scan.
+ * (#1499: that limit is baked into `buildMergedPrListArgs`'s own argv,
+ * which this file now only calls rather than builds -- this comment stays
+ * prose-only rather than importing the value, since nothing here needs it
+ * as a live binding.)
+ */
+const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --issue spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires (see ci-wait-policy.mts's identical note).
+const SUITABILITY_TRIAGE_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--token': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--policy': { type: 'string', default: '' },
+  '--manifest': { type: 'string', default: DEFAULT_MANIFEST_PATH },
+  '--bundles': { type: 'string' },
+  '--verbose': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+const CHECKS = [
+  {
+    id: 'repository_fit',
+    name: 'Repository Fit',
+    failureOutcome: 'out-of-scope',
+    evaluate: checkRepositoryFit,
+  },
+  {
+    id: 'coherence',
+    name: 'Issue Coherence',
+    failureOutcome: 'unclear',
+    evaluate: checkCoherence,
+  },
+  {
+    id: 'trust_safety',
+    name: 'Trust/Safety',
+    failureOutcome: 'invalid',
+    evaluate: checkTrustSafety,
+  },
+  {
+    id: 'duplicate_or_superseded',
+    name: 'Duplicate or Superseded Work',
+    failureOutcome: 'duplicate',
+    evaluate: checkDuplicateOrSuperseded,
+  },
+  {
+    id: 'actionability',
+    name: 'Actionability',
+    failureOutcome: 'needs-decision',
+    evaluate: checkActionability,
+  },
+  {
+    id: 'autonomy',
+    name: 'Autonomy',
+    failureOutcome: 'blocked-by-human',
+    evaluate: checkAutonomy,
+  },
+  {
+    id: 'verifiability',
+    name: 'Verifiability',
+    failureOutcome: 'needs-decision',
+    evaluate: checkVerifiability,
+  },
+];
+// cspell:ignore AKIA baprs xoxbaprs
+const SECRET_PATTERNS = [
+  /ghp_[A-Za-z0-9]{20,}/,
+  /github_pat_[A-Za-z0-9_]{20,}/,
+  /AKIA[0-9A-Z]{16}/,
+  /-----BEGIN (?:RSA|OPENSSH|EC|DSA) PRIVATE KEY-----/,
+  /xox[baprs]-[A-Za-z0-9-]{20,}/,
+];
+// Allow an optional `sudo` and/or `env VAR=val ...` prefix before the
+// shell on the right-hand side of the pipe, so `curl … | sudo bash` and
+// `curl … | env FOO=bar sh` are still detected.
+const UNSAFE_SHELL_SUFFIX = String.raw`\|\s*(?:sudo\s+|env\s+(?:\S+=\S*\s+)*)*(?:sh|bash)\b`;
+const UNSAFE_PATTERNS = [
+  new RegExp(String.raw`\bcurl\b[^\n|]*${UNSAFE_SHELL_SUFFIX}`, 'i'),
+  new RegExp(String.raw`\bwget\b[^\n|]*${UNSAFE_SHELL_SUFFIX}`, 'i'),
+  /\beval\s*\(/i,
+];
+const EXECUTION_VERB_PATTERN = /\b(run|execute|paste|install|invoke)\b/i;
+const EXTERNAL_COORDINATION_PATTERN =
+  /\b(cross-repo|cross repo|external repo|another repo|upstream change|maintainer of)\b/i;
+const EXTERNAL_SYSTEM_ACCESS_PATTERN =
+  /\b(requires?|need(?:s)?|must|depends on)\b[\s\S]{0,120}\b((?:external|third-?party|production|dashboard|workspace|console|service|system|slack|jira|datadog)[\s\S]{0,40}(?:access|credentials?|login|permission|sign-?in)|(?:access|credentials?|login|permission|sign-?in)[\s\S]{0,40}(?:external|third-?party|production|dashboard|workspace|console|service|system|slack|jira|datadog))\b/i;
+const DUPLICATE_DECLARATION_PATTERN =
+  /\b(duplicate of|superseded by)\s*(?:#\d+|https?:\/\/\S+?\/(?:issues|pull)\/\d+)\b/gi;
+const DUPLICATE_NEGATION_PATTERN = /\b(not|no|avoid)\b[\s\S]{0,30}$/i;
+const SUBJECTIVE_SUBJECT_PATTERN =
+  /\b(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)\b/i;
+const SUBJECTIVE_GATE_PATTERN = /\b(approval|sign-?off|decision|preference)\b/i;
+const OUTCOME_SIGNAL_PATTERN =
+  /\b(pass|fail|result|output|contains|include|present|required|objective|measurable|deterministic)\b/i;
+// Check 3 precision: an unsafe execution directive tells the agent to act on
+// *supplied / untrusted* content, not any command verb that merely lands near
+// the ordinary determiner "this". Match the strong untrusted-origin signals, or
+// a determiner that points at supplied content followed (within two words) by a
+// runnable-content noun ("run this script", "paste the following command").
+// Prose that documents a tool's own behavior ("run the helper; this prints the
+// body") no longer false-fires. The piped `curl … | sh`, `sudo`-wrapped
+// pipeline, and `eval(` catches stay in the separate UNSAFE_PATTERNS loop.
+const UNSAFE_DIRECTIVE_VERB = '(?:execute|run|paste|install|invoke)';
+const SUPPLIED_CONTENT_NOUN =
+  '(?:command|script|code|snippet|payload|url|link|instruction|input|file|attachment|gist|one-?liner|program|binary|shell)s?';
+// `[\x60'"]?` (an optional backtick / quote, written hex so it can live inside
+// a String.raw template) lets the noun be wrapped in inline code, so
+// "run this `script`" is still caught.
+const SUPPLIED_CONTENT_REFERENCE = String.raw`(?:this|that|following|attached|pasted|provided|the\s+(?:following|above|below|attached|pasted|provided))\s+(?:\S+\s+){0,2}?[\x60'"]?${SUPPLIED_CONTENT_NOUN}`;
+const EXPLICIT_UNSAFE_DIRECTIVE_PATTERN = new RegExp(
+  String.raw`\b${UNSAFE_DIRECTIVE_VERB}\b[\s\S]{0,100}\b(?:untrusted|user-provided|user input|(?:from|by)\s+(?:the\s+)?user|${SUPPLIED_CONTENT_REFERENCE})\b`,
+  'i',
+);
+const NEGATION_PATTERN =
+  /\b(not|no|don'?t|doesn'?t|can'?t|won'?t|never|avoid|skip|omit|ignore|exempt)\b/i;
+const POLICY_OVERRIDE_PATTERN =
+  /\b(ignore|bypass|override|disable|disable|skip|turn off|suppress|disable)\b[\s\S]{0,60}\b(repo|repository|policy|workflow|idd|process|check|gate|requirement)\b/i;
+const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
+// A heading line such as "## Decision (resolved 2026-06-27)" records that a
+// human has already ruled on the issue's open question (see Check 7). The
+// negative lookahead rejects only a still-open *phrase* that directly negates
+// "resolved" ("not [yet] [been] resolved", "to be resolved", "never [been]
+// resolved"), so an unrelated negator elsewhere on the line — e.g. "Decision
+// (not user-facing; resolved 2026-06-27)" — still counts as resolved. A
+// lookahead (not a variable-length lookbehind) keeps the assertion portable
+// across JavaScript regex engines.
+const RESOLVED_DECISION_PATTERN =
+  /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
+function findPolicyOverrideMatch(text, maskedText, getCodeRangeAt) {
+  const maskedMatch = POLICY_OVERRIDE_PATTERN.exec(maskedText);
+  if (maskedMatch?.index !== undefined) {
+    return {
+      index: maskedMatch.index,
+      text: text.slice(
+        maskedMatch.index,
+        maskedMatch.index + maskedMatch[0].length,
+      ),
+    };
+  }
+  // A real directive may wrap one of its tokens in inline code. The masked
+  // pass intentionally removes that token, so inspect raw matches as a
+  // fallback and retain only matches that are not wholly inside code.
+  const pattern = new RegExp(POLICY_OVERRIDE_PATTERN.source, 'gi');
+  let match;
+  while (true) {
+    match = pattern.exec(text);
+    if (match === null) {
+      break;
+    }
+    const index = match.index ?? -1;
+    if (index < 0) {
+      continue;
+    }
+    const end = index + match[0].length;
+    const codeRange = getCodeRangeAt(index);
+    if (codeRange) {
+      const codeOnlyMatch = POLICY_OVERRIDE_PATTERN.exec(
+        text.slice(index, codeRange.end),
+      );
+      if (codeOnlyMatch?.index === 0) {
+        // The raw pattern may greedily span a code-only occurrence and a
+        // later prose occurrence. Resume just after the inert occurrence, not
+        // the entire code range: a later trigger in the same code span may
+        // still form a cross-boundary match with visible prose after it.
+        pattern.lastIndex = index + codeOnlyMatch[0].length;
+        continue;
+      }
+    }
+    let sawMaskedCharacter = false;
+    let fullyMasked = true;
+    for (let cursor = index; cursor < end; cursor += 1) {
+      const rawCharacter = text[cursor];
+      if (
+        rawCharacter !== '\n' &&
+        rawCharacter !== '\r' &&
+        /\S/u.test(rawCharacter ?? '')
+      ) {
+        if (maskedText[cursor] !== ' ') {
+          fullyMasked = false;
+          break;
+        }
+        sawMaskedCharacter = true;
+      }
+    }
+    if (
+      !fullyMasked ||
+      !sawMaskedCharacter ||
+      !codeRange ||
+      codeRange.start > index ||
+      end > codeRange.end
+    ) {
+      return { index, text: match[0] };
+    }
+  }
+  return null;
+}
+if (import.meta.main) {
+  runCli();
+}
+export function evaluateSuitability(issue, options = {}) {
+  const normalized = normalizeIssue(issue);
+  const context = {
+    issue: normalized,
+    repository: normalizeRepository(options.repository),
+    duplicateCandidates: normalizeDuplicateCandidates(
+      options.duplicateCandidates,
+    ),
+    trustSafetyAmbiguous: Boolean(options.trustSafetyAmbiguous),
+    blockedByHumanLabelName: normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    needsDecisionLabelName: normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+    highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
+      options.highConfidenceDuplicate,
+    ),
+    highConfidenceCollectionDegraded: Boolean(
+      options.highConfidenceCollectionDegraded,
+    ),
+  };
+  const checks = [];
+  for (const check of CHECKS) {
+    const result = check.evaluate(context);
+    checks.push({
+      id: check.id,
+      name: check.name,
+      result: result.pass ? 'pass' : 'fail',
+      evidence: result.evidence,
+      ...(result.tier ? { tier: result.tier } : {}),
+    });
+    if (!result.pass) {
+      return {
+        passed: false,
+        outcome: check.failureOutcome,
+        failedCheck: check.id,
+        checks,
+      };
+    }
+  }
+  return {
+    passed: true,
+    outcome: 'ready',
+    failedCheck: null,
+    checks,
+  };
+}
+export function checkRepositoryFit(context) {
+  const { issue, repository } = context;
+  if (!repository) {
+    return {
+      pass: true,
+      evidence: 'Repository scope was not provided; check treated as pass.',
+    };
+  }
+  const body = issue.body;
+  const crossRepoLinks = [];
+  const regex =
+    /https?:\/\/github\.com\/([^/\s]+)\/([^/\s#?]+)\/(?:issues|pull)\/\d+/gi;
+  let match = regex.exec(body);
+  while (match) {
+    const owner = (match[1] ?? '').toLowerCase();
+    const repo = (match[2] ?? '').toLowerCase();
+    if (owner !== repository.owner || repo !== repository.repo) {
+      crossRepoLinks.push(match[0]);
+    }
+    match = regex.exec(body);
+  }
+  if (crossRepoLinks.length > 0 && EXTERNAL_COORDINATION_PATTERN.test(body)) {
+    return {
+      pass: false,
+      evidence: `Cross-repository references detected: ${crossRepoLinks.join(', ')}`,
+    };
+  }
+  for (const match of body.matchAll(
+    new RegExp(EXTERNAL_SYSTEM_ACCESS_PATTERN.source, 'gi'),
+  )) {
+    const matchIndex = match.index ?? 0;
+    const matchText = match[0] ?? '';
+    const contextBefore = body.slice(Math.max(0, matchIndex - 60), matchIndex);
+    // Skip a negated non-requirement; only an un-negated external-access
+    // requirement blocks Repository Fit. The negation may sit *before* the
+    // match ("does **not** require production credentials") or *after* the
+    // requirement verb inside the match ("requires **no** production
+    // credentials").
+    const negatedRequirement =
+      /\b(?:requires?|needs?|must|depends?\s+on)\s+(?:no|not|never|without|n['’]?t)\b/i;
+    if (
+      NEGATION_PATTERN.test(contextBefore) ||
+      negatedRequirement.test(matchText)
+    ) {
+      continue;
+    }
+    return {
+      pass: false,
+      evidence:
+        'Issue requires external system access beyond repository scope.',
+    };
+  }
+  return {
+    pass: true,
+    evidence:
+      crossRepoLinks.length > 0
+        ? 'Cross-repository links appear contextual; no explicit external coordination signal detected.'
+        : 'No out-of-repository scope signals detected.',
+  };
+}
+export function checkCoherence(context) {
+  const { issue } = context;
+  const title = issue.title.trim();
+  const body = issue.body.trim();
+  if (title.length < 5 || body.length < 20) {
+    return {
+      pass: false,
+      evidence: 'Issue title/body is too short to infer reliable intent.',
+    };
+  }
+  if (/<<<<<<<|=======|>>>>>>>/.test(body)) {
+    return {
+      pass: false,
+      evidence: 'Issue body contains unresolved conflict markers.',
+    };
+  }
+  return {
+    pass: true,
+    evidence: 'Issue body is structurally coherent and interpretable.',
+  };
+}
+export function checkTrustSafety(context) {
+  const { issue, trustSafetyAmbiguous } = context;
+  const corpus = `${issue.title}\n${issue.body}`;
+  if (trustSafetyAmbiguous) {
+    return {
+      pass: false,
+      evidence: 'Trust/safety evaluation marked ambiguous; failing closed.',
+    };
+  }
+  const matchedSecret = SECRET_PATTERNS.find((pattern) => pattern.test(corpus));
+  if (matchedSecret) {
+    return {
+      pass: false,
+      evidence: `Potential secret pattern detected: ${matchedSecret}`,
+    };
+  }
+  // Check for explicit policy-override directives. Issue titles are plain
+  // fields, not Markdown documents, so scan them raw. In the body, find the
+  // directive on raw text and ignore it only when the entire match is inside
+  // a valid Markdown code region. This keeps inert examples from firing while
+  // preserving fail-closed behavior when code formatting wraps only part of a
+  // real directive. The position-preserving mask keeps evidence offsets exact
+  // even when a fenced block precedes the match.
+  const bodyOffset = issue.title.length + 1;
+  const bodyCodeRanges = findMarkdownCodeRanges(issue.body);
+  const policyMatch = findPolicyOverrideMatch(
+    corpus,
+    `${issue.title}\n${maskMarkdownCodeRegionsPreservingPositions(issue.body, bodyCodeRanges)}`,
+    (start) => {
+      if (start < bodyOffset) {
+        return null;
+      }
+      const range = getMarkdownCodeRange(
+        issue.body,
+        start - bodyOffset,
+        bodyCodeRanges,
+      );
+      return range === null
+        ? null
+        : {
+            start: range.start + bodyOffset,
+            end: range.end + bodyOffset,
+          };
+    },
+  );
+  if (policyMatch) {
+    return {
+      pass: false,
+      evidence: `Policy-override directive detected: "${policyMatch.text}". Untrusted policy-manipulation instructions cannot be processed.`,
+    };
+  }
+  // Check for explicit unsafe execution directives
+  if (EXPLICIT_UNSAFE_DIRECTIVE_PATTERN.test(corpus)) {
+    const match = corpus.match(EXPLICIT_UNSAFE_DIRECTIVE_PATTERN);
+    return {
+      pass: false,
+      evidence: `Explicit unsafe execution directive detected: "${match?.[0] ?? ''}". Cannot execute untrusted user-provided instructions.`,
+    };
+  }
+  // Inspect every unsafe-command occurrence across all patterns, not just
+  // the first: an issue may discuss a command safely and then later direct
+  // running it. Any single occurrence with an un-negated execution directive
+  // in its local context fails the check.
+  let sawUnsafeContextOnly = false;
+  for (const pattern of UNSAFE_PATTERNS) {
+    const directivePattern = new RegExp(
+      `${EXECUTION_VERB_PATTERN.source}[\\s\\S]{0,80}${pattern.source}`,
+      'i',
+    );
+    const negatedDirectivePattern = new RegExp(
+      `\\b(do not|don't|never|avoid)\\s+(?:run|execute|paste|install|invoke)\\b[^\\n.!?]{0,60}${pattern.source}`,
+      'i',
+    );
+    for (const occurrence of corpus.matchAll(
+      new RegExp(pattern.source, 'gi'),
+    )) {
+      const unsafeIndex = occurrence.index ?? -1;
+      const matchText = occurrence[0] ?? '';
+      const contextStart = Math.max(0, unsafeIndex - 140);
+      const contextEnd = Math.min(
+        corpus.length,
+        unsafeIndex + matchText.length + 40,
+      );
+      const localContext =
+        unsafeIndex >= 0 ? corpus.slice(contextStart, contextEnd) : corpus;
+      if (
+        directivePattern.test(localContext) &&
+        !negatedDirectivePattern.test(localContext)
+      ) {
+        return {
+          pass: false,
+          evidence: `Unsafe command execution pattern detected: ${pattern}`,
+        };
+      }
+      sawUnsafeContextOnly = true;
+    }
+  }
+  if (sawUnsafeContextOnly) {
+    return {
+      pass: true,
+      evidence:
+        'Unsafe command string appears as context only; no execution directive detected.',
+    };
+  }
+  return {
+    pass: true,
+    evidence: 'No trust/safety blockers detected.',
+  };
+}
+export function checkDuplicateOrSuperseded(context) {
+  const highConfidence = evaluateHighConfidenceDuplicate(
+    context.highConfidenceDuplicate,
+    context.issue.number,
+  );
+  if (highConfidence) {
+    return highConfidence;
+  }
+  const { issue, duplicateCandidates } = context;
+  // #1484 (Codex P2 review finding): a genuine high-confidence
+  // evidence-collection failure -- not "checked, found nothing" -- degrades
+  // to exact-title matching ONLY, per the documented "Timeout on duplicate
+  // detection... fall back to exact title match only" Edge Case. Skips the
+  // free-text declaration scan and the near-duplicate fuzzy (>80%
+  // Levenshtein) check entirely: a merely similarly-titled but genuinely
+  // distinct issue must never read as a false duplicate just because
+  // evidence collection broke.
+  if (context.highConfidenceCollectionDegraded) {
+    const degradedExactTitle = normalizeText(issue.title);
+    const degradedExactMatch = duplicateCandidates.find(
+      (candidate) =>
+        candidate.number !== issue.number &&
+        normalizeText(candidate.title) === degradedExactTitle,
+    );
+    if (degradedExactMatch) {
+      return {
+        pass: false,
+        evidence: `Exact-title duplicate found: #${degradedExactMatch.number}`,
+        tier: 'weak',
+      };
+    }
+    return {
+      pass: true,
+      evidence:
+        'High-confidence evidence collection failed; degraded to exact-title match only per the documented "Timeout on duplicate detection" Edge Case. No exact-title duplicate found.',
+    };
+  }
+  const body = issue.body;
+  const declarations = [...body.matchAll(DUPLICATE_DECLARATION_PATTERN)];
+  for (const declaration of declarations) {
+    const matched = declaration[0] ?? '';
+    const index = declaration.index ?? 0;
+    const prefix = body.slice(Math.max(0, index - 30), index);
+    if (DUPLICATE_NEGATION_PATTERN.test(prefix)) {
+      continue;
+    }
+    return {
+      pass: false,
+      evidence: `Issue body declares duplicate/superseded status: ${matched}`,
+      tier: 'weak',
+    };
+  }
+  const exactTitle = normalizeText(issue.title);
+  const duplicate = duplicateCandidates.find((candidate) => {
+    if (candidate.number === issue.number) {
+      return false;
+    }
+    return normalizeText(candidate.title) === exactTitle;
+  });
+  if (duplicate) {
+    return {
+      pass: false,
+      evidence: `Exact-title duplicate found: #${duplicate.number}`,
+      tier: 'weak',
+    };
+  }
+  // Near-duplicate detection: check for high similarity (>80% Levenshtein match)
+  const nearDuplicate = duplicateCandidates.find((candidate) => {
+    if (candidate.number === issue.number) {
+      return false;
+    }
+    if (candidate.state === 'CLOSED') {
+      return false;
+    }
+    const sim = computeSimilarity(exactTitle, normalizeText(candidate.title));
+    return sim > 0.8;
+  });
+  if (nearDuplicate) {
+    return {
+      pass: false,
+      evidence: `Near-duplicate found: #${nearDuplicate.number} ("${nearDuplicate.title}"). Title similarity >80%.`,
+      tier: 'weak',
+    };
+  }
+  return {
+    pass: true,
+    evidence:
+      duplicateCandidates.length === 0
+        ? 'No duplicate candidate matched.'
+        : `Checked ${duplicateCandidates.length} duplicate candidates; no exact or near match.`,
+  };
+}
+function computeSimilarity(str1, str2) {
+  const maxLen = Math.max(str1.length, str2.length);
+  if (maxLen === 0) {
+    return 1;
+  }
+  const distance = levenshteinDistance(str1, str2);
+  return (maxLen - distance) / maxLen;
+}
+function levenshteinDistance(str1, str2) {
+  const memo = {};
+  function lev(i, j) {
+    if (i === 0) return j;
+    if (j === 0) return i;
+    const key = `${i},${j}`;
+    if (memo[key] !== undefined) return memo[key];
+    const cost = str1[i - 1] === str2[j - 1] ? 0 : 1;
+    memo[key] = Math.min(
+      lev(i - 1, j) + 1,
+      lev(i, j - 1) + 1,
+      lev(i - 1, j - 1) + cost,
+    );
+    return memo[key];
+  }
+  return lev(str1.length, str2.length);
+}
+export function checkActionability(context) {
+  const { issue } = context;
+  const body = issue.body;
+  const hasAcceptance =
+    /\bAcceptance Criteria\b|\bOutput\b|\bDeliverables\b/i.test(body);
+  const hasChecklist = /^\s*[-*]\s+\[[ xX]\]/m.test(body);
+  const hasSteps = /^\s*\d+\.\s+/m.test(body);
+  if (hasAcceptance || hasChecklist || hasSteps) {
+    return {
+      pass: true,
+      evidence:
+        'Issue defines actionable scope and verifiable delivery details.',
+    };
+  }
+  return {
+    pass: false,
+    evidence: 'Issue lacks concrete actionable scope or acceptance detail.',
+  };
+}
+export function checkAutonomy(context) {
+  const { issue } = context;
+  const labels = new Set(issue.labels);
+  const body = issue.body;
+  const blockedLabels = new Set([
+    normalizeConfiguredLabelName(
+      context.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    normalizeConfiguredLabelName(
+      context.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  ]);
+  for (const label of blockedLabels) {
+    if (labels.has(label)) {
+      return {
+        pass: false,
+        evidence: `Blocking label present: ${label}`,
+      };
+    }
+  }
+  // Negation-aware parsing for external coordination and human decision requirements
+  const coordinationMatches = [
+    ...body.matchAll(
+      /\brequires (?:maintainer|human|stakeholder) (?:decision|approval|sign-?off)\b/gi,
+    ),
+    ...body.matchAll(
+      /\bstakeholder\b[\s\S]{0,80}\b(sign-?off|approval|decision)\b/gi,
+    ),
+  ];
+  for (const match of coordinationMatches) {
+    const matchedText = match[0] ?? '';
+    const matchIndex = match.index ?? 0;
+    const contextBefore = body.slice(Math.max(0, matchIndex - 60), matchIndex);
+    const contextAfter = body.slice(
+      matchIndex + matchedText.length,
+      Math.min(body.length, matchIndex + matchedText.length + 60),
+    );
+    // Check if negated (either before or immediately after)
+    if (
+      NEGATION_PATTERN.test(contextBefore) ||
+      NEGATION_PATTERN.test(contextAfter)
+    ) {
+      // This is a negated non-requirement; skip this match
+      continue;
+    }
+    return {
+      pass: false,
+      evidence:
+        'Issue explicitly requires external human coordination or approval.',
+    };
+  }
+  return {
+    pass: true,
+    evidence: 'No external coordination blockers detected.',
+  };
+}
+export function checkVerifiability(context) {
+  const { issue } = context;
+  const body = issue.body;
+  const hasVerificationChannel =
+    /\btests?\b|\bverification\b|\bvalidate\b|\blint\b|\bci\b/i.test(body);
+  // Check for substantive objective criteria, not just empty headings
+  let hasObjectiveCriteria = false;
+  // Check for "Acceptance Criteria" with substantive content after it
+  const acceptanceCriteriaMatch = body.match(ACCEPTANCE_CRITERIA_PATTERN);
+  if (acceptanceCriteriaMatch) {
+    const indexAfter =
+      (acceptanceCriteriaMatch.index ?? 0) +
+      (acceptanceCriteriaMatch[0]?.length ?? 0);
+    const contentAfter = body.slice(indexAfter, indexAfter + 500).trim();
+    // Require either a list (starting with - or *) or numbered content with outcome signals
+    if (/^[-*]\s+/.test(contentAfter) || /^\d+\.\s+/.test(contentAfter)) {
+      const hasOutcomeSignals = OUTCOME_SIGNAL_PATTERN.test(contentAfter);
+      if (hasOutcomeSignals) {
+        hasObjectiveCriteria = true;
+      }
+    }
+  }
+  // Alternative: check for numbered steps with outcome signals or checklists
+  if (!hasObjectiveCriteria) {
+    const hasNumSteps =
+      /^\s*\d+\.\s+/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
+    const hasChecklist =
+      /^\s*[-*]\s+\[[ xX]\]/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
+    hasObjectiveCriteria = hasNumSteps || hasChecklist;
+  }
+  // Fallback: check for "Output", "Deliverables", or "Verification" keywords with signal words
+  if (!hasObjectiveCriteria) {
+    hasObjectiveCriteria =
+      /\b(?:Output|Deliverables|Verification)\b[\s\S]{0,300}(?:must|should|required|contains|includes|result)/i.test(
+        body,
+      );
+  }
+  const hasObjectiveSignals = hasVerificationChannel || hasObjectiveCriteria;
+  if (!hasObjectiveSignals) {
+    return {
+      pass: false,
+      evidence:
+        'Issue does not provide objective verification signals or substantive acceptance criteria.',
+    };
+  }
+  const hasSubjectiveApproval = (() => {
+    const lines = body.split(/\r?\n/);
+    return (
+      lines.some(
+        (line) =>
+          SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
+          SUBJECTIVE_GATE_PATTERN.test(line),
+      ) ||
+      /\b(approval|sign-?off|decision|preference)\b[\s\S]{0,80}\b(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)\b/i.test(
+        body,
+      )
+    );
+  })();
+  // A body that carries BOTH a resolved-decision marker (a
+  // "## Decision (resolved …)" section) AND a concrete, objectively-verifiable
+  // acceptance-criteria section is treated as having had its subjective call
+  // already settled by a human, so its prose merely *describes* that prior
+  // approval/decision. This is a soft heuristic for a soft advisory gate: it
+  // co-occurrence-matches the two signals rather than proving the decision
+  // resolves the exact approval wording, which is an accepted trade-off for
+  // maintainer-authored issues. An approval-gated body with no resolved
+  // decision still routes to needs-decision.
+  const hasResolvedDecision = RESOLVED_DECISION_PATTERN.test(body);
+  if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
+    return {
+      pass: false,
+      evidence: 'Issue success depends on subjective approval or judgment.',
+    };
+  }
+  return {
+    pass: true,
+    evidence:
+      'Issue includes objective verification language and substantive criteria.',
+  };
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.token) {
+    process.env.GH_TOKEN = args.token;
+    process.env.GITHUB_TOKEN = args.token;
+  }
+  const owner =
+    args.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repoRef = `${owner}/${repo}`;
+  const issue = fetchIssue(repoRef, args.issue);
+  const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
+  const policyConfig = loadPolicy(args.policy);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
+  // #1887: surface an existing, trusted `A4.5 suitability gate rejection`
+  // comment (if any) as a distinct output field, independent of the seven
+  // checks below and of the shouldCollectEvidence gate further down (that
+  // gate exists only to skip Check 4's own network-cost evidence when
+  // Checks 1-3 already fail) -- a prior trusted rejection matters
+  // regardless of which check a fresh run would fail today (the #1878
+  // scenario this issue documents: Check 7 fails fresh, but a human
+  // already ruled on it). Wrapped in its own try/catch: this is
+  // detect-only evidence, not a gate, so a transient `gh` failure here
+  // must degrade to `existingRejection: null` plus a warning, never crash
+  // the whole seven-check evaluation the way a genuine
+  // fetchIssue/fetchDuplicateCandidates failure still does.
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policyConfig,
+  });
+  const existingRejectionCollectionWarnings = [];
+  let existingRejection = null;
+  // Copilot review finding on PR #1890: findTrustedSuitabilityRejection can
+  // never return a match with zero trusted actors (it returns null before
+  // even looking at `comments`), so fetching the full, possibly-paginated
+  // comment thread in that case is guaranteed wasted `gh api` traffic with
+  // no observable benefit. Skip the fetch entirely rather than only
+  // skipping the (already-cheap) scan.
+  if (trustedMarkerActors.length > 0) {
+    try {
+      const issueComments = fetchIssueComments(repoRef, args.issue);
+      existingRejection = findTrustedSuitabilityRejection(
+        issueComments,
+        trustedMarkerActors,
+      );
+    } catch (error) {
+      existingRejectionCollectionWarnings.push(
+        `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  // #1815: repository_fit, coherence, and trust_safety are cheap, local,
+  // no-I/O checks that run before duplicate_or_superseded (Check 4) in
+  // evaluateSuitability's own CHECKS order, which short-circuits the whole
+  // 7-check loop on the first failure -- so collecting Check 4's
+  // network-heavy evidence below (closedByPullRequestsReferences, plus the
+  // up-to-50-sequential merged-PR file-overlap scan) is wasted work
+  // whenever one of the three already fails. Evaluate them here, against
+  // the same Context shape evaluateSuitability builds internally, purely to
+  // decide whether to collect that evidence at all -- evaluateSuitability
+  // below still re-runs all three (cheap, no I/O) as part of its own normal
+  // 7-check loop, so this changes only which network calls happen, never a
+  // check's pass/fail outcome (fetchDuplicateCandidates above stays eager:
+  // a single `gh api search/issues` call, not the network cost this issue
+  // targets).
+  const preEvidenceContext = {
+    issue,
+    repository: normalizeRepository({ owner, repo }),
+    duplicateCandidates: [],
+    trustSafetyAmbiguous: false,
+  };
+  const shouldCollectEvidence =
+    checkRepositoryFit(preEvidenceContext).pass &&
+    checkCoherence(preEvidenceContext).pass &&
+    checkTrustSafety(preEvidenceContext).pass;
+  // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
+  // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
+  // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
+  // finding on this PR): an earlier version wrapped both in one block, so a
+  // failure collecting the second signal discarded an already-successful
+  // first signal too. Each block's own failure is recorded independently in
+  // `collectionWarnings` and degrades only that one signal to empty/absent
+  // -- never silently reported as "no evidence" (that would mask a
+  // genuinely broken collector as a clean pass), and never discarding a
+  // sibling signal that already collected cleanly. `gh`/API fetch failures
+  // in either block are always recorded here; a manifest-unavailable
+  // same-candidate-files skip is a distinct, deliberate degradation
+  // documented on `loadHighContentionFiles` itself, not a fetch failure, so
+  // it is not added to this list (Copilot review finding on this PR: an
+  // earlier comment overclaimed that every degradation path surfaces here).
+  // This is also why an uncaught failure no longer aborts the entire
+  // 7-check evaluation (Codex review finding on this PR) -- this tier is an
+  // optional enhancement layered onto Check 4, and Check 4's own documented
+  // Edge Case ("Timeout on duplicate detection... fall back to exact title
+  // match only") already anticipates exactly this degradation. Both blocks
+  // below run only when `shouldCollectEvidence` is true (#1815) -- when it
+  // is false, Check 4 is never reached anyway, so `collectionWarnings`
+  // correctly stays empty (this is a deliberate skip, not a collection
+  // failure).
+  const collectionWarnings = [];
+  let closedByMergedPrNumbers = [];
+  let candidateFiles = [];
+  let highContentionFiles = [];
+  let mergedPrs = [];
+  if (shouldCollectEvidence) {
+    try {
+      closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+        owner,
+        repo,
+        args.issue,
+      );
+    } catch (error) {
+      collectionWarnings.push(
+        `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    try {
+      candidateFiles = parseCandidateFiles(issue.body);
+      // Only resolve the high-contention exclusion set (a file read + JSON
+      // parse) when there is a '## Candidate files' section to check it
+      // against -- most issues have none, and the result would otherwise be
+      // discarded.
+      const resolvedHighContentionFiles =
+        candidateFiles.length > 0
+          ? loadHighContentionFiles(
+              args.manifest,
+              args.bundles ?? DEFAULT_BUNDLE_IDS,
+            )
+          : null;
+      const shouldScanMergedPrs =
+        candidateFiles.length > 0 &&
+        resolvedHighContentionFiles !== null &&
+        issue.createdAt.length > 0;
+      highContentionFiles = resolvedHighContentionFiles ?? [];
+      if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+        // Codex P2 review finding: an unreadable/missing high-contention
+        // manifest silently skipped the same-candidate-files scan without
+        // recording a warning -- but from Check 4's perspective this is the
+        // same class of "high-confidence evidence could not be collected" as
+        // a genuine gh/API failure, and must degrade the same way (exact
+        // title match only), not let the full weak heuristic run.
+        collectionWarnings.push(
+          'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+        );
+      }
+      if (shouldScanMergedPrs) {
+        const scanResult = fetchMergedPrFileOverlapEvidence(
+          repoRef,
+          issue.createdAt,
+          candidateFiles,
+          highContentionFiles,
+          issue.number,
+        );
+        mergedPrs = scanResult.mergedPrs;
+        if (scanResult.truncatedByDeadline) {
+          // Codex P2 review finding: a deadline-truncated scan returns
+          // normally (not a throw), so it must record its own warning here --
+          // otherwise Check 4 would run the full weak heuristic on
+          // incomplete evidence instead of degrading to exact-title-only.
+          collectionWarnings.push(
+            'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+          );
+        }
+      } else {
+        mergedPrs = [];
+      }
+    } catch (error) {
+      collectionWarnings.push(
+        `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      candidateFiles = [];
+      mergedPrs = [];
+    }
+  }
+  const highConfidenceDuplicate = {
+    closedByMergedPrNumbers,
+    candidateFiles,
+    highContentionFiles,
+    mergedPrs,
+  };
+  const result = evaluateSuitability(issue, {
+    repository: { owner, repo },
+    duplicateCandidates,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    highConfidenceDuplicate,
+    highConfidenceCollectionDegraded: collectionWarnings.length > 0,
+  });
+  const output = {
+    repository: { owner, repo },
+    issue: {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      url: issue.url,
+    },
+    passed: result.passed,
+    outcome: result.outcome,
+    failedCheck: result.failedCheck,
+    ...(existingRejection ? { existingRejection } : {}),
+    ...(existingRejectionCollectionWarnings.length > 0
+      ? { existingRejectionCollectionWarnings }
+      : {}),
+    ...(collectionWarnings.length > 0
+      ? { highConfidenceDuplicateCollectionWarnings: collectionWarnings }
+      : {}),
+    checks: args.verbose
+      ? result.checks
+      : result.checks.map((check) => ({
+          id: check.id,
+          name: check.name,
+          result: check.result,
+          // #1499: carried through even in non-verbose mode -- the typed
+          // tier signal exists precisely so a consumer can branch on it
+          // without asking for full evidence prose.
+          ...(check.tier ? { tier: check.tier } : {}),
+        })),
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+/**
+ * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
+ * absent resolves to `null` (the original `issue: null` default, never
+ * overwritten when `--issue` is absent); present feeds the raw token
+ * straight to `Number.parseInt`, which accepts trailing-garbage ("42abc"
+ * -> 42) and leading-zero ("007" -> 7) tokens the same way the original
+ * hand-rolled `Number.parseInt(String(value ?? ''), 10)` always did.
+ * `cli-args.mts`'s `parseCanonicalIntegerOrNull` is a poor substitute
+ * here: its canonical-pattern regex rejects those same tokens outright,
+ * which is a real contract change a CodeRabbit review on PR #1466 caught
+ * -- #1450's acceptance criteria protect the post-parse integer contract
+ * as-is, only flag *syntax* (missing/flag-shaped values, unknown flags)
+ * is meant to tighten. This file's own `args.issue === null ||
+ * !Number.isInteger(args.issue) || args.issue <= 0` use-site guard
+ * already treats `NaN` (an invalid parseInt result) the same as `null`,
+ * so this restores the exact original resolved value, not just an
+ * equivalent downstream verdict.
+ */
+function parseLenientIntegerOrNull(token) {
+  return token === undefined ? null : Number.parseInt(token, 10);
+}
+export function parseArgs(argv) {
+  const { values, help } = parseCliArgs(argv, SUITABILITY_TRIAGE_FLAG_SPEC);
+  return {
+    issue: parseLenientIntegerOrNull(values.issue),
+    token: values.token,
+    owner: values.owner,
+    repo: values.repo,
+    policy: values.policy,
+    manifest: values.manifest,
+    // #1499: mirrors `discover-shared-file-overlap.mts`'s own `--bundles`
+    // parsing exactly -- absent means "not passed" (`null`), present is a
+    // comma-split, trimmed, empty-token-filtered list.
+    bundles:
+      values.bundles === undefined
+        ? null
+        : String(values.bundles)
+            .split(',')
+            .map((part) => part.trim())
+            .filter(Boolean),
+    verbose: values.verbose,
+    help,
+  };
+}
+/**
+ * Load and parse `.github/idd/config.json` (or `--policy <path>` when
+ * given). Read-and-parse failure semantics (explicit path throws; default
+ * path silently falls back only on ENOENT, matching an absent default
+ * policy file so the CLI stays usable without one, #1273) are converged in
+ * idd-config.mts's `loadPolicyConfig` (#1721) — this function has no shape
+ * normalization of its own beyond returning the raw config.
+ */
+function loadPolicy(policyPath) {
+  return loadPolicyConfig(policyPath).config;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+
+--manifest / --bundles override the Check 4 high-confidence tier's
+high-contention exclusion set (default: the same manifest path and bundle
+IDs as discover-shared-file-overlap.mjs's own --manifest/--bundles), so a
+repository that customizes its A4 Step 2 contention bundles gets a matching
+Check-4 exclusion set instead of a stale hardcoded default.
+
+Output schema:
+{
+  "repository": {"owner": "...", "repo": "..."},
+  "issue": {"number": 392, "title": "...", "state": "OPEN", "url": "..."},
+  "passed": true,
+  "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
+  "failedCheck": "repository_fit|...|null",
+  "existingRejection": {"author":"...","createdAt":"...","url":"...","outcome":"...|null","check":"...|null"},
+  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
+}
+
+Each checks[] entry may also carry "tier":"high-confidence|weak" -- present
+only on a duplicate_or_superseded fail (absent on every pass and on every
+other check), distinguishing a high-confidence mechanical hit from the weak
+title/declaration heuristic.
+
+"existingRejection" (#1887) is present only when a trusted marker actor
+already posted a correctly-formatted "A4.5 suitability gate rejection"
+comment on this issue -- the most recent one, when more than one exists.
+Absent (not null) for the common never-triaged case, and never surfaced for
+a rejection-shaped comment from an untrusted actor. An optional sibling
+"existingRejectionCollectionWarnings" array is present only when fetching
+or scanning the comment thread itself failed.
+`);
+}
+function normalizeIssue(issue) {
+  const i = issue ?? {};
+  return {
+    number: Number.parseInt(String(i.number), 10),
+    title: String(i.title ?? ''),
+    body: String(i.body ?? ''),
+    state: String(i.state ?? ''),
+    labels: normalizeLabels(i.labels),
+    url: String(i.url ?? i.html_url ?? ''),
+    createdAt: String(i.created_at ?? ''),
+  };
+}
+/**
+ * Normalize the `evaluateSuitability` options-boundary input for #1484's
+ * high-confidence tier. Returns `undefined` for anything that isn't a
+ * plausible object (existing callers that don't know about this field never
+ * pass it, which must resolve to "absent", not an empty-but-present shape --
+ * `evaluateHighConfidenceDuplicate` special-cases `undefined` for exactly
+ * this reason). Every array field defaults to `[]` on a malformed shape.
+ */
+function normalizeHighConfidenceDuplicateInput(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+  const r = raw;
+  return {
+    closedByMergedPrNumbers: normalizePositiveIntArray(
+      r.closedByMergedPrNumbers,
+    ),
+    candidateFiles: normalizeStringArray(r.candidateFiles),
+    highContentionFiles: normalizeStringArray(r.highContentionFiles),
+    mergedPrs: normalizeHighConfidenceMergedPrs(r.mergedPrs),
+  };
+}
+function normalizePositiveIntArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isInteger(entry) && entry > 0);
+}
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => String(entry ?? ''))
+    .filter((entry) => entry.length > 0);
+}
+function normalizeHighConfidenceMergedPrs(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      const e = entry ?? {};
+      return {
+        number: Number(e.number),
+        mergedAt: String(e.mergedAt ?? ''),
+        files: normalizeStringArray(e.files),
+        // #1878: same-issue-reference evidence, normalized the same
+        // fail-safe way as every other field on this options boundary --
+        // a malformed shape degrades to "no reference" rather than crashing
+        // or manufacturing a match.
+        closingIssuesReferences: normalizePositiveIntArray(
+          e.closingIssuesReferences,
+        ),
+        title: String(e.title ?? ''),
+        body: String(e.body ?? ''),
+      };
+    })
+    .filter((entry) => Number.isInteger(entry.number) && entry.number > 0);
+}
+/**
+ * Resolve one configured `labels.*` name (#1273), falling back to the given
+ * `policy-helpers.mts` `POLICY_DEFAULTS.labels` default for an absent or
+ * invalid value.
+ */
+function normalizeConfiguredLabelName(labelName, fallback) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : fallback;
+}
+function normalizeRepository(repository) {
+  if (!repository || typeof repository !== 'object') {
+    return null;
+  }
+  const r = repository;
+  const owner = String(r.owner ?? '')
+    .trim()
+    .toLowerCase();
+  const repo = String(r.repo ?? '')
+    .trim()
+    .toLowerCase();
+  if (!owner || !repo) {
+    return null;
+  }
+  return { owner, repo };
+}
+function normalizeDuplicateCandidates(candidates) {
+  if (!Array.isArray(candidates)) {
+    return [];
+  }
+  return candidates
+    .map((candidate) => {
+      const c = candidate ?? {};
+      return {
+        number: Number.parseInt(String(c.number), 10),
+        title: String(c.title ?? ''),
+        state: String(c.state ?? ''),
+        url: String(c.url ?? c.html_url ?? ''),
+      };
+    })
+    .filter(
+      (candidate) => Number.isInteger(candidate.number) && candidate.number > 0,
+    );
+}
+function normalizeLabels(labels) {
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+  return labels
+    .map((label) => (typeof label === 'string' ? label : (label?.name ?? '')))
+    .map((label) => String(label).trim().toLowerCase())
+    .filter(Boolean);
+}
+function normalizeText(value) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase();
+}
+function fetchIssue(repoRef, issueNumber) {
+  const issue = ghJson(['api', `repos/${repoRef}/issues/${issueNumber}`]);
+  return normalizeIssue(issue);
+}
+function fetchDuplicateCandidates(repoRef, issue) {
+  const escapedTitle = issue.title.replaceAll('"', '\\"');
+  const query = `repo:${repoRef} in:title "${escapedTitle}"`;
+  const payload = ghJson([
+    'api',
+    `search/issues?q=${encodeURIComponent(query)}&per_page=50`,
+  ]);
+  return normalizeDuplicateCandidates(payload.items ?? []);
+}
+/**
+ * Paginated fetch of `<owner>/<repo>` issue `<issueNumber>`'s full comment
+ * thread (#1887), mirroring `resume-claim-routing.mts`'s own
+ * `fetchIssueComments` -- REST issue comments, 100 per page, until a
+ * short page signals the end. Feeds `findTrustedSuitabilityRejection`
+ * (`supersession-detection.mts`). Throws on a `gh` failure like every other
+ * `ghJson`-based fetch in this file; the caller wraps this call in its own
+ * try/catch so a failure here degrades `existingRejection` to `null` plus a
+ * warning instead of crashing the whole seven-check evaluation.
+ */
+function fetchIssueComments(repoRef, issueNumber) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const pageItems = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+    ]);
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
+}
+// --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
+// The pure argv-builders (`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,
+// `buildPrDetailArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
+// moved to `supersession-detection.mts` (#1499); this file keeps only the
+// `gh`-executing orchestration below (fetch, try/catch, deadline budget,
+// `collectionWarnings`), which the issue does not name as part of the
+// extraction.
+/**
+ * Fetch the candidate issue's own merged closing-PR references. Throws (via
+ * `runGh`, no try/catch here) on a `gh` error rather than silently reading a
+ * broken fetch as "no evidence" -- the latter would make a real duplicate
+ * look clean. The caller (`runCli`) wraps this in its own try/catch,
+ * separate from the same-candidate-files scan's try/catch below (Copilot
+ * review finding on this PR: an earlier version described both as sharing
+ * one try/catch, which stopped being accurate once they were split so a
+ * failure in one signal's collection couldn't discard an already-successful
+ * sibling), so a failure here degrades the optional high-confidence tier
+ * (Check 4's own documented "Timeout on duplicate detection... fall back to
+ * exact title match only" Edge Case) without aborting the other six checks
+ * (Codex review finding on this PR: an earlier version let this throw
+ * uncaught all the way out of `runCli`, crashing the whole evaluation).
+ *
+ * Also requires the candidate issue's own current `state` to be `CLOSED`,
+ * mirroring B2.0's identical gate on this same signal
+ * (`idd-work.instructions.md`'s "Closed-by-a-merged-PR signal": `select(.state
+ * == "CLOSED")`). `closedByPullRequestsReferences` is not cleared when an
+ * issue is reopened, so without this gate a reopened issue with genuine
+ * remaining work would still show its old merged closing PR and get
+ * misclassified as a completed duplicate (Codex review finding on this PR).
+ */
+function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
+  const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
+  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
+  // query error, but a GraphQL response can also return HTTP 200 with a
+  // non-empty top-level `errors` array alongside partial/null `data` (a
+  // resolver-level failure on a nullable field) -- verified empirically
+  // that gh's own exit code does not always catch this shape. Treating that
+  // silently as "no evidence" would suppress a real collection failure
+  // (Copilot review finding on this PR); throw explicitly so the caller's
+  // try/catch records it in `collectionWarnings` instead.
+  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+    throw new Error(
+      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
+    );
+  }
+  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
+    return [];
+  }
+  const nodes =
+    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
+  return nodes
+    .filter((node) => String(node?.state ?? '') === 'MERGED')
+    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+/**
+ * Bounded two-step merged-PR file-overlap scan (list, then per-PR file
+ * list), mirroring B2.0's own documented commands exactly rather than a new
+ * query shape. A malformed list entry (non-positive-integer or absent
+ * `number`) is skipped rather than shelled out to `gh pr view` (Copilot
+ * review finding on this PR: `ghJsonArray` intentionally returns
+ * `unknown[]`, so an unexpected API shape should degrade this one entry,
+ * not become a hard `gh pr view NaN`/`gh pr view 0` failure). Also stops
+ * early, returning whatever has been collected so far plus
+ * `truncatedByDeadline: true`, once `MERGED_PR_SCAN_DEADLINE_MS` elapses
+ * (CodeRabbit review finding on this PR: up to `MERGED_PR_SCAN_LIMIT`
+ * sequential `gh pr view` calls with no overall cap could otherwise run for
+ * tens of minutes under a degraded/rate-limited GitHub API). The
+ * `truncatedByDeadline` flag matters because this early exit returns
+ * normally rather than throwing (Codex P2 review finding on this PR): an
+ * earlier version left the caller unable to distinguish "scanned
+ * everything, found nothing" from "gave up partway through", so a
+ * deadline-truncated scan silently ran the FULL weak heuristic (including
+ * the near-duplicate fuzzy match) on incomplete evidence instead of
+ * degrading to the documented exact-title-only fallback the way a thrown
+ * `gh` error already does. A genuine `gh` error on a well-formed entry
+ * still throws -- the caller (`runCli`) wraps this and its sibling fetch in
+ * a separate try/catch so that surfaces as the same documented Check 4 Edge
+ * Case fallback for just this signal, without discarding the other.
+ *
+ * `candidateFiles` / `highContentionFiles` (#1815) let the scan stop early:
+ * `evaluateHighConfidenceDuplicate` only needs the FIRST merged PR (in scan
+ * order) whose changed files overlap the exclusion-adjusted candidate set
+ * AND references `candidateIssueNumber` itself (#1878; see
+ * `prReferencesIssue` in `supersession-detection.mts`) to return a
+ * high-confidence fail -- every PR after it would otherwise be fetched and
+ * then ignored. `resolveCandidateFileSet` / `findCandidateFileOverlap` /
+ * `prReferencesIssue` (`supersession-detection.mts`) are the exact same
+ * helpers `evaluateHighConfidenceDuplicate` itself now uses, so the PR
+ * this loop stops on is provably the same PR the downstream evaluation
+ * would stop on -- no evidence-content change, only fewer PRs fetched. A
+ * merged PR whose files overlap but that never references the candidate
+ * (the #1862-vs-#1863/PR#1864 false positive #1878 fixes) no longer stops
+ * the scan -- every merged PR in the window is now fetched in that case,
+ * which is the fail-safe direction (worst case, a `truncatedByDeadline`
+ * scan degrades Check 4 to exact-title-only, never a false high-confidence
+ * hit) but does mean `MERGED_PR_SCAN_DEADLINE_MS` is reached far more
+ * often for a candidate whose files are shared across an entire roadmap of
+ * siblings, none of which reference it individually.
+ * Exported (not just called) so `fetchMergedPrFileOverlapEvidence` can be
+ * unit-tested directly against a stubbed `gh` on `PATH`, the way this
+ * repo's other `gh`-calling functions are exercised (see
+ * `tests/gh-exec.test.mts` / `tests/discover-roadmap-graph.test.mts`).
+ */
+export function fetchMergedPrFileOverlapEvidence(
+  repoRef,
+  sinceIso,
+  candidateFiles,
+  highContentionFiles,
+  candidateIssueNumber,
+) {
+  const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
+  const mergedPrs = [];
+  const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
+  let truncatedByDeadline = false;
+  const candidateSet = resolveCandidateFileSet(
+    candidateFiles,
+    highContentionFiles,
+  );
+  for (const entry of list) {
+    if (Date.now() >= deadline) {
+      truncatedByDeadline = true;
+      break;
+    }
+    const pr = entry ?? {};
+    const number = Number.parseInt(String(pr.number ?? ''), 10);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    const detail = ghJson(buildPrDetailArgs(repoRef, number));
+    const files = (Array.isArray(detail.files) ? detail.files : [])
+      .map((file) => String(file?.path ?? ''))
+      .filter(Boolean);
+    const closingIssuesReferences = (
+      Array.isArray(detail.closingIssuesReferences)
+        ? detail.closingIssuesReferences
+        : []
+    )
+      .map((ref) => Number(ref?.number))
+      .filter((n) => Number.isInteger(n) && n > 0);
+    const title = String(detail.title ?? '');
+    const body = String(detail.body ?? '');
+    mergedPrs.push({
+      number,
+      mergedAt: String(pr.mergedAt ?? ''),
+      files,
+      closingIssuesReferences,
+      title,
+      body,
+    });
+    if (
+      findCandidateFileOverlap(files, candidateSet).length > 0 &&
+      prReferencesIssue(
+        { closingIssuesReferences, title, body },
+        candidateIssueNumber,
+      )
+    ) {
+      // Qualifying overlap + same-issue reference found (#1815, #1878):
+      // stop -- see the doc comment above. Deliberately a plain `break`,
+      // NOT `truncatedByDeadline = true`: this is a complete, successful
+      // scan that found its answer early, not a scan cut short before
+      // finishing. Setting the flag here would wrongly push a
+      // `collectionWarnings` entry in `runCli`, which degrades Check 4 to
+      // exact-title-only -- silently turning a genuine high-confidence hit
+      // into a false pass.
+      break;
+    }
+  }
+  return { mergedPrs, truncatedByDeadline };
+}
+/**
+ * Resolve the high-contention exclusion set the same way A4 Step 2's
+ * `discover-shared-file-overlap` does, so the #1484 same-candidate-files
+ * signal never treats a broadly-shared bundle/manifest file as
+ * high-confidence evidence on its own. Returns `null` (not `[]`) when the
+ * manifest cannot be loaded, so `runCli` can skip the same-candidate-files
+ * scan entirely in that case rather than proceeding with zero exclusions --
+ * an empty exclusion set would make that signal MORE permissive, which is
+ * the wrong fail direction for "never fail toward a false high-confidence
+ * flag". `runCli` also records this as a `collectionWarnings` entry (Codex
+ * P2 review finding on this PR): from Check 4's perspective, "manifest
+ * unavailable" and "gh/API fetch failed" are the same class of "evidence
+ * could not be collected" and must degrade the weak-heuristic fallback the
+ * same way. `closedByPullRequestsReferences` is a separate, independent
+ * signal and is unaffected by either fallback.
+ */
+export function loadHighContentionFiles(manifestPath, bundleIds) {
+  // Copilot review finding on this PR: `[].every(...)` is vacuously `true`,
+  // so an explicitly-empty (or whitespace-only, after --bundles parsing)
+  // override would otherwise sail through the completeness check below and
+  // resolve to a high-contention set containing only `extraFiles` (just the
+  // manifest path) -- the opposite of this tier's fail-safe contract, since
+  // a smaller exclusion set makes the overlap scan MORE permissive, not
+  // less. Treat an empty list the same as any other invalid/incomplete
+  // request: degrade to null (collection warning, exact-title-only) rather
+  // than silently accepting zero bundles as "all resolved".
+  if (bundleIds.length === 0) {
+    return null;
+  }
+  try {
+    const manifest = JSON.parse(
+      readFileSync(resolve(process.cwd(), manifestPath), 'utf8'),
+    );
+    // Codex P2 review finding: a manifest that parses but lacks usable
+    // `bundleBudgets` entries for one or both target bundle IDs (an empty
+    // object, or an older schema) doesn't throw here -- `resolveHighContentionFiles`
+    // degrades gracefully to just the manifest path itself for A4 Step 2's
+    // own, lower-stakes de-prioritization use. But for this tier, an
+    // incomplete exclusion set can miss a genuinely high-contention file, so
+    // a shared bundle/instruction file could be misread as specific overlap
+    // evidence -- exactly the false high-confidence flag Check 4 must never
+    // produce. Require every requested bundle ID (#1499: the caller's own
+    // `--bundles` override when given, not the hardcoded default -- a
+    // repository that customizes its bundle set must have THOSE bundles
+    // validated, not `DEFAULT_BUNDLE_IDS`) to actually resolve before
+    // accepting the set; otherwise treat it the same as an unreadable
+    // manifest (return null, which the caller already records as a
+    // collection warning and degrades to exact-title-only).
+    const bundles = manifest?.bundleBudgets;
+    if (!Array.isArray(bundles)) {
+      return null;
+    }
+    const nonEmptyFilesBundleIds = new Set(
+      bundles
+        .filter((bundle) => {
+          const files = bundle?.files;
+          return Array.isArray(files) && files.length > 0;
+        })
+        .map((bundle) => String(bundle?.id ?? '')),
+    );
+    // Codex P2 review finding: a bundle entry whose id matched but whose
+    // `files` was missing, non-array, or empty passed the id-only check
+    // above yet still let `resolveHighContentionFiles` silently omit that
+    // bundle's real shared files -- the same false-flag risk as a missing
+    // bundle id entirely, so it must degrade the same way.
+    const allBundleIdsResolved = bundleIds.every((id) =>
+      nonEmptyFilesBundleIds.has(id),
+    );
+    if (!allBundleIdsResolved) {
+      return null;
+    }
+    return [
+      ...resolveHighContentionFiles({
+        manifest,
+        bundleIds,
+        // #1499: mirrors `discover-shared-file-overlap.mts`'s own `runCli`
+        // pattern -- the manifest path actually in use is the file reported
+        // (and matched) as high-contention, not a hardcoded default that
+        // silently stops tracking a customized manifest.
+        extraFiles: [manifestPath],
+      }),
+    ];
+  } catch {
+    return null;
+  }
+}
+function ghJson(args) {
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+function runGh(args) {
+  try {
+    return ghText(args, GH_TEXT_LOOP_TIMEOUT_OPTIONS);
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -1,0 +1,419 @@
+// idd-generated-from: src/scripts/supersession-detection.mts
+//
+// The scripts/supersession-detection.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// The #1484 high-confidence supersession-detection kernel (#1499): a
+// mechanical "is this issue already superseded by a merged PR" evaluator,
+// plus its read-only `gh` argv-builders, extracted out of
+// `suitability-triage.mts` so a future B2.0 mechanization
+// (`idd-work.instructions.md`'s post-claim supersession re-check, currently
+// prose-only) can reuse this kernel directly instead of duplicating it in a
+// second file. `suitability-triage.mts` is Check 4's only current consumer;
+// nothing here depends on it, so this module carries no import back to it
+// (a future consumer never needs to pull in suitability-triage.mts's whole
+// 7-check CLI just to reuse the kernel).
+//
+// Pure and I/O-free: `evaluateHighConfidenceDuplicate` only evaluates
+// already-collected evidence, and the argv-builders only build `gh` command
+// arrays -- neither executes anything. The actual `gh` fetch/orchestration
+// (`fetchClosedByMergedPrNumbers`, `fetchMergedPrFileOverlapEvidence`, the
+// `MERGED_PR_SCAN_DEADLINE_MS` wall-clock budget) stays in
+// `suitability-triage.mts`'s own CLI glue, which the issue does not name as
+// part of the extraction.
+import { normalizeContentionPath } from './discover-shared-file-overlap.mjs';
+
+/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
+ * documented `gh pr list --limit 50`). */
+const MERGED_PR_SCAN_LIMIT = 50;
+/**
+ * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
+ * first 50 closing-PR references. A later page could theoretically hold an
+ * additional MERGED reference this misses, but that only makes the tier
+ * under-detect (fall back to the weak heuristic) rather than over-detect --
+ * the safe fail direction for a check that must never fail TOWARD a false
+ * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
+ * `hasOpenClosingPr` implements for its own different, block-a-close use
+ * case) is not required here.
+ */
+const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      state
+      closedByPullRequestsReferences(first:50){
+        nodes { number state }
+      }
+    }
+  }
+}`;
+/**
+ * Resolve the exclusion-adjusted candidate-file set: `candidateFiles`
+ * normalized via `normalizeContentionPath`, with `highContentionFiles`
+ * (bundle + manifest files many unrelated issues touch) removed. This is
+ * the same filter chain `evaluateHighConfidenceDuplicate` applies before its
+ * own merged-PR loop, extracted (#1815) so
+ * `suitability-triage.mts`'s `fetchMergedPrFileOverlapEvidence` scan can
+ * reuse the identical resolution to detect a qualifying overlap PR-by-PR --
+ * and stop fetching further PRs' file lists once one is found -- instead of
+ * duplicating this normalize-then-exclude logic in a second copy that could
+ * silently drift from this one.
+ */
+export function resolveCandidateFileSet(candidateFiles, highContentionFiles) {
+  const highContention = new Set(
+    highContentionFiles.map((file) => normalizeContentionPath(file)),
+  );
+  return new Set(
+    candidateFiles
+      .map((file) => normalizeContentionPath(file))
+      .filter((file) => file.length > 0 && !highContention.has(file)),
+  );
+}
+/**
+ * Return the subset of `files` present in `candidateSet`, normalized via
+ * `normalizeContentionPath` (the same normalization `resolveCandidateFileSet`
+ * builds the set with). Always empty when `candidateSet` is empty, mirroring
+ * `evaluateHighConfidenceDuplicate`'s own "no exclusion-adjusted candidate
+ * files at all" early return -- a caller never needs to special-case an
+ * empty set itself.
+ */
+export function findCandidateFileOverlap(files, candidateSet) {
+  if (candidateSet.size === 0) {
+    return [];
+  }
+  return [
+    ...new Set(files.map((file) => normalizeContentionPath(file))),
+  ].filter((file) => candidateSet.has(file));
+}
+/**
+ * Closing-keyword-adjacent `#<issueNumber>` cross-reference test (#1878;
+ * narrowed by #1888), matched against a merged PR's
+ * `closingIssuesReferences` connection first, falling back to a regex scan
+ * of `title`/`body`. That regex scan **requires** a recognized GitHub
+ * closing keyword (`close(s|d)?`, `fix(es|ed)?`, `resolve(s|d)?`,
+ * case-insensitive) immediately before the reference, separated only by
+ * whitespace -- the same grammar `idd-pr-submit.instructions.md`'s D3.5
+ * step already documents for closing-keyword detection
+ * (`\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#<N>\b`). A bare `#<n>`
+ * mention with no adjacent closing keyword no longer counts as a reference:
+ * PR #1886 (closes only #1878) bare-mentioned "#1862" once as a narrative
+ * reproduction-example citation ("observed live: issue #1862 vs. merged PR
+ * #1864...") rather than declaring it implements #1862, which the prior
+ * unconditional bare-mention fallback (#1878) wrongly treated as evidence
+ * PR #1886 itself superseded #1862. `\b` after the digits still rejects a
+ * longer number sharing the same prefix (`Closes #18620` does not match
+ * `issueNumber: 1862`), and the mandatory `\s+` between keyword and `#`
+ * means a keyword glued directly to the reference (`closes#1862`, no
+ * whitespace) does not match either. Deliberately does not mask markdown
+ * code regions first (unlike `checkDuplicateOrSuperseded`'s own free-text
+ * declaration scan) -- the issue pins a plain substring/regex check with no
+ * masking step, and a closing-keyword-adjacent cross-reference inside a
+ * code span or fence is not a realistic false-positive vector for this
+ * specific pattern.
+ *
+ * Defensive against a malformed `pr` shape the same way the rest of this
+ * kernel is: a non-array `closingIssuesReferences` or non-string
+ * `title`/`body` degrades to "no reference" rather than throwing, and an
+ * invalid `issueNumber` (non-positive-integer) always returns `false`.
+ */
+export function prReferencesIssue(pr, issueNumber) {
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return false;
+  }
+  const closing = Array.isArray(pr.closingIssuesReferences)
+    ? pr.closingIssuesReferences
+    : [];
+  // Copilot review finding on PR #1886: accept both a raw number entry
+  // (the shape suitability-triage.mts's own caller already normalizes to
+  // before calling this function) and a raw `{ number }` object entry (the
+  // shape `gh pr view --json closingIssuesReferences` itself actually
+  // returns, confirmed empirically) -- `Number({ number: 1862 })` alone
+  // evaluates to `NaN` and would silently degrade a true match to "no
+  // reference" if a future caller ever passed the unnormalized `gh`
+  // payload straight through.
+  if (
+    closing.some((entry) => {
+      if (entry !== null && typeof entry === 'object') {
+        return Number(entry.number) === issueNumber;
+      }
+      return Number(entry) === issueNumber;
+    })
+  ) {
+    return true;
+  }
+  // #1888: narrowed from a bare `#<n>` scan (#1878) to require a
+  // recognized GitHub closing keyword immediately before the reference --
+  // "this PR references that issue as background/example context" is no
+  // longer treated the same as "this PR implements that issue's own
+  // deliverable". `\b` before the keyword group rejects a keyword glued to
+  // a longer word (`Autoclose` does not match `close`), the mandatory
+  // `\s+` requires at least one whitespace character between the keyword
+  // and `#` (rejecting both a keyword glued directly to the reference,
+  // e.g. `closes#1862`, and the #1878 `foo#1862` word-glued-`#` case --
+  // whitespace is never a word character, so nothing word-glued can
+  // precede `#` here), and the trailing `\b` still rejects a longer number
+  // sharing the same digit prefix (`Closes #18620` does not match
+  // `issueNumber: 1862`). Case-insensitive so `Closes`, `closes`, `CLOSES`,
+  // etc. all match.
+  const pattern = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`,
+    'i',
+  );
+  const title = typeof pr.title === 'string' ? pr.title : '';
+  const body = typeof pr.body === 'string' ? pr.body : '';
+  return pattern.test(title) || pattern.test(body);
+}
+/** Literal prefix a trusted-actor "A4.5 suitability gate rejection" comment
+ * must start with (after trimming leading whitespace) to be recognized as
+ * an authoritative prior verdict by {@link findTrustedSuitabilityRejection}
+ * (#1887). Exported so `suitability-triage.mts` and its tests reference the
+ * exact same literal the A4.5 posting convention itself uses
+ * (`idd-suitability.instructions.md`'s Mutation Policy section) instead of
+ * risking two copies drifting apart. */
+export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
+// Not anchored to line start/end: real rejection comments interleave the
+// `outcome: <token>` declaration with trailing prose on the same line (e.g.
+// "outcome: duplicate (mechanical, narrow false positive -- see above)"),
+// so a `^...$` anchor would silently miss it. The trailing `\b` still
+// prevents a longer word sharing the same prefix (e.g. "duplicated") from
+// matching. Restricted to the six canonical A4.5 outcome values
+// (`idd-suitability.instructions.md`'s Failure Outcomes table) so this
+// never invents a token the protocol doesn't recognize.
+const SUITABILITY_REJECTION_OUTCOME_PATTERN =
+  /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
+const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
+/**
+ * Scan `comments` for the most recent trusted-actor `A4.5 suitability gate
+ * rejection` comment (#1887): the acceptance-criteria-required detect-only
+ * evidence that a prior trusted run already recorded a specific outcome for
+ * this exact issue. A comment only qualifies when BOTH hold: its body,
+ * after trimming leading whitespace, starts with the literal
+ * {@link SUITABILITY_REJECTION_PREFIX} (the same "literal first bytes, not
+ * merely quoted or embedded mid-prose" anti-spoofing boundary
+ * `idd-claim.instructions.md` already applies to claim markers -- an
+ * untrusted actor pasting the phrase mid-sentence never qualifies either
+ * way, but this keeps the boundary consistent with the rest of the
+ * protocol); AND its author (case-insensitively) is one of
+ * `trustedMarkerLogins`. `trustedMarkerLogins` is expected pre-normalized
+ * (lowercased) by the caller via `resolveTrustedMarkerActors` in
+ * `protocol-helpers.mts` -- this function still lowercases defensively but
+ * does not import that module itself, keeping this file's own
+ * dependency-light, I/O-free kernel contract intact for a future
+ * non-suitability-triage consumer.
+ *
+ * Returns `null` -- never a synthesized verdict -- when no trusted match
+ * exists, whether because there is no such comment at all or because every
+ * rejection-shaped comment found was posted by an untrusted actor: both
+ * degrade to "nothing on record" the same way, matching this issue's
+ * fail-safe contract (an untrusted rejection-shaped comment is never
+ * treated as authoritative).
+ */
+export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
+  const trusted = new Set(
+    (trustedMarkerLogins ?? [])
+      .map((login) =>
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  if (trusted.size === 0 || !Array.isArray(comments)) {
+    return null;
+  }
+  let latest = null;
+  let latestTimestamp = Number.NEGATIVE_INFINITY;
+  for (const raw of comments) {
+    const comment = raw ?? {};
+    const body = typeof comment.body === 'string' ? comment.body : '';
+    if (!body.trimStart().startsWith(SUITABILITY_REJECTION_PREFIX)) {
+      continue;
+    }
+    const author = String(comment.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!author || !trusted.has(author)) {
+      continue;
+    }
+    const createdAt =
+      typeof comment.created_at === 'string' ? comment.created_at : '';
+    const timestamp = Date.parse(createdAt);
+    if (!Number.isFinite(timestamp) || timestamp <= latestTimestamp) {
+      continue;
+    }
+    latestTimestamp = timestamp;
+    const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
+    const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    latest = {
+      author,
+      createdAt,
+      url: typeof comment.html_url === 'string' ? comment.html_url : '',
+      // Copilot review finding on PR #1890 (suppressed comment): the
+      // pattern above is case-insensitive (`/i`), but a captured group
+      // returns the verbatim matched text -- an actor writing e.g.
+      // "outcome: DUPLICATE" would otherwise surface a non-canonical
+      // "DUPLICATE" instead of the documented lowercase token, making a
+      // downstream string comparison brittle. Normalize before returning.
+      outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,
+      check: checkMatch ? checkMatch[0] : null,
+    };
+  }
+  return latest;
+}
+/**
+ * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
+ * signals -- a merged closing-PR reference on the candidate issue itself, or
+ * a merged PR that already changed one of the issue's own declared
+ * `## Candidate files` **and** references the candidate issue itself
+ * (#1878; see `prReferencesIssue` above) -- excluding high-contention/shared
+ * files, which many unrelated issues touch and so are not on their own
+ * high-confidence evidence that THIS issue was superseded. Returns `null`
+ * -- never a synthesized verdict of its own -- whenever no strong signal
+ * fires, so the caller falls through to its own existing weak
+ * title/declaration heuristic unchanged. This is the fail-safe contract the
+ * issue requires: never fail TOWARD a false high-confidence flag. `input`
+ * may be `undefined` (evidence not collected by the caller) or a partially
+ * malformed shape; both degrade to "no verdict" rather than a crash or a
+ * false hit.
+ *
+ * `candidateIssueNumber` is required (#1878, not optional/defaulted):
+ * Signal 2 below cannot decide "references the candidate" without knowing
+ * which issue is the candidate, and a silently-defaulted value (e.g. `0` or
+ * `NaN`) would either always or never match depending on the default
+ * chosen -- neither is a safe implicit behavior for a check whose whole
+ * contract is "never fail toward a false positive". A missing caller-side
+ * argument is a compile-time error instead.
+ */
+export function evaluateHighConfidenceDuplicate(input, candidateIssueNumber) {
+  if (!input) {
+    return null;
+  }
+  const closedByMergedPrNumbers = (
+    Array.isArray(input.closedByMergedPrNumbers)
+      ? input.closedByMergedPrNumbers
+      : []
+  ).filter((n) => Number.isInteger(n) && n > 0);
+  if (closedByMergedPrNumbers.length > 0) {
+    // #1878: already an inherent same-issue reference -- this signal comes
+    // from the CANDIDATE issue's own `closedByPullRequestsReferences`
+    // connection (`fetchClosedByMergedPrNumbers` in `suitability-triage.mts`),
+    // so a hit here already means a merged PR closes THIS issue. No
+    // additional `prReferencesIssue` check applies to this signal.
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
+      tier: 'high-confidence',
+    };
+  }
+  const candidateSet = resolveCandidateFileSet(
+    Array.isArray(input.candidateFiles) ? input.candidateFiles : [],
+    Array.isArray(input.highContentionFiles) ? input.highContentionFiles : [],
+  );
+  if (candidateSet.size === 0) {
+    return null;
+  }
+  const mergedPrs = Array.isArray(input.mergedPrs) ? input.mergedPrs : [];
+  for (const raw of mergedPrs) {
+    const pr = raw ?? {};
+    const number = Number(pr.number);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    const files = Array.isArray(pr.files) ? pr.files : [];
+    const overlap = findCandidateFileOverlap(files, candidateSet);
+    if (overlap.length === 0) {
+      continue;
+    }
+    if (!prReferencesIssue(pr, candidateIssueNumber)) {
+      // #1878: file overlap alone is no longer sufficient -- a merged
+      // sibling-roadmap PR can legitimately touch the same shared file
+      // without ever mentioning THIS candidate issue (the #1862-vs-#1863/
+      // PR#1864 false positive this issue fixes). Fall through to the
+      // NEXT merged PR in scan order instead of returning here, so a
+      // later PR in the same window that both overlaps and references the
+      // candidate is still detected.
+      continue;
+    }
+    const mergedAt = String(pr.mergedAt ?? '');
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')} and references issue #${candidateIssueNumber}.`,
+      tier: 'high-confidence',
+    };
+  }
+  return null;
+}
+// --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
+// Read-only: every function below only ever builds argv for `gh api graphql`
+// (with a `query` operation, never `mutation`), `gh pr list`, or `gh pr view`
+// (no -X/--method, no issue/PR mutation subcommand) -- none of them execute
+// anything themselves. #1484 is detect-only by design; do not add a mutating
+// argv-builder here -- a later gated-close follow-up (#1485) is a separate,
+// human-gated change. The argv-builders are exported so tests can assert the
+// exact read-only verb without shelling out (a compiled-text grep for
+// mutating verb literals would miss a `gh api ... -X POST`-shaped mutation,
+// since none of these builders produce one).
+/**
+ * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
+ * `gh issue view --json closedByPullRequestsReferences`: the latter's
+ * REST-shimmed shape carries no per-PR `state`, and the connection includes
+ * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
+ * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
+ * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
+ * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
+ * determines relevance, not that flag). Filtering to `state === 'MERGED'`
+ * happens in the caller, after this fetch -- without it, an issue with only
+ * an in-progress unmerged closing PR would wrongly read as "already
+ * referenced by a merged closing PR".
+ */
+export function buildClosedByMergedPrArgs(owner, repo, issueNumber) {
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+}
+/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
+ * `gh pr list --search "merged:>=<since>"` shape). */
+export function buildMergedPrListArgs(repoRef, sinceIso) {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'merged',
+    '--search',
+    `merged:>=${sinceIso}`,
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+/**
+ * Argv for one merged PR's changed-file list plus the same-issue-reference
+ * evidence #1878 adds (`title`, `body`, `closingIssuesReferences`) --
+ * requested on this single existing `gh pr view` call rather than a second
+ * one, matching the issue's own "no new API calls needed" framing. Returns
+ * the full JSON object (no `--jq` projection) since the caller now needs
+ * more than one field; `.files[].path` extraction moves to the caller.
+ */
+export function buildPrDetailArgs(repoRef, prNumber) {
+  return [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repoRef,
+    '--json',
+    'files,title,body,closingIssuesReferences',
+  ];
+}

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -1,0 +1,437 @@
+// idd-generated-from: src/scripts/validate-schemas.mts
+//
+// The scripts/validate-schemas.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+/**
+ * Strict JSON Schema (draft 2020-12 subset) validator.
+ *
+ * Validates schema files for unsupported keywords, then validates
+ * fixture instances against their schemas.
+ *
+ * Supported enforcement keywords:
+ *   type, required, properties, patternProperties, additionalProperties,
+ *   minLength, minimum, exclusiveMinimum, pattern, format (date-time only),
+ *   minItems, items, enum
+ *
+ * Any other keyword in a schema triggers an error, preventing false
+ * confidence from silently-ignored constraints.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+// Resolve the repository root by walking up to the nearest package.json.
+// This is location-independent, so it returns the same root whether this
+// module runs as the emitted scripts/validate-schemas.mjs (one level
+// deep), the src/scripts/validate-schemas.mts source under Node
+// type-stripping (two levels deep), or is imported by another module —
+// a fixed `..` from import.meta.dirname would resolve to src/ for the
+// source.
+function resolveRepoRoot(fromDir) {
+  let dir = fromDir;
+  for (let depth = 0; depth < 16; depth += 1) {
+    if (existsSync(join(dir, 'package.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return dir;
+}
+const ROOT = resolveRepoRoot(import.meta.dirname);
+/** Keywords accepted as pure annotations (no validation effect). */
+const ANNOTATION_KEYWORDS = new Set(['$schema', '$id', 'title', 'description']);
+/** Keywords this validator actively enforces. */
+const ENFORCED_KEYWORDS = new Set([
+  'type',
+  'required',
+  'properties',
+  'patternProperties',
+  'additionalProperties',
+  'minLength',
+  'minimum',
+  'exclusiveMinimum',
+  'pattern',
+  'format',
+  'minItems',
+  'items',
+  'enum',
+]);
+const ALLOWED_KEYWORDS = new Set([
+  ...ANNOTATION_KEYWORDS,
+  ...ENFORCED_KEYWORDS,
+]);
+/**
+ * Format values this validator recognizes. `date-time` is actively enforced
+ * (see `validate`); `uri` is accepted as a documentation-only annotation that a
+ * full JSON Schema validator enforces but this lightweight one does not, so a
+ * schema may declare it without tripping the unsupported-format guard.
+ */
+const SUPPORTED_FORMATS = new Set(['date-time', 'uri']);
+/**
+ * Check that a schema object only uses allowed keywords, recursively.
+ */
+export function checkSchemaKeywords(schema, path = '$') {
+  if (typeof schema !== 'object' || schema === null) return [];
+  const s = schema;
+  const errors = [];
+  for (const key of Object.keys(s)) {
+    if (!ALLOWED_KEYWORDS.has(key)) {
+      errors.push(`${path}: unsupported keyword "${key}"`);
+    }
+  }
+  if (s.format !== undefined && !SUPPORTED_FORMATS.has(s.format)) {
+    errors.push(`${path}: unsupported format value "${s.format}"`);
+  }
+  for (const [prop, propSchema] of Object.entries(s.properties ?? {})) {
+    errors.push(
+      ...checkSchemaKeywords(propSchema, `${path}.properties.${prop}`),
+    );
+  }
+  for (const [pattern, propSchema] of Object.entries(
+    s.patternProperties ?? {},
+  )) {
+    errors.push(
+      ...checkSchemaKeywords(
+        propSchema,
+        `${path}.patternProperties.${pattern}`,
+      ),
+    );
+  }
+  if (s.items && typeof s.items === 'object') {
+    errors.push(...checkSchemaKeywords(s.items, `${path}.items`));
+  }
+  if (
+    typeof s.additionalProperties === 'object' &&
+    s.additionalProperties !== null
+  ) {
+    errors.push(
+      ...checkSchemaKeywords(
+        s.additionalProperties,
+        `${path}.additionalProperties`,
+      ),
+    );
+  }
+  return errors;
+}
+function getType(val) {
+  if (val === null) return 'null';
+  if (Array.isArray(val)) return 'array';
+  return typeof val;
+}
+/**
+ * Validate data against a schema (subset enforced by this validator).
+ * Returns error messages — empty array means valid.
+ */
+export function validate(data, schema, path = '$') {
+  const s = schema;
+  const errors = [];
+  const actualType = getType(data);
+  if (s.type !== undefined) {
+    if (Array.isArray(s.type)) {
+      // Union type (e.g. ["string", "null"]): valid when the value matches any
+      // listed type, where 'integer' means an integer-valued number.
+      const matches = s.type.some((t) =>
+        t === 'integer'
+          ? actualType === 'number' && Number.isInteger(data)
+          : actualType === t,
+      );
+      if (!matches) {
+        errors.push(
+          `${path}: expected type "${s.type.join('|')}", got "${actualType}"`,
+        );
+        return errors;
+      }
+    } else if (s.type === 'integer') {
+      if (actualType !== 'number') {
+        errors.push(`${path}: expected type "integer", got "${actualType}"`);
+        return errors;
+      }
+      if (!Number.isInteger(data)) {
+        errors.push(
+          `${path}: expected type "integer", got non-integer number ${data}`,
+        );
+        return errors;
+      }
+    } else if (actualType !== s.type) {
+      errors.push(`${path}: expected type "${s.type}", got "${actualType}"`);
+      return errors;
+    }
+  }
+  if (actualType === 'string') {
+    const str = data;
+    if (s.minLength !== undefined && str.length < s.minLength) {
+      errors.push(`${path}: length ${str.length} < minLength ${s.minLength}`);
+    }
+    if (s.pattern !== undefined && !new RegExp(s.pattern).test(str)) {
+      errors.push(`${path}: does not match pattern /${s.pattern}/`);
+    }
+    if (s.format === 'date-time' && Number.isNaN(Date.parse(str))) {
+      errors.push(`${path}: invalid date-time value "${str}"`);
+    }
+  }
+  if (s.enum !== undefined && !s.enum.includes(data)) {
+    errors.push(
+      `${path}: "${String(data)}" not in enum [${s.enum.join(', ')}]`,
+    );
+  }
+  if (actualType === 'number' && s.minimum !== undefined && data < s.minimum) {
+    errors.push(`${path}: ${data} < minimum ${s.minimum}`);
+  }
+  if (
+    actualType === 'number' &&
+    s.exclusiveMinimum !== undefined &&
+    data <= s.exclusiveMinimum
+  ) {
+    errors.push(`${path}: ${data} <= exclusiveMinimum ${s.exclusiveMinimum}`);
+  }
+  if (actualType === 'array') {
+    const arr = data;
+    if (s.minItems !== undefined && arr.length < s.minItems) {
+      errors.push(
+        `${path}: array length ${arr.length} < minItems ${s.minItems}`,
+      );
+    }
+    if (s.items !== undefined) {
+      for (let i = 0; i < arr.length; i++) {
+        errors.push(...validate(arr[i], s.items, `${path}[${i}]`));
+      }
+    }
+  }
+  if (actualType === 'object') {
+    const obj = data;
+    for (const req of s.required ?? []) {
+      if (!(req in obj)) {
+        errors.push(`${path}: missing required property "${req}"`);
+      }
+    }
+    for (const [prop, propSchema] of Object.entries(s.properties ?? {})) {
+      if (prop in obj) {
+        errors.push(...validate(obj[prop], propSchema, `${path}.${prop}`));
+      }
+    }
+    const declaredProperties = s.properties ?? {};
+    const compiledPatternSchemas = [];
+    for (const [pattern, patternSchema] of Object.entries(
+      s.patternProperties ?? {},
+    )) {
+      try {
+        compiledPatternSchemas.push([new RegExp(pattern), patternSchema]);
+      } catch {
+        errors.push(`${path}: invalid patternProperties regex "${pattern}"`);
+      }
+    }
+    const additionalPropertiesSchema =
+      typeof s.additionalProperties === 'object' &&
+      s.additionalProperties !== null
+        ? s.additionalProperties
+        : null;
+    for (const key of Object.keys(obj)) {
+      const isDeclaredProperty = Object.hasOwn(declaredProperties, key);
+      let matchedPattern = false;
+      for (const [patternRegex, patternSchema] of compiledPatternSchemas) {
+        if (patternRegex.test(key)) {
+          matchedPattern = true;
+          errors.push(...validate(obj[key], patternSchema, `${path}.${key}`));
+        }
+      }
+      if (isDeclaredProperty || matchedPattern) {
+        continue;
+      }
+      if (s.additionalProperties === false) {
+        errors.push(`${path}: additional property "${key}" not allowed`);
+        continue;
+      }
+      if (additionalPropertiesSchema !== null) {
+        errors.push(
+          ...validate(obj[key], additionalPropertiesSchema, `${path}.${key}`),
+        );
+      }
+    }
+  }
+  return errors;
+}
+/**
+ * Validate one top-level section of a config document against its own
+ * schema node (`schema.properties[sectionKey]`), ignoring errors anywhere
+ * else in `config` or `schema`. This is the scoped counterpart to calling
+ * `validate(config, schema)` on the whole document: a config-section reader
+ * (e.g. `ciWait`, `advisoryWait`) that reverts only its own values to
+ * defaults on its own section's error must not be zeroed out by an
+ * unrelated top-level key — an unknown property, a missing required field,
+ * or a typo'd enum in a sibling section — because that section's own values
+ * were never invalid (see #1359).
+ *
+ * Returns no errors (treats the section as valid) when `config` is not a
+ * plain object, `schema` declares no schema for `sectionKey`, or
+ * `sectionKey` is absent from `config` — an absent section is valid on its
+ * own terms; the caller's own defaults apply.
+ */
+export function validateConfigSection(config, schema, sectionKey) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return [];
+  }
+  const sectionSchema = schema?.properties?.[sectionKey];
+  if (sectionSchema === undefined) {
+    return [];
+  }
+  const obj = config;
+  if (!Object.hasOwn(obj, sectionKey)) {
+    return [];
+  }
+  return validate(obj[sectionKey], sectionSchema, `$.${sectionKey}`);
+}
+/**
+ * Load and parse a JSON file by path relative to repository root.
+ */
+export function loadJson(relPath) {
+  return JSON.parse(readFileSync(join(ROOT, relPath), 'utf8'));
+}
+/**
+ * Check referential integrity of a phase-graph data object.
+ *
+ * Verifies that every node referenced in a `next` array exists as a node
+ * id within the same graph, and that no node id is duplicated.
+ */
+export function validatePhaseGraph(data) {
+  const errors = [];
+  const nodes = data?.nodes;
+  if (typeof data !== 'object' || data === null || !Array.isArray(nodes)) {
+    return errors;
+  }
+  const graphNodes = nodes;
+  const nodeIds = new Set();
+  const duplicates = new Set();
+  for (const node of graphNodes) {
+    if (typeof node.id !== 'string') continue;
+    if (nodeIds.has(node.id)) duplicates.add(node.id);
+    nodeIds.add(node.id);
+  }
+  for (const id of duplicates) {
+    errors.push(`Duplicate node id: "${id}"`);
+  }
+  for (const node of graphNodes) {
+    for (const target of node.next ?? []) {
+      if (typeof target !== 'string' || !nodeIds.has(target)) {
+        errors.push(
+          `Node "${String(node.id)}": next target "${String(target)}" does not exist`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+/**
+ * Validate a fixture against its schema.
+ */
+export function validateFixture(schemaPath, fixturePath, expectValid) {
+  const schema = loadJson(schemaPath);
+  const fixture = loadJson(fixturePath);
+  const keyErrors = checkSchemaKeywords(schema);
+  if (keyErrors.length > 0) {
+    return {
+      ok: false,
+      errors: [`Schema has unsupported keywords: ${keyErrors.join('; ')}`],
+    };
+  }
+  const errs = validate(fixture, schema);
+  let graphErrors = [];
+  if (schemaPath.endsWith('phase-graph.schema.json') && errs.length === 0) {
+    graphErrors = validatePhaseGraph(fixture);
+  }
+  const allErrors = [...errs, ...graphErrors];
+  const isValid = allErrors.length === 0;
+  if (expectValid && !isValid) return { ok: false, errors: allErrors };
+  if (!expectValid && isValid) {
+    return {
+      ok: false,
+      errors: ['Expected validation failure but fixture passed'],
+    };
+  }
+  return { ok: true, errors: [] };
+}
+/**
+ * Auto-discover schema/fixture validation cases under `root`: every
+ * `schemas/*.schema.json` is paired with `fixtures/schemas/<name>.valid.json`
+ * (expect-pass) and `<name>.invalid.json` (expect-fail). A schema missing
+ * either fixture is reported in `missing` rather than silently skipped, so the
+ * CLI can fail closed and a new schema cannot slip through unvalidated. Pure
+ * over the filesystem (globs and stats only), so it is unit-testable.
+ */
+export function discoverSchemaCases(root) {
+  const schemaFiles = readdirSync(join(root, 'schemas'))
+    .filter((file) => file.endsWith('.schema.json'))
+    .sort();
+  const cases = [];
+  const missing = [];
+  for (const file of schemaFiles) {
+    const name = file.slice(0, -'.schema.json'.length);
+    const schemaPath = `schemas/${file}`;
+    const validFixture = `fixtures/schemas/${name}.valid.json`;
+    const invalidFixture = `fixtures/schemas/${name}.invalid.json`;
+    const missingFixtures = [];
+    if (!existsSync(join(root, validFixture))) {
+      missingFixtures.push(validFixture);
+    }
+    if (!existsSync(join(root, invalidFixture))) {
+      missingFixtures.push(invalidFixture);
+    }
+    if (missingFixtures.length > 0) {
+      missing.push({ schema: schemaPath, missingFixtures });
+      continue;
+    }
+    cases.push({ schemaPath, fixturePath: validFixture, expectValid: true });
+    cases.push({
+      schemaPath,
+      fixturePath: invalidFixture,
+      expectValid: false,
+    });
+  }
+  return { cases, missing };
+}
+// CLI: run all schemas and fixtures when invoked directly.
+if (import.meta.main) {
+  const { cases, missing } = discoverSchemaCases(ROOT);
+  if (missing.length > 0) {
+    for (const entry of missing) {
+      console.error(
+        `✗  ${entry.schema}: missing fixture(s) ${entry.missingFixtures.join(', ')}`,
+      );
+    }
+    console.error(
+      `\n${missing.length} schema(s) have no fixtures. Add ` +
+        `fixtures/schemas/<name>.valid.json and <name>.invalid.json for each.`,
+    );
+    process.exit(1);
+  }
+  // phase-graph additionally validates its live data file (referential
+  // integrity via validateFixture's dedicated validatePhaseGraph hook) as an
+  // explicit override beyond the discovered valid/invalid fixture pair.
+  cases.push({
+    schemaPath: 'schemas/phase-graph.schema.json',
+    fixturePath: 'schemas/phase-graph.json',
+    expectValid: true,
+  });
+  let failed = 0;
+  for (const { schemaPath, fixturePath, expectValid } of cases) {
+    const result = validateFixture(schemaPath, fixturePath, expectValid);
+    const label = expectValid ? 'valid' : 'invalid';
+    if (result.ok) {
+      console.log(`✓  ${fixturePath} (${label})`);
+    } else {
+      console.error(
+        `✗  ${fixturePath} (${label}): ${result.errors.join('; ')}`,
+      );
+      failed++;
+    }
+  }
+  if (failed > 0) {
+    console.error(`\n${failed} case(s) failed.`);
+    process.exit(1);
+  } else {
+    console.log('\nAll cases passed.');
+  }
+}


### PR DESCRIPTION
## Summary

Vendors `scripts/` verbatim from `kurone-kito/idd-skill` tag `v0.6.0`
(tag object `f1666048`, dereferencing to commit
`0a9c90dc277e05e0d7d96f1b09d79ff668860cc6`) — the scripts slice of the
five-track split recorded in roadmap #122 (sibling tracks: #222
lint/format exclusions, #223 `.gitattributes`, #226 `schemas/` +
`fixtures/schemas/`, #228 the `helperRuntime.profile` switch).

- Copied every `vendored-node` profile `managedFiles` entry whose
  `targetPath` starts with `scripts/` — 57 files, as emitted, no
  hand-pruning.
- Generated the manifest from an out-of-repo checkout run under
  `mise exec node@24.19.0` (this repo's pinned floor is `>=24.2.0`;
  the environment's effective default Node, `23.6.1`, silently no-ops
  the helper's `import.meta.main` CLI gate).
- File mode `100644` for all 57 files, matching upstream `git
  ls-tree` exactly — upstream does not mark any `scripts/*.mjs`
  executable; the invocation surface is `node scripts/<name>.mjs`.
- No lint/format configuration, `.gitattributes`, `schemas/`,
  `fixtures/`, or `.github/idd/config.json` touched — #222 already
  wired `scripts/` out of prettier, eslint, oxlint, and cspell, and
  #223 already marked it `linguist-vendored`. This PR does not flip
  `helperRuntime.profile`; the repository stays on
  `instructions-only` until #228.

## Verification

- `cmp` against the source checkout: all 57 files byte-identical.
- `git diff --stat` confined to `scripts/` — no other file added or
  modified.
- `pnpm run lint` passes; `pnpm run lint:fix` produces **no diff**
  under `scripts/` (empirical confirmation that #222's exclusions
  cover the freshly vendored files, including through the
  `lint-staged` pre-commit path).
- `node scripts/idd-doctor.mjs` under Node 24 produces a full,
  real multi-section report (not a silent exit 0) — exit 1 with 1
  pre-existing error (unresolved `{{ year }}` i18n placeholders in
  `packages/web/src/i18n/{en,ja}.ts`) and 3 pre-existing warnings,
  none of which trace to a file this diff touches.
- `pnpm run test`: `packages/lib` and `packages/fetcher` pass in
  full; `packages/web` passes except the pre-existing
  `Calendar.test.tsx` failure from a missing `data.json` fixture that
  requires live Google Calendar API credentials unavailable in this
  environment (hosted CI has them) — unrelated to this diff, same
  pre-existing failure noted on #231/#233/#234.
- An independent critique-pass subagent re-derived the manifest from
  a fresh upstream download and re-verified byte-identity, scope, and
  the mode/SHA claims above before this PR was opened.

Closes #225

Part of roadmap #122.
