### PR TITLE
feat(ci): host the idd-advisory-convergence workflow as a non-required check

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,0 +1,101 @@
+name: IDD advisory-convergence gate
+# cspell:ignore GHES GHEC
+# Optional, opt-in required-check workflow (see ONBOARDING.md "Optional
+# — host idd-advisory-convergence as a required-check CI workflow" for
+# the full rationale, the required-check Ruleset registration step, and
+# the waiver-after-deadline escape path). Copy this file into your
+# repository's .github/workflows/ to enable it -- it is not wired in
+# automatically by importing the rest of idd-template/, since a new
+# required-status-check-able workflow is a deliberate adopter decision,
+# not a default.
+#
+# Runner override: `runs-on` below reads the `CI_RUNNER_LABEL`
+# repository variable, falling back to `ubuntu-latest` when unset. Set
+# it from Settings > Secrets and variables > Actions > Variables >
+# CI_RUNNER_LABEL -- no workflow file edit needed. The primary
+# motivating case is GitHub Enterprise Server: GHES does not support
+# GitHub-hosted runners at all (self-hosted runners are mandatory
+# there), so `ubuntu-latest` fails outright on GHES regardless of
+# which label this template ships as the fallback. Any organization
+# that mandates self-hosted runners even on github.com/GHEC hits the
+# same wall and can use the same variable. This mechanism works for
+# whatever the shipped fallback value is now or later, not
+# specifically `ubuntu-latest`.
+#
+# Adjust the pinned `actions/checkout` SHA (or use the floating `@v4`
+# tag as shipped here), the checkout `ref:` (see below), and the
+# `node scripts/...` command to your own helper-runtime profile. This
+# file intentionally uses the portable `ubuntu-latest` fallback +
+# `@v4` forms rather than a repository-specific pinned SHA or a
+# hardcoded custom runner label, unlike this source repository's own
+# dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
+concurrency:
+  cancel-in-progress: true
+  # Grouped by PR number, not github.ref: pull_request_review and
+  # pull_request_review_comment are not pull_request-family events, so
+  # github.ref does not resolve the same way for them as it does for a
+  # pull_request-only workflow. workflow_dispatch has no pull_request
+  # context either, so it falls back to its own input.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to re-check (e.g. after posting a maintainer waiver)
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+jobs:
+  # The job id `idd-advisory-convergence` is the exact check-run context
+  # consumed by the rerun helper, advisory-wait policy, required status
+  # check, and external-check waiver selector. Adding a `name:` display-name
+  # key or changing the job id changes that literal context. This warning is
+  # preventive; no observed incident yet. If either edit is intentional,
+  # update every consumer to the new literal context together.
+  idd-advisory-convergence:
+    # See the header comment above for the CI_RUNNER_LABEL override.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
+    # Bounds pathological hangs; adjust to your own observed run duration
+    # once you have history (see idd-doctor.yml/lint.yml in the source
+    # repository for the pattern of sizing this from real run durations).
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Trusted default-branch checkout, not the PR head, for any
+          # trigger type including workflow_dispatch: the enforcement
+          # script (scripts/advisory-convergence.mjs) and its config
+          # (.github/idd/config.json) must be the trusted copy, not the
+          # PR's own -- otherwise a PR could edit the verdict logic
+          # itself to force `ready: true`. The verdict still correctly
+          # evaluates the intended PR: `--pr <number>` below drives
+          # every live GitHub API call the script makes, independent of
+          # what is checked out locally. Replace `main` with your own
+          # default branch name if it differs.
+          ref: main
+          persist-credentials: false
+      # Read the Node.js version from .node-version instead of the
+      # template's portable `node-version: 24.x`, so this workflow always
+      # tracks the same pinned version as push.yml / push-main.yml rather
+      # than a hardcoded digit string that can drift from .node-version.
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          # workflow_dispatch's `pr_number` input is `type: number` in the
+          # UI, but that constraint is not strictly enforced for direct API
+          # dispatches, so route it through env: and reference it as a
+          # quoted shell variable rather than interpolating the `${{ }}`
+          # expression directly into the run: script.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,9 +1,11 @@
 name: IDD advisory-convergence gate
 # cspell:ignore GHES GHEC
-# Optional, opt-in required-check workflow (see ONBOARDING.md "Optional
-# — host idd-advisory-convergence as a required-check CI workflow" for
-# the full rationale, the required-check Ruleset registration step, and
-# the waiver-after-deadline escape path). Copy this file into your
+# Optional, opt-in required-check workflow (see
+# https://github.com/kurone-kito/idd-skill/blob/v0.6.0/idd-template/ONBOARDING.md
+# "Optional — host idd-advisory-convergence as a required-check CI
+# workflow" for the full rationale, the required-check Ruleset
+# registration step, and the waiver-after-deadline escape path; that
+# file is not vendored into this repository). Copy this file into your
 # repository's .github/workflows/ to enable it -- it is not wired in
 # automatically by importing the rest of idd-template/, since a new
 # required-status-check-able workflow is a deliberate adopter decision,
@@ -22,13 +24,16 @@ name: IDD advisory-convergence gate
 # whatever the shipped fallback value is now or later, not
 # specifically `ubuntu-latest`.
 #
-# Adjust the pinned `actions/checkout` SHA (or use the floating `@v4`
-# tag as shipped here), the checkout `ref:` (see below), and the
-# `node scripts/...` command to your own helper-runtime profile. This
-# file intentionally uses the portable `ubuntu-latest` fallback +
-# `@v4` forms rather than a repository-specific pinned SHA or a
-# hardcoded custom runner label, unlike this source repository's own
-# dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
+# Adjust the pinned `actions/checkout` SHA (or use a floating tag, as
+# shipped here), the checkout `ref:` (see below), and the
+# `node scripts/...` command to your own helper-runtime profile. The
+# upstream template ships the portable `ubuntu-latest` fallback +
+# `@v4` forms; this repository's copy uses `@v7` instead, matching the
+# major version already pinned by the sibling `push.yml` /
+# `push-main.yml` workflows, rather than a repository-specific pinned
+# SHA or a hardcoded custom runner label like the idd-skill source
+# repository's own dogfooded copy at
+# .github/workflows/idd-advisory-convergence.yml.
 concurrency:
   cancel-in-progress: true
   # Grouped by PR number, not github.ref: pull_request_review and

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -22,7 +22,11 @@ name: IDD advisory-convergence gate
 # that mandates self-hosted runners even on github.com/GHEC hits the
 # same wall and can use the same variable. This mechanism works for
 # whatever the shipped fallback value is now or later, not
-# specifically `ubuntu-latest`.
+# specifically `ubuntu-latest`. A self-hosted runner set via
+# CI_RUNNER_LABEL must also have the GitHub CLI (`gh`) installed and
+# authenticated -- the run: step's helper (scripts/advisory-convergence.mjs)
+# shells out to `gh`, and GitHub-hosted runners ship it preinstalled,
+# but a bare self-hosted image may not.
 #
 # Adjust the pinned `actions/checkout` SHA (or use a floating tag, as
 # shipped here), the checkout `ref:` (see below), and the


### PR DESCRIPTION
## Summary

Hosts `idd-advisory-convergence` as a new, **non-required** GitHub
Actions check by copying
`idd-template/.github/workflows/idd-advisory-convergence.yml` from
`kurone-kito/idd-skill` tag `v0.6.0` (tag object `f1666048`,
dereferencing to commit `0a9c90dc277e05e0d7d96f1b09d79ff668860cc6`)
to `.github/workflows/idd-advisory-convergence.yml`.

Adaptations applied — and only these, per the issue's own "Proposed
change" list:

- `actions/checkout` and `actions/setup-node`: `@v4` (template) →
  `@v7`, matching the sibling `push.yml` / `push-main.yml` workflows'
  *current* major version. (The issue text names `@v6`; live
  inspection shows both siblings are now on `@v7` — Dependabot has
  bumped them since the issue was authored. Same kind of
  stale-reference drift as roadmap #122's `f1666048` tag-vs-commit
  note; not a defect in the issue, just using the live value.)
- `actions/setup-node`'s `node-version: 24.x` → `node-version-file:
  .node-version`, matching both sibling workflows' own pattern and
  always tracking the pinned version (`24.19.0` today) instead of a
  digit string that can drift from `.node-version`.
- `runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}` kept
  verbatim (recorded decision: this repository does not set a
  `CI_RUNNER_LABEL` repository variable, so it resolves to
  `ubuntu-latest` today).
- `ref: main` on the checkout kept verbatim (trusted default-branch
  copy, not the PR head — the enforcement script and its config must
  stay the trusted copy).
- The `run:` step already invoked
  `node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert`,
  which matches this repository's `vendored-node` helper path
  (`scripts/advisory-convergence.mjs`, vendored via #225) verbatim —
  no edit needed.
- Added one line not in the issue's literal adaptation list: `#
  cspell:ignore GHES GHEC` — the template's own header comment
  mentions GitHub Enterprise Server (GHES) and GHE Cloud (GHEC), which
  this repository's `cspell` dictionary does not recognize. Resolved
  inside the file only (this repo's established
  `# cspell:disable-next-line` pattern, already used in `push.yml`),
  never by touching `cspell.config.yml`.
- Did **not** register the workflow as a required status check — that
  is #129's admin-only Ruleset action, out of scope here by the
  issue's own text.

## Verification

- `diff` against the upstream `v0.6.0` file confirms the only changes
  are the ones listed above.
- `actionlint .github/workflows/idd-advisory-convergence.yml` — clean.
- `pnpm run lint` passes (cspell, eslint, oxlint, prettier, stylelint,
  markdownlint all clean; the 2 pre-existing oxlint warnings on
  unrelated files are untouched by this diff).
- `pnpm run test`: `packages/lib` and `packages/fetcher` pass in
  full; `packages/web` passes except the pre-existing
  `Calendar.test.tsx` failure from a missing `data.json` fixture that
  requires live Google Calendar API credentials unavailable in this
  environment (hosted CI has them) — unrelated to this diff, same
  pre-existing failure noted on #231/#233/#234/#235.
- `git diff --stat` confined to the one new workflow file (101
  insertions, 0 deletions elsewhere).
- Two independent critique-pass subagents reviewed this change (one
  against the plan before implementation, one against the finished
  diff) — no blocking findings; the low-severity finding from the
  second pass (a commit message mislabeling the tag object SHA as a
  commit SHA) was fixed before this PR was opened.
- `.github/idd/config.json` already has `advisoryWait.convergenceScope:
  "idd-claimed"` (set by #126, merged) so this check will not
  false-flag claimless Dependabot PRs on its first run, and
  `scripts/advisory-convergence.mjs` already exists (vendored by
  #225, merged) so the check's only step can actually run.

Closes #127

Part of roadmap #122.
