### PR TITLE
feat(idd): switch helperRuntime.profile to vendored-node

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -37,7 +37,7 @@
   },
   "discover": { "selectionDesync": "session-offset" },
   "helperRuntime": {
-    "profile": "instructions-only"
+    "profile": "vendored-node"
   },
   "iddVersion": "0.6.0",
   "issueScope": "roadmap-first",


### PR DESCRIPTION
## Summary

Flips `helperRuntime.profile` from `"instructions-only"` to
`"vendored-node"` in `.github/idd/config.json` — the finalize/switch-over
track for roadmap #122's helper-runtime upgrade, now that its three
sibling tracks (#225 `scripts/`, #226 `schemas/` + `fixtures/schemas/`,
#222 lint/format exclusions) are all merged and the vendored bundle
passes lint/test.

Vendored upstream commit: **`f1666048`** (tag **`v0.6.0`**).

This PR changes exactly one config key, per the issue's explicit scope
constraint — `docs/idd-policy.md`'s Helper Runtime Profile narrative
update is deliberately out of scope here (owned by #128, the roadmap's
completion-verification track, to avoid a duplicate edit to the same
section).

## Verification (on Node >=24.2.0 via `mise exec node@24.19.0`)

- `node scripts/idd-doctor.mjs` produces real, non-silent output
  post-change: it now reports `.github/idd/config.json declares helper
  runtime profile "vendored-node"` and validates against
  `policy.schema.json`.
- `pnpm run lint` passes.
- `pnpm run test` passes, with one pre-existing, credential-gated
  exception: `Calendar.test.tsx` fails to resolve `../../data.json`,
  which is generated by `kb-fetcher` against live credentials not
  available in this environment — verified pre-existing and unrelated
  to this change (this repository's own CI on `issue/*` branches runs
  with real secrets and is authoritative for this test).
- `pnpm run lint:fix` produces no diff under `scripts/`, `schemas/`, and
  `fixtures/schemas/` (confirmed via `git status --porcelain` on those
  paths).

**Known non-blocking finding, documented rather than fixed here:**
`idd-doctor.mjs` also reports one `ERROR` — its generic `{{...}}`
placeholder scanner flags `packages/web/src/i18n/en.ts` and `ja.ts`'s
legitimate `{{ year }}` i18n template placeholders as unresolved IDD
onboarding placeholders. Verified profile-independent (reproduces
identically on `instructions-only` and `vendored-node`) and not
CI-gated (no workflow invokes `idd-doctor.mjs`). This still satisfies
the acceptance criterion's literal bar (real, non-silent output) — the
point of that criterion is that the vendored doctor script now runs on
Node 24 instead of silently no-op'ing under Node 23's `import.meta.main`
gate. Fixing the scanner itself means editing vendored upstream
`scripts/idd-doctor.mjs` content, which is outside this issue's
single-key-flip scope.

Refs #228

Closes #228
