### PR TITLE
docs(idd): update the policy record for the v0.6.0 re-import

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -45,11 +45,13 @@ track #128 — see the roadmap for the full prerequisite-track list). The
 repository moved from the 2026-07-03 `iddVersion: 0.3.0` baseline onto
 **upstream tag `v0.6.0` (commit `f1666048`)**.
 
-- Roadmap #122 originally targeted a SHA-pinned snapshot (`4e8c7043`)
-  because upstream had not cut a tag past `v0.4.0` when the roadmap was
-  opened (2026-07-27); it re-baselined onto the `v0.6.0` tag on 2026-08-12
-  once upstream cut it. `.github/idd/config.json`'s `iddVersion` carries
-  the tag's declared template value, `"0.6.0"`.
+- Roadmap #122 opened 2026-07-14 targeting the `v0.4.0` tag plus a
+  forward-port from upstream commit `4103665`. A 2026-07-27 re-plan
+  pinned a SHA snapshot (`4e8c7043`) instead, once upstream had moved
+  `main` past `v0.4.0` without cutting a new tag; it re-baselined onto
+  the `v0.6.0` tag on 2026-08-12 once upstream cut it.
+  `.github/idd/config.json`'s `iddVersion` carries the tag's declared
+  template value, `"0.6.0"`.
 - The Step 6 checklist passed again against the re-imported set: all
   `.github/instructions/idd-*.instructions.md` files (now including the
   `lite/` weak-model-tier bundle), the expanded `docs/` set (adding
@@ -218,8 +220,10 @@ default) — see Deferred below.
 ## Advisory-Convergence Gate
 
 **Status**: hosted as a **non-required** check (`.github/workflows/idd-advisory-convergence.yml`,
-added in #127, copied verbatim from the `idd-template/` artifact upstream
-ships at `v0.6.0`). It triggers on `pull_request`, `pull_request_review`,
+added in #127, adapted from the `idd-template/` artifact upstream ships
+at `v0.6.0` — this repository's copy pins `actions/checkout@v7` instead
+of upstream's `@v4`, matching the sibling `push.yml`/`push-main.yml`
+workflows). It triggers on `pull_request`, `pull_request_review`,
 `pull_request_review_comment`, and manual `workflow_dispatch` (for
 re-checking after a maintainer waiver), and produces a convergence verdict
 on every PR today.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -57,8 +57,8 @@ repository moved from the 2026-07-03 `iddVersion: 0.3.0` baseline onto
   `docs/idd-design-rationale.md`), and the four `profiles/` READMEs are
   present; `.github/idd/config.json` validates against
   `schemas/policy.schema.json`.
-- The corrupted `< placeholder >`-as-shell-redirection command examples
-  the 0.3.0 import shipped (root-caused and fixed in #123) are confirmed
+- The corrupted `<placeholder>`-as-shell-redirection command examples the
+  0.3.0 import shipped (root-caused and fixed in #123) are confirmed
   gone and cannot come back:
   `grep -rn '< [a-z-]* >' .github/instructions docs profiles .claude/skills`
   returns no matches, and `pnpm run lint:fix` produces no diff under the

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -36,8 +36,68 @@ passed:
 
 From this point the repository's own `.github/instructions/` are
 authoritative; the upstream ("theirs") bootstrap flow is no longer
-required. Known follow-ups: the helper-runtime upgrade to
-`package-manager` once a reviewed helper spec is published.
+required.
+
+### v0.6.0 re-import verification
+
+**Re-imported and verified on 2026-08-15** (roadmap #122, close-out
+track #128 — see the roadmap for the full prerequisite-track list). The
+repository moved from the 2026-07-03 `iddVersion: 0.3.0` baseline onto
+**upstream tag `v0.6.0` (commit `f1666048`)**.
+
+- Roadmap #122 originally targeted a SHA-pinned snapshot (`4e8c7043`)
+  because upstream had not cut a tag past `v0.4.0` when the roadmap was
+  opened (2026-07-27); it re-baselined onto the `v0.6.0` tag on 2026-08-12
+  once upstream cut it. `.github/idd/config.json`'s `iddVersion` carries
+  the tag's declared template value, `"0.6.0"`.
+- The Step 6 checklist passed again against the re-imported set: all
+  `.github/instructions/idd-*.instructions.md` files (now including the
+  `lite/` weak-model-tier bundle), the expanded `docs/` set (adding
+  `docs/idd-resume-detail.md`, `docs/idd-advisory-wait-shell-fallback.md`,
+  `docs/idd-design-rationale.md`), and the four `profiles/` READMEs are
+  present; `.github/idd/config.json` validates against
+  `schemas/policy.schema.json`.
+- The corrupted `< placeholder >`-as-shell-redirection command examples
+  the 0.3.0 import shipped (root-caused and fixed in #123) are confirmed
+  gone and cannot come back:
+  `grep -rn '< [a-z-]* >' .github/instructions docs profiles .claude/skills`
+  returns no matches, and `pnpm run lint:fix` produces no diff under the
+  vendored IDD surfaces.
+- `node scripts/idd-doctor.mjs` (run under Node ≥24.2.0 — see Helper
+  Runtime Profile below) now runs from the vendored bundle and produces
+  real output instead of silently exiting 0. It reports 12 passing checks,
+  3 warnings, and 1 error on this verification pass:
+  - The `worktreeGuard`/`core.hooksPath` warning is a false alarm: husky's
+    `.husky/pre-commit` and `.husky/pre-push` chain
+    `.githooks/_idd-worktree-guard.sh` at the end of their own scripts (see
+    Worktree Guard below), so the guard is active even though
+    `core.hooksPath` points at `.husky/_` rather than `.githooks`
+    directly.
+  - The branch-protection-not-readable warning is genuine
+    (`gh api repos/{owner}/{repo}/branches/main/protection` returns `404`;
+    `gh api repos/{owner}/{repo}/rulesets` returns the repository's two
+    active rulesets, neither of which contains a `required_status_checks`
+    rule). This is the fail-closed `ciGate.trustEmptyProtectionReads`
+    default doing its job, per design — see Deferred below for why the
+    key stays unset rather than flipped here.
+  - The autopilot-suitability score/label warning on issue #136 is
+    accurate by design: #136 carries a stale score of 3 alongside its
+    intentional `status:blocked-by-human` label.
+  - The placeholder-scanner error
+    (`packages/web/src/i18n/{en,ja}.ts: {{ year }}`) is a false positive —
+    the scanner's `files` input is every git-tracked text-like file in the
+    repository, not just IDD-managed paths, so it also reaches the
+    application's own i18n runtime-template tokens. Filed upstream as
+    [kurone-kito/idd-skill#2079](https://github.com/kurone-kito/idd-skill/issues/2079)
+    rather than patched locally, since `scripts/idd-doctor.mjs` is
+    vendored byte-identical from upstream (#225) and a local patch would
+    silently revert on the next re-sync.
+- `pnpm run lint` and `pnpm run test` pass, with one pre-existing,
+  environment-specific exception: `packages/web`'s `Calendar.test.tsx`
+  needs a live-credentialed `kb-fetcher` fetch (`src/data.json`) that is
+  not obtainable in every execution environment (for example, a freshly
+  created IDD worktree); this is a data-availability gap, not a defect
+  introduced by the re-import.
 
 ## Merge Policy
 
@@ -112,15 +172,10 @@ or advisory feedback.
 - **generation timeout**: `PT10M` (10 min)
 - **rerun policy**: `rerun-once`
 
-> **Repository note.** `.github/workflows/push.yml` (build/lint/test)
-> now runs on `issue/*` branches: its branch filter explicitly lists
-> `'issue/*'` alongside the slash-free `'*'` (fixed in #117 — GitHub
-> Actions branch-filter globs otherwise treat `*` as not matching `/`,
-> and a blanket `'**'` was rejected because it would also match
-> `dependabot/*` branches, which run without repository secrets and
-> would fail the build). IDD PRs now carry real build/lint/test CI
-> signal in addition to lint + test run locally in the worktree
-> (pre-push-validate), CodeQL, Copilot, and CodeRabbit.
+`.github/workflows/push.yml` (build/lint/test) runs on `issue/*` branches,
+so IDD PRs carry real build/lint/test CI signal in addition to lint + test
+run locally in the worktree (pre-push-validate), CodeQL, Copilot, and
+CodeRabbit.
 
 ## Role Labels
 
@@ -154,11 +209,33 @@ mode, `owners-and-maintainers-only` authority, and expire after
 `idd-advisory-convergence` required check (once #129 registers it)
 from being unwaivable if the check gets stuck. For a claimless PR (e.g.
 Dependabot), a maintainer can bind a waiver to the sentinel claim-id
-`none` via `scripts/external-check-waiver.mjs --claimless` once #124
-vendors the helper bundle.
+`none` via `scripts/external-check-waiver.mjs --claimless` — the vendored
+helper bundle (#225) ships this script now.
 
 `ciGate.trustEmptyProtectionReads` intentionally stays unset (fail-closed
-default).
+default) — see Deferred below.
+
+## Advisory-Convergence Gate
+
+**Status**: hosted as a **non-required** check (`.github/workflows/idd-advisory-convergence.yml`,
+added in #127, copied verbatim from the `idd-template/` artifact upstream
+ships at `v0.6.0`). It triggers on `pull_request`, `pull_request_review`,
+`pull_request_review_comment`, and manual `workflow_dispatch` (for
+re-checking after a maintainer waiver), and produces a convergence verdict
+on every PR today.
+
+- **Scope** (`advisoryWait.convergenceScope`, set in #126):
+  `idd-claimed` — see PR Review Policy above for why (Dependabot PRs stay
+  out of the gate).
+- **Waiver surface**: configured and live — see External-Check Waivers
+  above.
+- **Required-check enforcement**: not yet active. Registering
+  `idd-advisory-convergence` as a required status check is a GitHub
+  Ruleset edit tracked in #129, an operator-only action (repository
+  Settings access this automation does not hold). Until #129 lands, the
+  workflow's verdict is advisory-only, matching this repository's
+  `copilot-advisory` review policy; #129 does not block #128, since the
+  gate already runs and produces real signal as a non-required check.
 
 ## Issue-Author Approval Gate
 
@@ -169,17 +246,35 @@ default).
 
 ## Helper Runtime Profile
 
-**Profile**: `instructions-only`
+**Profile**: `vendored-node` (set in #228, superseding the earlier
+`instructions-only` posture recorded at 2026-07-03 onboarding)
 
-The operator preferred `package-manager` (pnpm) during onboarding, but
-the IDD helper package `@kurone-kito/idd-skill` is not published to the
-npm registry, so no reviewed, non-mutable helper spec is resolvable.
-Rather than pin an unreviewed mutable source (a branch tarball / git
-URL), the repository stays on the fail-safe `instructions-only` profile,
-where the written decision tables in `.github/instructions/` are
-canonical. Upgrading to `package-manager` is tracked as a follow-up once
-a reviewed helper spec (a published package or a pinned tarball) is
-available.
+The operator preferred `package-manager` (pnpm) during onboarding, but the
+IDD helper package `@kurone-kito/idd-skill` remains unpublished to the npm
+registry. Rather than pin an unreviewed mutable source (a branch tarball
+or git URL) via the newly-available `helperRuntime.packageSpec` field,
+the repository vendors the reviewed, committed helper bundle directly:
+`scripts/` (#225) and `schemas/` + `fixtures/schemas/` (#226) are synced
+verbatim from `idd-skill` `v0.6.0` and excluded from prettier/eslint/
+oxlint/cspell reformatting and marked `linguist-vendored` (#222, #223), so
+they stay byte-identical across re-imports and diff cleanly against
+upstream. `helperRuntime.profile: vendored-node` was verified against the
+committed bundle in #228.
+
+**Node 24 LTS floor (load-bearing, #141).** Upstream helpers declare
+`engines.node: "^22.22.2 || >=24.2.0"`, and 39 of the 57 vendored
+`scripts/*.mjs` files gate their CLI body on `import.meta.main`, which
+does not exist before Node 24.2.0. On this repository's previous Node
+23.6.1 pin, every gated helper — including `node scripts/idd-doctor.mjs`
+— printed nothing and exited `0`: a silent fail-open no-op that let every
+gate the vendored bundle feeds pass vacuously. `.nvmrc` / `.node-version`
+/ `.tool-versions` and `package.json`'s `engines.node` now require
+`>=24.2.0`; every helper invocation in this repository's instructions
+runs under that floor.
+
+Upgrading to `package-manager` remains a tracked follow-up once a
+reviewed helper spec (a published package, or a pinned tarball evaluated
+under the same review bar) becomes available — see Deferred below.
 
 ## Issue-Authoring Companion
 
@@ -211,3 +306,85 @@ git config core.hooksPath .githooks
 Either way, IDD implementation work must happen in a sibling worktree
 (`git worktree add ../<repo>.<branch> -b <branch> origin/main`), not by
 switching the primary worktree onto the issue branch.
+
+## Claude Code Permission Baseline
+
+**Status**: adopted (#142), from the upstream `idd-template/.claude/settings.json`
+curated baseline, at `.claude/settings.json`.
+
+Unlike the upstream default-off template, this repository's baseline
+deliberately **enables merge-capable operations** — `gh pr merge` is
+allowlisted, and the deny entries upstream ships for
+`node scripts/idd-merge-execute.mjs` / `node bin/idd-merge-execute.mjs`
+are removed — so that a Claude Code session can carry out the F3 merge
+autonomously, matching this repository's `fully_autonomous_merge` policy.
+`gh api` is deliberately **not** allowlisted at all (see the `gh api`
+DELETE-verb trap documented in `docs/permissions.md` before adding any
+`gh api` entry). Personal additions belong in
+`.claude/settings.local.json`, which layers on top of this file.
+
+## Formatting Divergence
+
+Repository-wide Prettier formatting is **not** a preserved divergence for
+vendored IDD surfaces — the opposite is true: `.prettierignore` excludes
+them deliberately.
+
+- `.github/instructions/`, the `docs/idd-*.md` set (except the
+  locally-authored `docs/idd-policy.md`, re-included), `docs/concepts.md`,
+  `docs/customization.md`, `docs/getting-started.md`, `docs/index.md`,
+  `docs/permissions.md`, `docs/policy-constants.md`, `docs/reference.md`,
+  `docs/onboarding/`, `profiles/`, and `.githooks/` are excluded (#123).
+- The vendored helper bundle `/scripts/`, `/schemas/`, and
+  `/fixtures/schemas/` is excluded (#222), anchored to the repository root
+  so nested package directories of the same name (e.g.
+  `packages/web/scripts/`) are not swept in.
+- `.claude/skills/` is excluded as a vendored Claude Code skill bundle.
+
+This exists because `prettier-plugin-sh` parsed the vendored docs'
+`<issue-number>` / `<pr-number>` argument placeholders inside fenced
+` ```sh ` blocks as shell redirections, corrupting sixteen command
+examples across six files in the 0.3.0 import (five of them in
+instruction files agents read as authoritative). `markdownlint-cli2`
+keeps running on these paths and passes on upstream-faithful content;
+only Prettier (and, for the helper bundle, `prettier-plugin-sort-json`)
+is excluded.
+
+## Deferred
+
+Tracked, but intentionally not changed by #128 or the v0.6.0
+re-import:
+
+- **`helperRuntime.profile: package-manager`** — once
+  `@kurone-kito/idd-skill` is published to the npm registry with a
+  reviewed, non-mutable spec. The newly-available `helperRuntime.packageSpec`
+  pin (an unreviewed mutable tarball/git-URL source) was considered during
+  the v0.6.0 re-import and declined in favor of vendoring (see Helper
+  Runtime Profile above).
+- **`instructionProfile: "lite"`** — the `lite/` condensed phase files are
+  imported (#123) and available, but the opt-in switch stays unset:
+  upstream's `schemas/policy.schema.json` root object rejects unknown
+  properties, so setting this key today fails `idd-doctor`'s schema
+  validation outright rather than merely doing nothing. Revisit once
+  upstream's schema accepts the field.
+- **`ciGate.trustEmptyProtectionReads`** — left at the fail-closed
+  default. `#128` verification reconfirmed the branch-protection and
+  ruleset reads genuinely 404 (`gh api .../branches/main/protection` →
+  404; `gh api .../rulesets` → 200, no `required_status_checks` rule), but
+  this has not held any merge — this repository's own IDD sessions have
+  proceeded on that direct 404 evidence across every PR merged since the
+  rulesets were introduced, with no merge blocked by it. Revisit only if
+  that changes (a 404 that starts actually holding merges).
+- **`advisoryWait.exemptBotAuthoredPrs`** — left unset (default `false`).
+  It only matters under `advisoryWait.convergenceScope: "all-prs"`; this
+  repository uses `"idd-claimed"`, which already keeps claimless PRs out
+  of the gate, so the flag is redundant here.
+- **Upstream deltas landing after `v0.6.0`** — including polish/fix
+  commits already on upstream `main` past the tag, and GitHub Enterprise
+  Server support (not applicable to this GitHub.com-hosted repository) —
+  picked up by the next release re-sync.
+- **`scripts/idd-doctor.mjs` placeholder-scanner false positive** — filed
+  upstream as
+  [kurone-kito/idd-skill#2079](https://github.com/kurone-kito/idd-skill/issues/2079);
+  see the v0.6.0 re-import verification note above. Non-blocking and
+  profile-independent; the fix must land upstream and arrive via the next
+  re-sync, since `scripts/` stays vendored byte-identical.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -30,9 +30,13 @@ passed:
   the issue-authoring companion is installed at
   `.claude/skills/issue-authoring/`.
 - All seven onboarding placeholders are resolved. The only remaining
-  `{{...}}` token is the literal doc example `{{placeholder}}` in
-  vendored upstream onboarding docs (routed upstream in
-  kurone-kito/idd-skill#1207), not an unresolved onboarding placeholder.
+  onboarding-scoped `{{...}}` token is the literal doc example
+  `{{placeholder}}` in vendored upstream onboarding docs (routed
+  upstream in kurone-kito/idd-skill#1207), not an unresolved onboarding
+  placeholder. A separate, unrelated `{{...}}` class — the app's own
+  `packages/web/src/i18n/{en,ja}.ts` runtime template tokens — is
+  documented below; it predates this repository's IDD adoption and is
+  not an onboarding placeholder either.
 
 From this point the repository's own `.github/instructions/` are
 authoritative; the upstream ("theirs") bootstrap flow is no longer


### PR DESCRIPTION
## Summary

Verifies roadmap #122's re-import to upstream IDD tag `v0.6.0` end to
end (Step 6 checklist, `idd-doctor`, corrupted-example grep, lint,
test) and rewrites `docs/idd-policy.md` so it describes only shipped
state: the `v0.6.0` baseline, the `vendored-node` helper runtime and
Node 24 floor, every policy key `#126` set, the advisory-convergence
gate's current non-required status, the Claude Code merge-capable
permission baseline, the Prettier formatting-divergence rationale, and
a Deferred bucket. No `.github/idd/config.json` changes — every key it
documents was already set by prior tracks.

Closes #128

## Acceptance-criteria disposition

- [x] Step 6 checklist passes; every deviation found is either
      confirmed non-issue or filed as a linked follow-up (see below).
- [ ] **`idd-doctor` "exits without errors" — unmet by design, disclosed
      rather than glossed over.** `node scripts/idd-doctor.mjs` (under
      Node ≥24.2.0) reports 12 PASS / 3 WARN / 1 ERROR. The ERROR
      (`packages/web/src/i18n/{en,ja}.ts: {{ year }}`) is a false
      positive: the vendored placeholder scanner's file list is every
      git-tracked text-like file in the repo, not just IDD-managed
      paths, so it also flags the app's own i18n runtime-template
      tokens. `scripts/idd-doctor.mjs` is vendored byte-identical from
      upstream (#225) and excluded from local formatting/patching by
      design (#222/#223) — a local patch would silently revert on the
      next re-sync. Filed upstream instead:
      [kurone-kito/idd-skill#2079](https://github.com/kurone-kito/idd-skill/issues/2079).
      The 3 WARNs are each dispositioned in `docs/idd-policy.md`'s new
      "v0.6.0 re-import verification" subsection (worktree-guard/
      hooksPath false alarm, branch-protection 404 — genuine, not
      holding merges, `ciGate.trustEmptyProtectionReads` stays
      fail-closed — and the accurate-by-design #136 score/label WARN).
- [x] `idd-doctor` reports no config↔prose drift **on the mechanism it
      actually implements**: the only drift check
      (`checkClaimTimingConsistency`) compares `claimTiming` against
      `.github/instructions/idd-overview-core.instructions.md`'s
      Thresholds prose (clean, no warning), and
      `checkPolicySignals`/`checkTemplateVersionSignal` only assert
      that policy-signal strings are *present* somewhere in
      `docs/idd-policy.md` (also clean). **Disclosure**: the AC bullet's
      literal wording ("no config-to-prose policy drift between
      `.github/idd/config.json` and `docs/idd-policy.md`") describes a
      full per-key diff that no `idd-doctor` check actually implements
      today — I supplemented it with a manual cross-check (every
      top-level `.github/idd/config.json` key group has a matching,
      accurate `docs/idd-policy.md` section) rather than silently
      claiming the named mechanism covers it.
- [x] `grep -rn '< [a-z-]* >' .github/instructions docs profiles
      .claude/skills` returns no matches (verified after a follow-up
      commit fixed a self-inflicted trip-up — see Review notes below).
- [x] `docs/idd-policy.md` records the `v0.6.0` baseline, `vendored-node`,
      the Node 24 floor (39 of 57 vendored `scripts/*.mjs` gate on
      `import.meta.main` — corrected from the roadmap's "48" figure,
      which described upstream's own `bin/`-wrapped package layout;
      this repository has no `bin/` directory), every `#126` policy key,
      the convergence-gate status, the permission baseline, and the
      deferred bucket — and describes no unshipped behavior.
- [x] The stale `push.yml` / `issue/*` note is removed from the CI Wait
      Policy section.
- [x] `pnpm run lint` passes. `pnpm run test` passes except one
      pre-existing, environment-specific failure unrelated to this
      diff: `packages/web`'s `Calendar.test.tsx` needs a
      live-credentialed `kb-fetcher` fetch (`src/data.json`) not
      obtainable in this worktree; `main` has the same gap in a fresh
      worktree.

## Review notes

- **Self-inflicted grep trip-up, fixed in a follow-up commit.** The
  first commit's prose described the corrupted pattern as
  `` `< placeholder >` `` (with spaces), which is exactly the shape the
  verification grep matches — so the doc briefly failed the very check
  it was documenting as passing. An independent C1 critique pass on the
  diff caught this; the second commit switches to the properly-formed
  `` `<placeholder>` `` (no spaces).
- **Branch-protection 404 — no separate follow-up issue filed.**
  #128's own body says to file a follow-up if the doctor *holds*
  because of a branch-protection/ruleset 404. Here it's a WARN, not a
  hold (the only ERROR is the unrelated placeholder issue above), and
  #122's existing deferred-bucket entry already encodes the real
  revisit trigger ("404-ing **and holding merges**") — unmet across
  every PR merged this session (#231–#237) under the same evidence. The
  `docs/idd-policy.md` Deferred section records this explicitly instead
  of opening an unfixable "revisit if X happens" issue.
- `ciGate.trustEmptyProtectionReads` is **not** changed by this PR —
  out of scope per #128's own body, and its deferred-bucket condition
  remains unmet.

## Follow-ups filed

- [kurone-kito/idd-skill#2079](https://github.com/kurone-kito/idd-skill/issues/2079)
  — scope the `idd-doctor` placeholder scanner to IDD-managed files
  instead of the whole adopter repository.
