### PR TITLE
docs(idd): fix the broken ONBOARDING.md link in template-distribution.md

### DIFF
--- a/docs/onboarding/template-distribution.md
+++ b/docs/onboarding/template-distribution.md
@@ -131,7 +131,7 @@ the other files `collectVendoredFiles` manages under the source
 repository's own `scripts/` have an `idd-template/` mirror. Getting the
 **complete** `vendored-node` bundle requires running this from the clone
 (see
-[CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)):
+[CLI-assisted onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
 
 ```sh
 node scripts/idd-onboard.mjs --import --source <path-to-a-cloned-idd-skill-tree> \


### PR DESCRIPTION
## Summary

- `docs/onboarding/template-distribution.md:134` linked to a relative
  `../../ONBOARDING.md#cli-assisted-onboarding` path. That path only
  resolves inside the upstream `idd-skill` source repository;
  `idd-template/ONBOARDING.md` is intentionally not part of the
  distributed file set, so once this doc is copied into a downstream
  repository (like this one), the link 404s (no root `ONBOARDING.md`
  exists here).
- Point the link at the pinned upstream URL this repository already
  uses elsewhere for the same purpose (`docs/customization.md`):
  `https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding`.
- No other line or file changes.

Closes #229

## Test plan

- [x] `pnpm run lint:fix && pnpm run lint` passes
- [x] `pnpm run test` passes, with the single pre-existing,
      environment-specific `packages/web` `Calendar.test.tsx` failure
      (needs a live-credentialed `data.json` not obtainable in this
      worktree) — documented in `docs/idd-policy.md`, not caused by
      this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)