### PR TITLE
docs(idd): add the shipped E1-E3 review-snapshot row to the lite phase map

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -305,6 +305,7 @@ and whether your repository has authored any of its own:
 | A5 Claim                 | `idd-claim.instructions.md`         | `lite/idd-claim-lite.instructions.md`         |
 | B1-C6 Work               | `idd-work.instructions.md`          | `lite/idd-work-lite.instructions.md`          |
 | D1-D4 PR-submit          | `idd-pr-submit.instructions.md`     | `lite/idd-pr-submit-lite.instructions.md`     |
+| E1-E3 Review-snapshot    | `idd-review-snapshot.instructions.md` | `lite/idd-review-snapshot-lite.instructions.md` |
 | E9-E15 Review-fix        | `idd-review-fix.instructions.md`    | `lite/idd-review-fix-lite.instructions.md`    |
 | F1-F2 helper-read subset | `idd-pre-merge.instructions.md`     | `lite/idd-pre-merge-lite.instructions.md`     |
 | F2.5 handoff-stop        | `idd-merge-handoff.instructions.md` | `lite/idd-merge-handoff-lite.instructions.md` |


### PR DESCRIPTION
## Summary
- Add the missing `E1-E3 Review-snapshot` row to `docs/idd-workflow.md`'s "Phase -> lite file mapping" table, pointing at `idd-review-snapshot.instructions.md` (standard) and `lite/idd-review-snapshot-lite.instructions.md` (lite), positioned between the `D1-D4 PR-submit` and `E9-E15 Review-fix` rows.
- No other row or prose changed.

Closes #230

## Test plan
- [x] `pnpm run lint:fix && pnpm run lint`
- [x] `pnpm run test` (pre-existing, unrelated failure only: `Calendar.test.tsx` needs `data.json`, which requires live credentials unavailable in this environment)